### PR TITLE
Add multi-provider support for LLM backends

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://fallow.tools/schema.json",
+  "overrides": [
+    {
+      "files": ["src/providers/*.ts"],
+      "rules": {
+        "unused-class-members": "off"
+      }
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-wiki-compiler",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-wiki-compiler",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
@@ -16,6 +16,7 @@
         "dotenv": "^17.4.0",
         "js-yaml": "^4.1.1",
         "jsdom": "^25.0.0",
+        "openai": "^4.0.0",
         "p-limit": "^6.0.0",
         "turndown": "^7.2.0"
       },
@@ -2180,6 +2181,51 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/openai": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
     "node_modules/p-limit": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
@@ -3030,6 +3076,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "commander": "^13.0.0",
     "dotenv": "^17.4.0",
     "js-yaml": "^4.1.1",
+    "openai": "^4.0.0",
     "jsdom": "^25.0.0",
     "p-limit": "^6.0.0",
     "turndown": "^7.2.0"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,8 @@
 /**
  * CLI entry point for llmwiki — the knowledge compiler.
  *
- * Registers all commands (ingest, compile, query, watch) via Commander.
- * Validates ANTHROPIC_API_KEY for commands that need LLM access.
+ * Registers all commands (ingest, compile, query, watch, lint) via Commander.
+ * Validates the correct API key for the selected LLM provider.
  * Designed for `npx llmwiki` or global install via `npm install -g llm-wiki-compiler`.
  */
 
@@ -14,6 +14,7 @@ import compileCommand from "./commands/compile.js";
 import queryCommand from "./commands/query.js";
 import watchCommand from "./commands/watch.js";
 import lintCommand from "./commands/lint.js";
+import { DEFAULT_PROVIDER } from "./utils/constants.js";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json") as { version: string };
@@ -41,7 +42,7 @@ program
   .command("compile")
   .description("Compile sources/ into an interlinked wiki")
   .action(async () => {
-    requireApiKey();
+    requireProvider();
     try {
       await compileCommand();
     } catch (err) {
@@ -55,7 +56,7 @@ program
   .description("Ask a question against the wiki")
   .option("--save", "Save the answer as a wiki page")
   .action(async (question: string, options: { save?: boolean }) => {
-    requireApiKey();
+    requireProvider();
     try {
       await queryCommand(process.cwd(), question, options);
     } catch (err) {
@@ -68,7 +69,7 @@ program
   .command("watch")
   .description("Watch sources/ and auto-recompile on changes")
   .action(async () => {
-    requireApiKey();
+    requireProvider();
     try {
       await watchCommand();
     } catch (err) {
@@ -89,16 +90,33 @@ program
     }
   });
 
-program.parse();
+/** API key env var required per provider. Null means no key needed. */
+const PROVIDER_KEY_VARS: Record<string, string | null> = {
+  anthropic: "ANTHROPIC_API_KEY",
+  openai: "OPENAI_API_KEY",
+  ollama: null,
+};
 
-/** Exit with a helpful message if ANTHROPIC_API_KEY is missing. */
-function requireApiKey(): void {
-  if (!process.env.ANTHROPIC_API_KEY) {
+/** Exit with a helpful message if the selected provider's API key is missing. */
+function requireProvider(): void {
+  const provider = process.env.LLMWIKI_PROVIDER ?? DEFAULT_PROVIDER;
+  const keyVar = PROVIDER_KEY_VARS[provider];
+
+  if (keyVar === undefined) {
     console.error(
-      "\x1b[31mError:\x1b[0m ANTHROPIC_API_KEY environment variable is required.\n" +
-        "  Set it with: export ANTHROPIC_API_KEY=sk-ant-...\n" +
-        "  Get a key at: https://console.anthropic.com/settings/keys",
+      `\x1b[31mError:\x1b[0m Unknown provider "${provider}".\n` +
+        `  Supported: ${Object.keys(PROVIDER_KEY_VARS).join(", ")}`,
+    );
+    process.exit(1);
+  }
+
+  if (keyVar && !process.env[keyVar]) {
+    console.error(
+      `\x1b[31mError:\x1b[0m ${keyVar} environment variable is required for the "${provider}" provider.\n` +
+        `  Set it with: export ${keyVar}=<your-key>`,
     );
     process.exit(1);
   }
 }
+
+program.parse();

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -13,8 +13,8 @@
 
 import { existsSync } from "fs";
 import path from "path";
-import Anthropic from "@anthropic-ai/sdk";
 import { callClaude } from "../utils/llm.js";
+import type { LLMTool } from "../utils/provider.js";
 import { atomicWrite, safeReadFile, slugify, buildFrontmatter, parseFrontmatter } from "../utils/markdown.js";
 import { generateIndex } from "../compiler/indexgen.js";
 import * as output from "../utils/output.js";
@@ -23,8 +23,8 @@ import { QUERY_PAGE_LIMIT, INDEX_FILE, CONCEPTS_DIR, QUERIES_DIR } from "../util
 /** Directories to search when loading selected pages, in priority order. */
 const PAGE_DIRS = [CONCEPTS_DIR, QUERIES_DIR];
 
-/** Anthropic tool schema for page selection. */
-const PAGE_SELECTION_TOOL: Anthropic.Tool = {
+/** Tool schema for page selection (provider-agnostic). */
+const PAGE_SELECTION_TOOL: LLMTool = {
   name: "select_pages",
   description: "Select the most relevant wiki pages to answer a question",
   input_schema: {

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -1,0 +1,88 @@
+/**
+ * Anthropic LLM provider implementation.
+ *
+ * Wraps the @anthropic-ai/sdk to implement the LLMProvider interface.
+ * Handles complete, streaming, and tool-use calls against Claude models.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import type { LLMProvider, LLMMessage, LLMTool } from "../utils/provider.js";
+
+/** Anthropic-backed LLM provider using the official SDK. */
+export class AnthropicProvider implements LLMProvider {
+  private readonly client: Anthropic;
+  private readonly model: string;
+
+  constructor(model: string) {
+    this.model = model;
+    this.client = new Anthropic();
+  }
+
+  /** Send a single non-streaming completion request. */
+  async complete(system: string, messages: LLMMessage[], maxTokens: number): Promise<string> {
+    const response = await this.client.messages.create({
+      model: this.model,
+      max_tokens: maxTokens,
+      system,
+      messages,
+    });
+
+    const textBlock = response.content.find((block) => block.type === "text");
+    return textBlock?.type === "text" ? textBlock.text : "";
+  }
+
+  /** Stream a completion, invoking onToken for each text chunk. */
+  async stream(
+    system: string,
+    messages: LLMMessage[],
+    maxTokens: number,
+    onToken?: (text: string) => void,
+  ): Promise<string> {
+    const stream = this.client.messages.stream({
+      model: this.model,
+      max_tokens: maxTokens,
+      system,
+      messages,
+    });
+
+    let fullText = "";
+    for await (const event of stream) {
+      if (event.type === "content_block_delta" && event.delta.type === "text_delta") {
+        fullText += event.delta.text;
+        onToken?.(event.delta.text);
+      }
+    }
+
+    return fullText;
+  }
+
+  /** Call Claude with tool definitions and return the parsed tool input as JSON. */
+  async toolCall(
+    system: string,
+    messages: LLMMessage[],
+    tools: LLMTool[],
+    maxTokens: number,
+  ): Promise<string> {
+    const anthropicTools: Anthropic.Tool[] = tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      input_schema: t.input_schema as Anthropic.Tool.InputSchema,
+    }));
+
+    const response = await this.client.messages.create({
+      model: this.model,
+      max_tokens: maxTokens,
+      system,
+      messages,
+      tools: anthropicTools,
+    });
+
+    const toolBlock = response.content.find((block) => block.type === "tool_use");
+    if (toolBlock?.type === "tool_use") {
+      return JSON.stringify(toolBlock.input);
+    }
+
+    const textBlock = response.content.find((block) => block.type === "text");
+    return textBlock?.type === "text" ? textBlock.text : "";
+  }
+}

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -1,0 +1,15 @@
+/**
+ * Ollama LLM provider implementation.
+ *
+ * Extends OpenAIProvider since Ollama exposes an OpenAI-compatible API.
+ * Overrides only the constructor to set baseURL and disable API key auth.
+ */
+
+import { OpenAIProvider } from "./openai.js";
+
+/** Ollama-backed LLM provider using the OpenAI-compatible endpoint. */
+export class OllamaProvider extends OpenAIProvider {
+  constructor(model: string, baseURL: string) {
+    super(model, baseURL, "ollama");
+  }
+}

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -1,0 +1,101 @@
+/**
+ * OpenAI LLM provider implementation.
+ *
+ * Wraps the openai npm package to implement the LLMProvider interface.
+ * Translates Anthropic-style tool schemas (input_schema) to OpenAI format (parameters).
+ */
+
+import OpenAI from "openai";
+import type { LLMProvider, LLMMessage, LLMTool } from "../utils/provider.js";
+
+/** Translate an Anthropic-style LLMTool to an OpenAI ChatCompletionTool. */
+export function translateToolToOpenAI(
+  tool: LLMTool,
+): OpenAI.ChatCompletionTool {
+  return {
+    type: "function",
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.input_schema,
+    },
+  };
+}
+
+/** OpenAI-backed LLM provider. */
+export class OpenAIProvider implements LLMProvider {
+  protected readonly client: OpenAI;
+  protected readonly model: string;
+
+  constructor(model: string, baseURL?: string, apiKey?: string) {
+    this.model = model;
+    // The OpenAI SDK validates OPENAI_API_KEY at construction time.
+    // Pass the key explicitly so the provider controls when validation happens.
+    const resolvedKey = apiKey ?? process.env.OPENAI_API_KEY ?? "";
+    this.client = new OpenAI({
+      apiKey: resolvedKey,
+      ...(baseURL ? { baseURL } : {}),
+    });
+  }
+
+  /** Send a single non-streaming completion request. */
+  async complete(system: string, messages: LLMMessage[], maxTokens: number): Promise<string> {
+    const response = await this.client.chat.completions.create({
+      model: this.model,
+      max_tokens: maxTokens,
+      messages: [{ role: "system", content: system }, ...messages],
+    });
+
+    return response.choices[0]?.message?.content ?? "";
+  }
+
+  /** Stream a completion, invoking onToken for each text chunk. */
+  async stream(
+    system: string,
+    messages: LLMMessage[],
+    maxTokens: number,
+    onToken?: (text: string) => void,
+  ): Promise<string> {
+    const stream = await this.client.chat.completions.create({
+      model: this.model,
+      max_tokens: maxTokens,
+      messages: [{ role: "system", content: system }, ...messages],
+      stream: true,
+    });
+
+    let fullText = "";
+    for await (const chunk of stream) {
+      const delta = chunk.choices[0]?.delta?.content;
+      if (delta) {
+        fullText += delta;
+        onToken?.(delta);
+      }
+    }
+
+    return fullText;
+  }
+
+  /** Call the model with tool definitions and return the parsed tool input as JSON. */
+  async toolCall(
+    system: string,
+    messages: LLMMessage[],
+    tools: LLMTool[],
+    maxTokens: number,
+  ): Promise<string> {
+    const openaiTools = tools.map(translateToolToOpenAI);
+
+    const response = await this.client.chat.completions.create({
+      model: this.model,
+      max_tokens: maxTokens,
+      messages: [{ role: "system", content: system }, ...messages],
+      tools: openaiTools,
+    });
+
+    const toolCalls = response.choices[0]?.message?.tool_calls;
+    if (toolCalls && toolCalls.length > 0) {
+      return toolCalls[0].function.arguments;
+    }
+
+    return response.choices[0]?.message?.content ?? "";
+  }
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -20,8 +20,18 @@ export const RETRY_COUNT = 3;
 export const RETRY_BASE_MS = 1000;
 export const RETRY_MULTIPLIER = 4;
 
-/** Claude model to use for all LLM calls. */
-export const MODEL = "claude-sonnet-4-20250514";
+/** Default provider when LLMWIKI_PROVIDER is not set. */
+export const DEFAULT_PROVIDER = "anthropic";
+
+/** Default model per provider. */
+export const PROVIDER_MODELS: Record<string, string> = {
+  anthropic: "claude-sonnet-4-20250514",
+  openai: "gpt-4o",
+  ollama: "llama3.1",
+};
+
+/** Default Ollama API base URL. */
+export const OLLAMA_DEFAULT_HOST = "http://localhost:11434/v1";
 
 /** Directory names relative to the project root. */
 export const SOURCES_DIR = "sources";

--- a/src/utils/llm.ts
+++ b/src/utils/llm.ts
@@ -1,21 +1,14 @@
 /**
- * Shared LLM helper wrapping the Anthropic SDK.
- * Provides callClaude() for both streaming and tool_use calls,
- * with retry logic and exponential backoff.
+ * Shared LLM helper with provider abstraction.
+ *
+ * Provides callClaude() for backward compatibility — delegates to the
+ * active LLMProvider while preserving retry logic with exponential backoff.
+ * The provider is selected via LLMWIKI_PROVIDER env var (see provider.ts).
  */
 
-import Anthropic from "@anthropic-ai/sdk";
-import { MODEL, RETRY_COUNT, RETRY_BASE_MS, RETRY_MULTIPLIER } from "./constants.js";
-
-let client: Anthropic | null = null;
-
-/** Get or create the Anthropic client singleton. */
-function getClient(): Anthropic {
-  if (!client) {
-    client = new Anthropic();
-  }
-  return client;
-}
+import { RETRY_COUNT, RETRY_BASE_MS, RETRY_MULTIPLIER } from "./constants.js";
+import { getProvider } from "./provider.js";
+import type { LLMMessage, LLMTool } from "./provider.js";
 
 /** Sleep for a given number of milliseconds. */
 function sleep(ms: number): Promise<void> {
@@ -24,33 +17,33 @@ function sleep(ms: number): Promise<void> {
 
 interface CallClaudeOptions {
   system: string;
-  messages: Anthropic.MessageParam[];
-  tools?: Anthropic.Tool[];
+  messages: LLMMessage[];
+  tools?: LLMTool[];
   maxTokens?: number;
   stream?: boolean;
   onToken?: (text: string) => void;
 }
 
 /**
- * Call Claude with retry logic. Supports both streaming and non-streaming modes.
- * For tool_use calls, returns the parsed tool input. For streaming calls, invokes
- * onToken for each text chunk and returns the full assembled text.
+ * Call the active LLM provider with retry logic.
+ * Supports streaming, tool-use, and basic completion modes.
+ * Preserves the original callClaude interface for backward compatibility.
  */
 export async function callClaude(options: CallClaudeOptions): Promise<string> {
   const { system, messages, tools, maxTokens = 4096, stream = false, onToken } = options;
-  const anthropic = getClient();
+  const provider = getProvider();
 
   for (let attempt = 0; attempt <= RETRY_COUNT; attempt++) {
     try {
       if (stream) {
-        return await callClaudeStreaming(anthropic, system, messages, maxTokens, onToken);
+        return await provider.stream(system, messages, maxTokens, onToken);
       }
 
       if (tools && tools.length > 0) {
-        return await callClaudeToolUse(anthropic, system, messages, tools, maxTokens);
+        return await provider.toolCall(system, messages, tools, maxTokens);
       }
 
-      return await callClaudeBasic(anthropic, system, messages, maxTokens);
+      return await provider.complete(system, messages, maxTokens);
     } catch (error) {
       if (attempt === RETRY_COUNT) throw error;
 
@@ -63,83 +56,4 @@ export async function callClaude(options: CallClaudeOptions): Promise<string> {
   }
 
   throw new Error("Unreachable");
-}
-
-async function callClaudeStreaming(
-  anthropic: Anthropic,
-  system: string,
-  messages: Anthropic.MessageParam[],
-  maxTokens: number,
-  onToken?: (text: string) => void,
-): Promise<string> {
-  const stream = anthropic.messages.stream({
-    model: MODEL,
-    max_tokens: maxTokens,
-    system,
-    messages,
-  });
-
-  let fullText = "";
-
-  for await (const event of stream) {
-    if (
-      event.type === "content_block_delta" &&
-      event.delta.type === "text_delta"
-    ) {
-      fullText += event.delta.text;
-      onToken?.(event.delta.text);
-    }
-  }
-
-  return fullText;
-}
-
-async function callClaudeToolUse(
-  anthropic: Anthropic,
-  system: string,
-  messages: Anthropic.MessageParam[],
-  tools: Anthropic.Tool[],
-  maxTokens: number,
-): Promise<string> {
-  const response = await anthropic.messages.create({
-    model: MODEL,
-    max_tokens: maxTokens,
-    system,
-    messages,
-    tools,
-  });
-
-  const toolBlock = response.content.find((block) => block.type === "tool_use");
-  if (toolBlock && toolBlock.type === "tool_use") {
-    return JSON.stringify(toolBlock.input);
-  }
-
-  // Fallback: return text content if no tool use
-  const textBlock = response.content.find((block) => block.type === "text");
-  if (textBlock && textBlock.type === "text") {
-    return textBlock.text;
-  }
-
-  return "";
-}
-
-async function callClaudeBasic(
-  anthropic: Anthropic,
-  system: string,
-  messages: Anthropic.MessageParam[],
-  maxTokens: number,
-): Promise<string> {
-  const response = await anthropic.messages.create({
-    model: MODEL,
-    max_tokens: maxTokens,
-    system,
-    messages,
-  });
-
-  const textBlock = response.content.find((block) => block.type === "text");
-  if (textBlock && textBlock.type === "text") {
-    return textBlock.text;
-  }
-
-  return "";
 }

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -1,0 +1,77 @@
+/**
+ * LLM provider abstraction layer.
+ *
+ * Defines the LLMProvider interface and a factory function that reads
+ * LLMWIKI_PROVIDER and LLMWIKI_MODEL env vars to instantiate the
+ * appropriate backend (Anthropic, OpenAI, or Ollama).
+ */
+
+import { DEFAULT_PROVIDER, PROVIDER_MODELS, OLLAMA_DEFAULT_HOST } from "./constants.js";
+import { AnthropicProvider } from "../providers/anthropic.js";
+import { OpenAIProvider } from "../providers/openai.js";
+import { OllamaProvider } from "../providers/ollama.js";
+
+/** A single message in an LLM conversation. */
+export interface LLMMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+/** A tool definition in Anthropic-style format (used as the canonical shape). */
+export interface LLMTool {
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+}
+
+/** Provider-agnostic interface for LLM backends. */
+export interface LLMProvider {
+  complete(system: string, messages: LLMMessage[], maxTokens: number): Promise<string>;
+  stream(
+    system: string,
+    messages: LLMMessage[],
+    maxTokens: number,
+    onToken?: (text: string) => void,
+  ): Promise<string>;
+  toolCall(
+    system: string,
+    messages: LLMMessage[],
+    tools: LLMTool[],
+    maxTokens: number,
+  ): Promise<string>;
+}
+
+const SUPPORTED_PROVIDERS: ReadonlySet<string> = new Set(["anthropic", "openai", "ollama"]);
+
+/**
+ * Factory that returns the appropriate LLMProvider based on env vars.
+ * Reads LLMWIKI_PROVIDER (default "anthropic") and LLMWIKI_MODEL
+ * (defaults per provider from PROVIDER_MODELS).
+ *
+ * Direct process.env access is acceptable here as this is a system boundary.
+ */
+export function getProvider(): LLMProvider {
+  const providerName = process.env.LLMWIKI_PROVIDER ?? DEFAULT_PROVIDER;
+
+  if (!SUPPORTED_PROVIDERS.has(providerName)) {
+    throw new Error(
+      `Unknown provider "${providerName}". Supported: ${[...SUPPORTED_PROVIDERS].join(", ")}`,
+    );
+  }
+
+  const model = process.env.LLMWIKI_MODEL ?? PROVIDER_MODELS[providerName];
+
+  switch (providerName) {
+    case "anthropic":
+      return new AnthropicProvider(model);
+    case "openai":
+      return new OpenAIProvider(model);
+    case "ollama":
+      return new OllamaProvider(
+        model,
+        process.env.OLLAMA_HOST ?? OLLAMA_DEFAULT_HOST,
+      );
+    default:
+      throw new Error(`Unhandled provider: ${providerName}`);
+  }
+}

--- a/test/llm-compat.test.ts
+++ b/test/llm-compat.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Backward compatibility tests for the callClaude export.
+ * Ensures that the refactored llm.ts still exports callClaude and
+ * accepts the same options interface as before the provider abstraction.
+ */
+
+import { describe, it, expect } from "vitest";
+import { callClaude } from "../src/utils/llm.js";
+
+describe("callClaude backward compatibility", () => {
+  it("is exported as a function from llm.ts", () => {
+    expect(typeof callClaude).toBe("function");
+  });
+
+  it("accepts the existing options interface shape", () => {
+    // Verify the function signature accepts all known option fields
+    // without throwing a type error at import time.
+    const optionsShape = {
+      system: "You are a test assistant.",
+      messages: [{ role: "user" as const, content: "Hello" }],
+      tools: [{ name: "t", description: "d", input_schema: { type: "object" } }],
+      maxTokens: 1024,
+      stream: false,
+      onToken: (_text: string) => {},
+    };
+
+    // The options object should match the expected shape without type errors.
+    // We do not actually call the function (would require a real API key).
+    expect(optionsShape).toBeDefined();
+  });
+});

--- a/test/provider-factory.test.ts
+++ b/test/provider-factory.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests for the provider factory (getProvider).
+ * Verifies correct provider instantiation based on env vars.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { getProvider } from "../src/utils/provider.js";
+import { AnthropicProvider } from "../src/providers/anthropic.js";
+import { OpenAIProvider } from "../src/providers/openai.js";
+import { OllamaProvider } from "../src/providers/ollama.js";
+
+describe("getProvider", () => {
+  afterEach(() => {
+    delete process.env.LLMWIKI_PROVIDER;
+    delete process.env.LLMWIKI_MODEL;
+  });
+
+  it("returns AnthropicProvider when LLMWIKI_PROVIDER is unset", () => {
+    delete process.env.LLMWIKI_PROVIDER;
+    const provider = getProvider();
+    expect(provider).toBeInstanceOf(AnthropicProvider);
+  });
+
+  it("returns AnthropicProvider when LLMWIKI_PROVIDER=anthropic", () => {
+    process.env.LLMWIKI_PROVIDER = "anthropic";
+    const provider = getProvider();
+    expect(provider).toBeInstanceOf(AnthropicProvider);
+  });
+
+  it("returns OpenAIProvider when LLMWIKI_PROVIDER=openai", () => {
+    process.env.LLMWIKI_PROVIDER = "openai";
+    const provider = getProvider();
+    expect(provider).toBeInstanceOf(OpenAIProvider);
+  });
+
+  it("returns OllamaProvider when LLMWIKI_PROVIDER=ollama", () => {
+    process.env.LLMWIKI_PROVIDER = "ollama";
+    const provider = getProvider();
+    expect(provider).toBeInstanceOf(OllamaProvider);
+  });
+
+  it("throws for unknown provider", () => {
+    process.env.LLMWIKI_PROVIDER = "gemini";
+    expect(() => getProvider()).toThrow('Unknown provider "gemini"');
+  });
+
+  it("respects LLMWIKI_MODEL override", () => {
+    process.env.LLMWIKI_PROVIDER = "openai";
+    process.env.LLMWIKI_MODEL = "gpt-4-turbo";
+    const provider = getProvider();
+    expect(provider).toBeInstanceOf(OpenAIProvider);
+    // The model is stored as a protected field; verify it was accepted
+    // by checking the provider was created without throwing
+    expect(provider).toBeDefined();
+  });
+});

--- a/test/provider-openai.test.ts
+++ b/test/provider-openai.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for OpenAI tool schema translation.
+ * Verifies that Anthropic-style tool schemas (input_schema) are correctly
+ * converted to OpenAI format (parameters).
+ */
+
+import { describe, it, expect } from "vitest";
+import { translateToolToOpenAI } from "../src/providers/openai.js";
+import type { LLMTool } from "../src/utils/provider.js";
+
+describe("translateToolToOpenAI", () => {
+  it("translates input_schema to parameters", () => {
+    const tool: LLMTool = {
+      name: "get_weather",
+      description: "Get the weather for a city",
+      input_schema: {
+        type: "object",
+        properties: {
+          city: { type: "string", description: "City name" },
+        },
+        required: ["city"],
+      },
+    };
+
+    const result = translateToolToOpenAI(tool);
+
+    expect(result.type).toBe("function");
+    expect(result.function.name).toBe("get_weather");
+    expect(result.function.description).toBe("Get the weather for a city");
+    expect(result.function.parameters).toEqual(tool.input_schema);
+  });
+
+  it("preserves required fields through translation", () => {
+    const tool: LLMTool = {
+      name: "search",
+      description: "Search documents",
+      input_schema: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+          limit: { type: "number" },
+        },
+        required: ["query"],
+      },
+    };
+
+    const result = translateToolToOpenAI(tool);
+    const params = result.function.parameters as Record<string, unknown>;
+    expect(params.required).toEqual(["query"]);
+  });
+
+  it("translates multiple tools correctly", () => {
+    const tools: LLMTool[] = [
+      {
+        name: "tool_a",
+        description: "First tool",
+        input_schema: { type: "object", properties: { x: { type: "string" } } },
+      },
+      {
+        name: "tool_b",
+        description: "Second tool",
+        input_schema: { type: "object", properties: { y: { type: "number" } } },
+      },
+    ];
+
+    const results = tools.map(translateToolToOpenAI);
+
+    expect(results).toHaveLength(2);
+    expect(results[0].function.name).toBe("tool_a");
+    expect(results[1].function.name).toBe("tool_b");
+    expect(results[0].function.parameters).toEqual(tools[0].input_schema);
+    expect(results[1].function.parameters).toEqual(tools[1].input_schema);
+  });
+});


### PR DESCRIPTION
Introduce provider abstraction so users can swap LLM backends via LLMWIKI_PROVIDER env var. Supports Anthropic (default), OpenAI, and Ollama. Each provider implements a common LLMProvider interface with complete, stream, and toolCall methods.

- Add provider factory (src/utils/provider.ts) reading LLMWIKI_PROVIDER and LLMWIKI_MODEL env vars
- Add AnthropicProvider, OpenAIProvider, and OllamaProvider classes
- Refactor callClaude to delegate to the active provider while preserving retry logic and backward-compatible interface
- Replace requireApiKey with requireProvider in CLI, checking the correct API key per provider
- Add openai npm dependency
- Add fallow config to suppress interface-implementation class members
- Add tests for provider factory, OpenAI tool translation, and backward compatibility