### PR TITLE
Add Obsidian integration: tags, aliases, and Map of Content

### DIFF
--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -39,6 +39,7 @@ import {
 import { markOrphaned, orphanUnownedFrozenPages } from "./orphan.js";
 import { resolveLinks } from "./resolver.js";
 import { generateIndex } from "./indexgen.js";
+import { addObsidianMeta, generateMOC } from "./obsidian.js";
 import * as output from "../utils/output.js";
 import {
   COMPILE_CONCURRENCY,
@@ -164,6 +165,7 @@ async function runCompilePipeline(root: string): Promise<void> {
   }
 
   await generateIndex(root);
+  await generateMOC(root);
 
   output.header("Compilation complete");
   output.status("✓", output.success(
@@ -289,13 +291,15 @@ async function generateMergedPage(
   const createdAt = (existing?.meta.createdAt && typeof existing.meta.createdAt === "string")
     ? existing.meta.createdAt
     : now;
-  const frontmatter = buildFrontmatter({
+  const frontmatterFields: Record<string, unknown> = {
     title: entry.concept.concept,
     summary: entry.concept.summary,
     sources: entry.sourceFiles,
     createdAt,
     updatedAt: now,
-  });
+  };
+  addObsidianMeta(frontmatterFields, entry.concept.concept, entry.concept.tags ?? []);
+  const frontmatter = buildFrontmatter(frontmatterFields);
   const fullPage = `${frontmatter}\n\n${pageBody}\n`;
   await writePageIfValid(pagePath, fullPage, entry.concept.concept);
 }

--- a/src/compiler/obsidian.ts
+++ b/src/compiler/obsidian.ts
@@ -1,0 +1,213 @@
+/**
+ * Obsidian integration helpers for the llmwiki knowledge compiler.
+ *
+ * Provides two capabilities:
+ * 1. Enriching wiki page frontmatter with tags and aliases for better
+ *    Obsidian graph navigation and search.
+ * 2. Generating a Map of Content (MOC) page that groups concept pages
+ *    by tag for easy browsing.
+ */
+
+import { readdir } from "fs/promises";
+import path from "path";
+import { slugify, atomicWrite, safeReadFile, parseFrontmatter } from "../utils/markdown.js";
+import { CONCEPTS_DIR, MOC_FILE } from "../utils/constants.js";
+
+/** Minimum word count to generate an abbreviation alias. */
+const ABBREVIATION_MIN_WORDS = 3;
+
+/** Conjunctions that trigger a word-swap alias. */
+const SWAP_CONJUNCTIONS = [" and ", " or "];
+
+/**
+ * Enrich a frontmatter object with Obsidian-specific tags and aliases.
+ * Mutates the frontmatter object in place.
+ * @param frontmatter - The frontmatter object to enrich.
+ * @param conceptTitle - The human-readable concept title.
+ * @param tags - Tags from extraction (may be empty).
+ */
+export function addObsidianMeta(
+  frontmatter: Record<string, unknown>,
+  conceptTitle: string,
+  tags: string[],
+): void {
+  frontmatter.tags = tags;
+  frontmatter.aliases = generateAliases(conceptTitle);
+}
+
+/**
+ * Generate deterministic aliases from a concept title.
+ * Produces up to three alias variants:
+ * - Slug form (e.g., "gradient-descent")
+ * - Word-swap around conjunctions (e.g., "Optimization and Gradient Descent")
+ * - Abbreviation from first letters for 3+ word titles (e.g., "RAG")
+ * @param title - The concept title to derive aliases from.
+ * @returns Array of aliases that differ from the original title.
+ */
+function generateAliases(title: string): string[] {
+  const aliases: string[] = [];
+  const slug = slugify(title);
+
+  if (slug !== title) {
+    aliases.push(slug);
+  }
+
+  const swapAlias = generateSwapAlias(title);
+  if (swapAlias) {
+    aliases.push(swapAlias);
+  }
+
+  const abbreviation = generateAbbreviation(title);
+  if (abbreviation) {
+    aliases.push(abbreviation);
+  }
+
+  return aliases;
+}
+
+/**
+ * Generate a word-swap alias by reversing parts around a conjunction.
+ * E.g., "Gradient Descent and Optimization" becomes "Optimization and Gradient Descent".
+ * @param title - The concept title.
+ * @returns The swapped alias, or null if no conjunction found.
+ */
+function generateSwapAlias(title: string): string | null {
+  for (const conjunction of SWAP_CONJUNCTIONS) {
+    const index = title.toLowerCase().indexOf(conjunction);
+    if (index === -1) continue;
+
+    const before = title.slice(0, index);
+    const after = title.slice(index + conjunction.length);
+    const originalConjunction = title.slice(index, index + conjunction.length);
+    return `${after}${originalConjunction}${before}`;
+  }
+  return null;
+}
+
+/**
+ * Generate an abbreviation from first letters of each word for titles with 3+ words.
+ * E.g., "Retrieval Augmented Generation" becomes "RAG".
+ * @param title - The concept title.
+ * @returns The abbreviation, or null if title has fewer than 3 words.
+ */
+function generateAbbreviation(title: string): string | null {
+  const words = title.split(/\s+/);
+  if (words.length < ABBREVIATION_MIN_WORDS) return null;
+
+  const abbreviation = words.map((w) => w[0].toUpperCase()).join("");
+  if (abbreviation === title) return null;
+
+  return abbreviation;
+}
+
+/**
+ * Generate a Map of Content (MOC) page grouping concept pages by tag.
+ * Reads all concept pages, extracts their tags from frontmatter, and writes
+ * a structured MOC.md with sections per tag and an Uncategorized section.
+ * @param root - Project root directory.
+ */
+export async function generateMOC(root: string): Promise<void> {
+  const conceptsPath = path.join(root, CONCEPTS_DIR);
+  const pages = await loadConceptPages(conceptsPath);
+
+  const tagGroups = groupPagesByTag(pages);
+  const content = buildMOCContent(tagGroups);
+
+  await atomicWrite(path.join(root, MOC_FILE), content);
+}
+
+/** Minimal page info needed for MOC generation. */
+interface PageInfo {
+  title: string;
+  tags: string[];
+}
+
+/**
+ * Load all concept pages and extract their title and tags.
+ * @param conceptsPath - Absolute path to the concepts directory.
+ * @returns Array of page info objects.
+ */
+async function loadConceptPages(conceptsPath: string): Promise<PageInfo[]> {
+  let files: string[];
+  try {
+    files = await readdir(conceptsPath);
+  } catch {
+    return [];
+  }
+
+  const pages: PageInfo[] = [];
+  for (const file of files) {
+    if (!file.endsWith(".md")) continue;
+
+    const content = await safeReadFile(path.join(conceptsPath, file));
+    if (!content) continue;
+
+    const { meta } = parseFrontmatter(content);
+    if (meta.orphaned) continue;
+
+    const title = typeof meta.title === "string" ? meta.title : file.replace(/\.md$/, "");
+    const tags = Array.isArray(meta.tags) ? (meta.tags as string[]) : [];
+    pages.push({ title, tags });
+  }
+
+  return pages;
+}
+
+/**
+ * Group pages by their tags into a map. Pages with no tags go under "Uncategorized".
+ * @param pages - Array of page info objects.
+ * @returns Map of tag name to array of page titles.
+ */
+function groupPagesByTag(pages: PageInfo[]): Map<string, string[]> {
+  const groups = new Map<string, string[]>();
+
+  for (const page of pages) {
+    if (page.tags.length === 0) {
+      appendToGroup(groups, "Uncategorized", page.title);
+      continue;
+    }
+
+    for (const tag of page.tags) {
+      appendToGroup(groups, tag, page.title);
+    }
+  }
+
+  return groups;
+}
+
+/** Append a title to a group, creating the group if needed. */
+function appendToGroup(groups: Map<string, string[]>, key: string, title: string): void {
+  const existing = groups.get(key);
+  if (existing) {
+    existing.push(title);
+  } else {
+    groups.set(key, [title]);
+  }
+}
+
+/**
+ * Build the MOC markdown content from grouped pages.
+ * @param tagGroups - Map of tag name to array of page titles.
+ * @returns Complete MOC markdown string.
+ */
+function buildMOCContent(tagGroups: Map<string, string[]>): string {
+  const lines: string[] = ["# Map of Content", ""];
+
+  const sortedTags = [...tagGroups.keys()].sort((a, b) => {
+    // "Uncategorized" always goes last
+    if (a === "Uncategorized") return 1;
+    if (b === "Uncategorized") return -1;
+    return a.localeCompare(b);
+  });
+
+  for (const tag of sortedTags) {
+    const titles = tagGroups.get(tag) ?? [];
+    lines.push(`## ${tag}`, "");
+    for (const title of titles.sort()) {
+      lines.push(`- [[${title}]]`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}

--- a/src/compiler/prompts.ts
+++ b/src/compiler/prompts.ts
@@ -34,6 +34,12 @@ export const CONCEPT_EXTRACTION_TOOL = {
               type: "boolean",
               description: "True if this is a new concept not in existing wiki",
             },
+            tags: {
+              type: "array",
+              items: { type: "string" },
+              description:
+                "2-4 categorical tags for organizing this concept (e.g., 'machine-learning', 'optimization')",
+            },
           },
           required: ["concept", "summary", "is_new"],
         },
@@ -121,12 +127,20 @@ export function parseConcepts(toolOutput: string): ExtractedConcept[] {
   try {
     const parsed = JSON.parse(toolOutput);
     const concepts: ExtractedConcept[] = parsed.concepts ?? [];
-    return concepts.filter(
-      (c) =>
-        typeof c.concept === "string" &&
-        typeof c.summary === "string" &&
-        typeof c.is_new === "boolean",
-    );
+    return concepts
+      .filter(
+        (c) =>
+          typeof c.concept === "string" &&
+          typeof c.summary === "string" &&
+          typeof c.is_new === "boolean" &&
+          (c.tags === undefined || Array.isArray(c.tags)),
+      )
+      .map((c) => ({
+        concept: c.concept,
+        summary: c.summary,
+        is_new: c.is_new,
+        tags: Array.isArray(c.tags) ? c.tags : undefined,
+      }));
   } catch {
     return [];
   }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -31,3 +31,4 @@ export const LLMWIKI_DIR = ".llmwiki";
 export const STATE_FILE = ".llmwiki/state.json";
 export const LOCK_FILE = ".llmwiki/lock";
 export const INDEX_FILE = "wiki/index.md";
+export const MOC_FILE = "wiki/MOC.md";

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -8,6 +8,7 @@ export interface ExtractedConcept {
   concept: string;
   summary: string;
   is_new: boolean;
+  tags?: string[];
 }
 
 /** Per-source entry in .llmwiki/state.json. */
@@ -38,6 +39,8 @@ interface WikiFrontmatter {
   sources: string[];
   summary: string;
   orphaned?: boolean;
+  tags?: string[];
+  aliases?: string[];
   createdAt: string;
   updatedAt: string;
 }

--- a/test/fixtures/temp-root.ts
+++ b/test/fixtures/temp-root.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared test helper for creating temporary llmwiki project roots.
+ * Used by tests that need a realistic filesystem layout (wiki/concepts, wiki/queries).
+ */
+
+import { mkdir } from "fs/promises";
+import path from "path";
+import os from "os";
+
+/**
+ * Create a temp directory simulating an llmwiki project root.
+ * Creates wiki/concepts and wiki/queries subdirectories.
+ * @param prefix - Short label for the temp directory name.
+ * @returns Absolute path to the temporary root.
+ */
+export async function makeTempRoot(prefix: string): Promise<string> {
+  const root = path.join(
+    os.tmpdir(),
+    `llmwiki-${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  await mkdir(path.join(root, "wiki/concepts"), { recursive: true });
+  await mkdir(path.join(root, "wiki/queries"), { recursive: true });
+  return root;
+}

--- a/test/indexgen.test.ts
+++ b/test/indexgen.test.ts
@@ -1,17 +1,9 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { mkdir, writeFile, readFile, rm } from "fs/promises";
+import { writeFile, readFile } from "fs/promises";
 import path from "path";
-import os from "os";
 import { generateIndex } from "../src/compiler/indexgen.js";
 import { buildFrontmatter } from "../src/utils/markdown.js";
-
-/** Create a temp directory simulating an llmwiki project root. */
-async function makeTempRoot(): Promise<string> {
-  const root = path.join(os.tmpdir(), `llmwiki-idx-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-  await mkdir(path.join(root, "wiki/concepts"), { recursive: true });
-  await mkdir(path.join(root, "wiki/queries"), { recursive: true });
-  return root;
-}
+import { makeTempRoot } from "./fixtures/temp-root.js";
 
 /** Write a minimal wiki page with frontmatter into a directory. */
 async function writePage(dir: string, slug: string, title: string, summary: string): Promise<void> {
@@ -23,7 +15,7 @@ describe("generateIndex", () => {
   let root: string;
 
   beforeEach(async () => {
-    root = await makeTempRoot();
+    root = await makeTempRoot("idx");
   });
 
   it("includes concept pages in the index", async () => {

--- a/test/obsidian.test.ts
+++ b/test/obsidian.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { readFile, writeFile } from "fs/promises";
+import path from "path";
+import { addObsidianMeta, generateMOC } from "../src/compiler/obsidian.js";
+import { buildFrontmatter } from "../src/utils/markdown.js";
+import { makeTempRoot } from "./fixtures/temp-root.js";
+
+/** Write a concept page with optional tags. */
+async function writePage(
+  dir: string,
+  slug: string,
+  title: string,
+  tags?: string[],
+): Promise<void> {
+  const fields: Record<string, unknown> = { title, summary: "A summary" };
+  if (tags) fields.tags = tags;
+  const fm = buildFrontmatter(fields);
+  await writeFile(path.join(dir, `${slug}.md`), `${fm}\n\nBody of ${title}.\n`);
+}
+
+describe("addObsidianMeta", () => {
+  it("sets tags from input", () => {
+    const fm: Record<string, unknown> = {};
+    addObsidianMeta(fm, "Test", ["ml", "optimization"]);
+    expect(fm.tags).toEqual(["ml", "optimization"]);
+  });
+
+  it("sets empty tags from empty input", () => {
+    const fm: Record<string, unknown> = {};
+    addObsidianMeta(fm, "Test", []);
+    expect(fm.tags).toEqual([]);
+  });
+
+  it("generates slug alias", () => {
+    const fm: Record<string, unknown> = {};
+    addObsidianMeta(fm, "Gradient Descent", []);
+    expect(fm.aliases).toContain("gradient-descent");
+  });
+
+  it("generates word-swap alias for titles with 'and'", () => {
+    const fm: Record<string, unknown> = {};
+    addObsidianMeta(fm, "Gradient Descent and Optimization", []);
+    expect(fm.aliases).toContain("Optimization and Gradient Descent");
+  });
+
+  it("generates word-swap alias for titles with 'or'", () => {
+    const fm: Record<string, unknown> = {};
+    addObsidianMeta(fm, "Precision or Recall", []);
+    expect(fm.aliases).toContain("Recall or Precision");
+  });
+
+  it("generates abbreviation for 3+ word titles", () => {
+    const fm: Record<string, unknown> = {};
+    addObsidianMeta(fm, "Retrieval Augmented Generation", []);
+    expect(fm.aliases).toContain("RAG");
+  });
+
+  it("returns empty aliases when title is one word", () => {
+    const fm: Record<string, unknown> = {};
+    addObsidianMeta(fm, "embeddings", []);
+    expect(fm.aliases).toEqual([]);
+  });
+
+  it("does not include slug alias when slug equals title", () => {
+    const fm: Record<string, unknown> = {};
+    addObsidianMeta(fm, "test", []);
+    expect(fm.aliases).toEqual([]);
+  });
+});
+
+describe("generateMOC", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await makeTempRoot("obs");
+  });
+
+  it("groups pages by tag", async () => {
+    const dir = path.join(root, "wiki/concepts");
+    await writePage(dir, "alpha", "Alpha", ["ml"]);
+    await writePage(dir, "beta", "Beta", ["ml"]);
+    await writePage(dir, "gamma", "Gamma", ["databases"]);
+
+    await generateMOC(root);
+    const moc = await readFile(path.join(root, "wiki/MOC.md"), "utf-8");
+
+    expect(moc).toContain("## ml");
+    expect(moc).toContain("## databases");
+    expect(moc).toContain("[[Alpha]]");
+    expect(moc).toContain("[[Beta]]");
+    expect(moc).toContain("[[Gamma]]");
+  });
+
+  it("includes uncategorized section for tagless pages", async () => {
+    const dir = path.join(root, "wiki/concepts");
+    await writePage(dir, "alpha", "Alpha", ["ml"]);
+    await writePage(dir, "beta", "Beta");
+
+    await generateMOC(root);
+    const moc = await readFile(path.join(root, "wiki/MOC.md"), "utf-8");
+
+    expect(moc).toContain("## Uncategorized");
+    expect(moc).toContain("[[Beta]]");
+  });
+
+  it("creates valid markdown output", async () => {
+    const dir = path.join(root, "wiki/concepts");
+    await writePage(dir, "alpha", "Alpha", ["ml"]);
+
+    await generateMOC(root);
+    const moc = await readFile(path.join(root, "wiki/MOC.md"), "utf-8");
+
+    expect(moc).toMatch(/^# Map of Content/);
+    expect(moc).toContain("- [[Alpha]]");
+  });
+
+  it("handles empty concepts directory", async () => {
+    await generateMOC(root);
+    const moc = await readFile(path.join(root, "wiki/MOC.md"), "utf-8");
+    expect(moc).toContain("# Map of Content");
+  });
+
+  it("excludes orphaned pages", async () => {
+    const dir = path.join(root, "wiki/concepts");
+    await writePage(dir, "alive", "Alive", ["ml"]);
+    const orphanFm = buildFrontmatter({ title: "Dead", summary: "Gone", orphaned: true, tags: ["ml"] });
+    await writeFile(path.join(dir, "dead.md"), `${orphanFm}\n\nOrphaned.\n`);
+
+    await generateMOC(root);
+    const moc = await readFile(path.join(root, "wiki/MOC.md"), "utf-8");
+
+    expect(moc).toContain("[[Alive]]");
+    expect(moc).not.toContain("[[Dead]]");
+  });
+});


### PR DESCRIPTION
Add tags to concept extraction schema so the LLM returns categorical tags per concept. Enrich wiki page frontmatter with tags and deterministic aliases (slug, conjunction swap, abbreviation) for better Obsidian graph navigation. Generate a MOC.md that groups concept pages by tag with an Uncategorized fallback section.

Extract shared makeTempRoot test helper to reduce duplication.