### PR TITLE
Add Claude settings fallback support for Anthropic provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 localdocs/
 .fallow/
 .worktrees/
+.sisyphus/

--- a/README.md
+++ b/README.md
@@ -17,10 +17,53 @@ Inspired by Karpathy's [LLM Wiki](https://gist.github.com/karpathy/442a6bf555914
 ```bash
 npm install -g llm-wiki-compiler
 export ANTHROPIC_API_KEY=sk-...
+# Or use ANTHROPIC_AUTH_TOKEN if your Anthropic-compatible gateway expects it.
+# Or use a different provider:
+# export LLMWIKI_PROVIDER=openai
+# export OPENAI_API_KEY=sk-...
 
 llmwiki ingest https://some-article.com
 llmwiki compile
 llmwiki query "what is X?"
+```
+
+## Configuration
+
+llmwiki configures providers via environment variables. The default provider is Anthropic.
+
+Configuration precedence for Anthropic values:
+
+1. Shell env / local `.env`
+2. Claude Code settings fallback (`~/.claude/settings.json` → `env` block)
+3. Built-in provider defaults (where applicable)
+
+- `LLMWIKI_PROVIDER`: The provider to use (e.g., anthropic, openai).
+- `LLMWIKI_MODEL`: The model name to override the provider default.
+
+### Anthropic (Default)
+
+- `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN`: Required. Either one can satisfy Anthropic authentication.
+- `ANTHROPIC_BASE_URL`: Optional. Custom endpoint for proxies. Valid HTTP(S) URLs are accepted, including Claude-style path endpoints such as `https://api.kimi.com/coding/`.
+
+Example using an Anthropic or cc-switch custom proxy:
+
+```bash
+export LLMWIKI_PROVIDER=anthropic
+export ANTHROPIC_API_KEY=sk-...
+export ANTHROPIC_BASE_URL=https://proxy.example.com
+```
+
+If those values are not set in shell env or `.env`, llmwiki will try Anthropic-compatible values from `~/.claude/settings.json` (`env` block) for:
+
+- `ANTHROPIC_API_KEY`
+- `ANTHROPIC_AUTH_TOKEN`
+- `ANTHROPIC_BASE_URL`
+- `ANTHROPIC_MODEL`
+
+Example with zero exports (Claude Code already configured):
+
+```bash
+llmwiki compile
 ```
 
 ## Why not just RAG?
@@ -109,7 +152,7 @@ See `examples/basic/` in the repo for pre-generated output you can browse withou
 
 ## Limitations
 
-Early software. Best for small, high-signal corpora (a few dozen sources). Query routing is index-based. Anthropic-only for now.
+Early software. Best for small, high-signal corpora (a few dozen sources). Query routing is index-based.
 
 **Honest about truncation.** Sources that exceed the character limit are truncated on ingest with `truncated: true` and the original character count recorded in frontmatter, so downstream consumers know they're working with partial content.
 
@@ -142,7 +185,7 @@ If you want to contribute, these are the highest-leverage areas right now. Issue
 
 ## Requirements
 
-Node.js >= 18, an Anthropic API key.
+Node.js >= 18, plus provider credentials (for Anthropic: `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN`).
 
 ## License
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import queryCommand from "./commands/query.js";
 import watchCommand from "./commands/watch.js";
 import lintCommand from "./commands/lint.js";
 import { DEFAULT_PROVIDER } from "./utils/constants.js";
+import { resolveAnthropicAuthFromEnv } from "./utils/claude-settings.js";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json") as { version: string };
@@ -42,8 +43,8 @@ program
   .command("compile")
   .description("Compile sources/ into an interlinked wiki")
   .action(async () => {
-    requireProvider();
     try {
+      requireProvider();
       await compileCommand();
     } catch (err) {
       console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
@@ -56,8 +57,8 @@ program
   .description("Ask a question against the wiki")
   .option("--save", "Save the answer as a wiki page")
   .action(async (question: string, options: { save?: boolean }) => {
-    requireProvider();
     try {
+      requireProvider();
       await queryCommand(process.cwd(), question, options);
     } catch (err) {
       console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
@@ -69,8 +70,8 @@ program
   .command("watch")
   .description("Watch sources/ and auto-recompile on changes")
   .action(async () => {
-    requireProvider();
     try {
+      requireProvider();
       await watchCommand();
     } catch (err) {
       console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
@@ -100,6 +101,19 @@ const PROVIDER_KEY_VARS: Record<string, string | null> = {
 /** Exit with a helpful message if the selected provider's API key is missing. */
 function requireProvider(): void {
   const provider = process.env.LLMWIKI_PROVIDER ?? DEFAULT_PROVIDER;
+
+  if (provider === "anthropic") {
+    const auth = resolveAnthropicAuthFromEnv();
+    if (!auth.apiKey && !auth.authToken) {
+      console.error(
+        `\x1b[31mError:\x1b[0m Anthropic credentials are required for the "anthropic" provider.\n` +
+          `  Set one of: export ANTHROPIC_API_KEY=<your-key> OR export ANTHROPIC_AUTH_TOKEN=<your-token>`,
+      );
+      process.exit(1);
+    }
+    return;
+  }
+
   const keyVar = PROVIDER_KEY_VARS[provider];
 
   if (keyVar === undefined) {

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -5,17 +5,59 @@
  * Handles complete, streaming, and tool-use calls against Claude models.
  */
 
-import Anthropic from "@anthropic-ai/sdk";
+import Anthropic, { type ClientOptions } from "@anthropic-ai/sdk";
 import type { LLMProvider, LLMMessage, LLMTool } from "../utils/provider.js";
+
+/**
+ * Builds the client options for the Anthropic SDK.
+ *
+ * Handles optional baseURL and filters out empty values so the SDK
+ * can fall back to its internal defaults when not specified.
+ */
+interface AnthropicProviderOptions {
+  apiKey?: string;
+  authToken?: string;
+  baseURL?: string;
+}
+
+export function buildAnthropicClientOptions(
+  options: AnthropicProviderOptions = {},
+): ClientOptions {
+  const trimmedBaseURL = options.baseURL?.trim();
+  const trimmedApiKey = options.apiKey?.trim();
+  const trimmedAuthToken = options.authToken?.trim();
+
+  const result: ClientOptions = {};
+
+  if (trimmedApiKey) {
+    result.apiKey = trimmedApiKey;
+  }
+  if (trimmedAuthToken) {
+    result.authToken = trimmedAuthToken;
+  }
+
+  if (!trimmedBaseURL) {
+    return result;
+  }
+
+  const normalizedBaseURL =
+    trimmedBaseURL.endsWith("/") && trimmedBaseURL.length > 1
+      ? trimmedBaseURL.slice(0, -1)
+      : trimmedBaseURL;
+
+  result.baseURL = normalizedBaseURL;
+  return result;
+}
+
 
 /** Anthropic-backed LLM provider using the official SDK. */
 export class AnthropicProvider implements LLMProvider {
   private readonly client: Anthropic;
   private readonly model: string;
 
-  constructor(model: string) {
+  constructor(model: string, options: AnthropicProviderOptions = {}) {
     this.model = model;
-    this.client = new Anthropic();
+    this.client = new Anthropic(buildAnthropicClientOptions(options));
   }
 
   /** Send a single non-streaming completion request. */

--- a/src/utils/claude-settings.ts
+++ b/src/utils/claude-settings.ts
@@ -1,0 +1,131 @@
+/**
+ * Claude settings fallback helpers.
+ *
+ * Provides a narrow, read-only integration with `~/.claude/settings.json`.
+ * We only read the `env` object and only extract Anthropic-related values that
+ * llmwiki can safely consume. Explicit process env values remain higher priority.
+ */
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+const CLAUDE_SETTINGS_PATH_ENV = "LLMWIKI_CLAUDE_SETTINGS_PATH";
+
+interface ClaudeSettingsEnv {
+  ANTHROPIC_API_KEY?: string;
+  ANTHROPIC_AUTH_TOKEN?: string;
+  ANTHROPIC_BASE_URL?: string;
+  ANTHROPIC_MODEL?: string;
+}
+
+interface AnthropicAuthConfig {
+  apiKey?: string;
+  authToken?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function normalize(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function resolveClaudeSettingsPath(env: NodeJS.ProcessEnv): string {
+  return env[CLAUDE_SETTINGS_PATH_ENV] ?? path.join(homedir(), ".claude", "settings.json");
+}
+
+function readClaudeSettingsFile(settingsPath: string): string | undefined {
+  try {
+    return readFileSync(settingsPath, "utf8");
+  } catch (err) {
+    if (isRecord(err) && err.code === "ENOENT") {
+      return undefined;
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to read Claude settings at "${settingsPath}": ${message}`);
+  }
+}
+
+export function readClaudeSettingsEnv(env: NodeJS.ProcessEnv = process.env): ClaudeSettingsEnv | undefined {
+  const settingsPath = resolveClaudeSettingsPath(env);
+  const raw = readClaudeSettingsFile(settingsPath);
+  if (!raw) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to parse Claude settings at "${settingsPath}": ${message}`);
+  }
+
+  if (!isRecord(parsed) || !isRecord(parsed.env)) {
+    return undefined;
+  }
+
+  const values: ClaudeSettingsEnv = {
+    ANTHROPIC_API_KEY: normalize(parsed.env.ANTHROPIC_API_KEY),
+    ANTHROPIC_AUTH_TOKEN: normalize(parsed.env.ANTHROPIC_AUTH_TOKEN),
+    ANTHROPIC_BASE_URL: normalize(parsed.env.ANTHROPIC_BASE_URL),
+    ANTHROPIC_MODEL: normalize(parsed.env.ANTHROPIC_MODEL),
+  };
+
+  if (!values.ANTHROPIC_API_KEY && !values.ANTHROPIC_AUTH_TOKEN && !values.ANTHROPIC_BASE_URL && !values.ANTHROPIC_MODEL) {
+    return undefined;
+  }
+  return values;
+}
+
+function tryReadClaudeSettingsEnv(env: NodeJS.ProcessEnv): ClaudeSettingsEnv | undefined {
+  try {
+    return readClaudeSettingsEnv(env);
+  } catch {
+    return undefined;
+  }
+}
+
+function validateAnthropicBaseURL(value: string): string {
+  const normalized = value.trim();
+  try {
+    const parsed = new URL(normalized);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error("Must use http:// or https:// protocol.");
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Must be a valid http(s) URL.";
+    throw new Error(`Invalid ANTHROPIC_BASE_URL: "${normalized}". ${message}`);
+  }
+  return normalized;
+}
+
+export function resolveAnthropicAuthFromEnv(env: NodeJS.ProcessEnv = process.env): AnthropicAuthConfig {
+  const explicitApiKey = normalize(env.ANTHROPIC_API_KEY);
+  if (explicitApiKey) return { apiKey: explicitApiKey };
+
+  const explicitAuthToken = normalize(env.ANTHROPIC_AUTH_TOKEN);
+  if (explicitAuthToken) return { authToken: explicitAuthToken };
+
+  const fallback = readClaudeSettingsEnv(env);
+  if (fallback?.ANTHROPIC_API_KEY) return { apiKey: fallback.ANTHROPIC_API_KEY };
+  if (fallback?.ANTHROPIC_AUTH_TOKEN) return { authToken: fallback.ANTHROPIC_AUTH_TOKEN };
+  return {};
+}
+
+export function resolveAnthropicModelFromEnv(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const explicitModel = env.LLMWIKI_MODEL;
+  if (explicitModel !== undefined) return explicitModel;
+  return tryReadClaudeSettingsEnv(env)?.ANTHROPIC_MODEL;
+}
+
+export function resolveAnthropicBaseURLFromEnv(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const explicitBaseURL = normalize(env.ANTHROPIC_BASE_URL);
+  if (explicitBaseURL) return validateAnthropicBaseURL(explicitBaseURL);
+
+  const fallbackBaseURL = tryReadClaudeSettingsEnv(env)?.ANTHROPIC_BASE_URL;
+  if (!fallbackBaseURL) return undefined;
+  return validateAnthropicBaseURL(fallbackBaseURL);
+}

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -10,6 +10,11 @@ import { DEFAULT_PROVIDER, PROVIDER_MODELS, OLLAMA_DEFAULT_HOST } from "./consta
 import { AnthropicProvider } from "../providers/anthropic.js";
 import { OpenAIProvider } from "../providers/openai.js";
 import { OllamaProvider } from "../providers/ollama.js";
+import {
+  resolveAnthropicAuthFromEnv,
+  resolveAnthropicBaseURLFromEnv,
+  resolveAnthropicModelFromEnv,
+} from "./claude-settings.js";
 
 /** A single message in an LLM conversation. */
 export interface LLMMessage {
@@ -51,27 +56,44 @@ const SUPPORTED_PROVIDERS: ReadonlySet<string> = new Set(["anthropic", "openai",
  * Direct process.env access is acceptable here as this is a system boundary.
  */
 export function getProvider(): LLMProvider {
-  const providerName = process.env.LLMWIKI_PROVIDER ?? DEFAULT_PROVIDER;
-
-  if (!SUPPORTED_PROVIDERS.has(providerName)) {
-    throw new Error(
-      `Unknown provider "${providerName}". Supported: ${[...SUPPORTED_PROVIDERS].join(", ")}`,
-    );
-  }
-
-  const model = process.env.LLMWIKI_MODEL ?? PROVIDER_MODELS[providerName];
+  const providerName = getProviderName();
 
   switch (providerName) {
     case "anthropic":
-      return new AnthropicProvider(model);
+      return getAnthropicProvider();
     case "openai":
-      return new OpenAIProvider(model);
+      return new OpenAIProvider(getModelForProvider("openai"));
     case "ollama":
       return new OllamaProvider(
-        model,
+        getModelForProvider("ollama"),
         process.env.OLLAMA_HOST ?? OLLAMA_DEFAULT_HOST,
       );
     default:
       throw new Error(`Unhandled provider: ${providerName}`);
   }
+}
+
+function getModelForProvider(providerName: "openai" | "ollama"): string {
+  return process.env.LLMWIKI_MODEL ?? PROVIDER_MODELS[providerName];
+}
+
+function getAnthropicProvider(): AnthropicProvider {
+  const model = resolveAnthropicModelFromEnv() ?? PROVIDER_MODELS.anthropic;
+  const baseURL = resolveAnthropicBaseURLFromEnv();
+  const auth = resolveAnthropicAuthFromEnv();
+
+  return new AnthropicProvider(model, {
+    baseURL,
+    ...auth,
+  });
+}
+
+function getProviderName(): string {
+  const providerName = process.env.LLMWIKI_PROVIDER ?? DEFAULT_PROVIDER;
+  if (!SUPPORTED_PROVIDERS.has(providerName)) {
+    throw new Error(
+      `Unknown provider "${providerName}". Supported: ${[...SUPPORTED_PROVIDERS].join(", ")}`,
+    );
+  }
+  return providerName;
 }

--- a/test/claude-settings.test.ts
+++ b/test/claude-settings.test.ts
@@ -1,0 +1,96 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  readClaudeSettingsEnv,
+  resolveAnthropicAuthFromEnv,
+  resolveAnthropicBaseURLFromEnv,
+  resolveAnthropicModelFromEnv,
+} from "../src/utils/claude-settings.js";
+
+const TEST_SETTINGS_PATH_ENV = "LLMWIKI_CLAUDE_SETTINGS_PATH";
+const tempDirs: string[] = [];
+
+function createSettingsEnv(content: string): NodeJS.ProcessEnv {
+  const dir = mkdtempSync(path.join(tmpdir(), "llmwiki-claude-settings-"));
+  tempDirs.push(dir);
+  const settingsPath = path.join(dir, "settings.json");
+  writeFileSync(settingsPath, content, "utf8");
+  return { [TEST_SETTINGS_PATH_ENV]: settingsPath };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("Claude settings fallback", () => {
+  it("returns undefined when settings file is missing", () => {
+    const missingPath = path.join(tmpdir(), `llmwiki-missing-${Date.now()}`, "settings.json");
+    const result = readClaudeSettingsEnv({ [TEST_SETTINGS_PATH_ENV]: missingPath });
+    expect(result).toBeUndefined();
+  });
+
+  it("extracts only supported Anthropic env keys", () => {
+    const env = createSettingsEnv(
+      JSON.stringify({
+        env: {
+          ANTHROPIC_AUTH_TOKEN: " token-123 ",
+          ANTHROPIC_BASE_URL: " https://api.kimi.com/coding/ ",
+          ANTHROPIC_MODEL: "Kimi-2.5",
+          SOME_OTHER_KEY: "ignored",
+        },
+      }),
+    );
+
+    expect(readClaudeSettingsEnv(env)).toEqual({
+      ANTHROPIC_AUTH_TOKEN: "token-123",
+      ANTHROPIC_BASE_URL: "https://api.kimi.com/coding/",
+      ANTHROPIC_MODEL: "Kimi-2.5",
+    });
+  });
+
+  it("throws a clear error when settings JSON is malformed", () => {
+    const env = createSettingsEnv("{ not-valid-json }");
+    expect(() => readClaudeSettingsEnv(env)).toThrow("Failed to parse Claude settings");
+  });
+
+  it("resolves auth from fallback when explicit auth is missing", () => {
+    const env = {
+      ...createSettingsEnv(JSON.stringify({ env: { ANTHROPIC_AUTH_TOKEN: "fallback-token" } })),
+      ANTHROPIC_API_KEY: "",
+      ANTHROPIC_AUTH_TOKEN: "",
+    };
+
+    expect(resolveAnthropicAuthFromEnv(env)).toEqual({ authToken: "fallback-token" });
+  });
+
+  it("prefers explicit ANTHROPIC_API_KEY over fallback auth token", () => {
+    const env = {
+      ...createSettingsEnv(JSON.stringify({ env: { ANTHROPIC_AUTH_TOKEN: "fallback-token" } })),
+      ANTHROPIC_API_KEY: "explicit-key",
+    };
+
+    expect(resolveAnthropicAuthFromEnv(env)).toEqual({ apiKey: "explicit-key" });
+  });
+
+  it("resolves base URL from fallback and allows path endpoints", () => {
+    const env = createSettingsEnv(JSON.stringify({ env: { ANTHROPIC_BASE_URL: "https://api.kimi.com/coding/" } }));
+    expect(resolveAnthropicBaseURLFromEnv(env)).toBe("https://api.kimi.com/coding/");
+  });
+
+  it("resolves anthropic model from fallback when LLMWIKI_MODEL is absent", () => {
+    const env = createSettingsEnv(JSON.stringify({ env: { ANTHROPIC_MODEL: "Kimi-2.5" } }));
+    expect(resolveAnthropicModelFromEnv(env)).toBe("Kimi-2.5");
+  });
+
+  it("keeps explicit LLMWIKI_MODEL over fallback model", () => {
+    const env = {
+      ...createSettingsEnv(JSON.stringify({ env: { ANTHROPIC_MODEL: "Kimi-2.5" } })),
+      LLMWIKI_MODEL: "claude-3-5-sonnet-latest",
+    };
+    expect(resolveAnthropicModelFromEnv(env)).toBe("claude-3-5-sonnet-latest");
+  });
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2,18 +2,54 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import path from "path";
-import { existsSync } from "fs";
-import { mkdir, rm } from "fs/promises";
+import { mkdir, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 
 const exec = promisify(execFile);
 const CLI = path.resolve("dist/cli.js");
 
+async function cleanupDirectory(directory: string): Promise<void> {
+  await rm(directory, { recursive: true, force: true });
+}
+
+async function runCompileWithoutSources(
+  suffix: string,
+  envOverrides: NodeJS.ProcessEnv,
+): Promise<string> {
+  const cwd = path.join(tmpdir(), `llmwiki-test-${suffix}-${Date.now()}`);
+  await mkdir(path.join(cwd, "sources"), { recursive: true });
+  try {
+    const { stdout } = await exec("node", [CLI, "compile"], {
+      cwd,
+      env: { ...process.env, ...envOverrides },
+    });
+    return stdout;
+  } finally {
+    await cleanupDirectory(cwd);
+  }
+}
+
+async function createCompileWorkspace(
+  suffix: string,
+  claudeSettingsContent?: string,
+): Promise<{ cwd: string; settingsPath?: string }> {
+  const cwd = path.join(tmpdir(), `llmwiki-test-${suffix}-${Date.now()}`);
+  await mkdir(path.join(cwd, "sources"), { recursive: true });
+
+  if (!claudeSettingsContent) {
+    return { cwd };
+  }
+
+  const claudeDir = path.join(cwd, ".claude");
+  const settingsPath = path.join(claudeDir, "settings.json");
+  await mkdir(claudeDir, { recursive: true });
+  await writeFile(settingsPath, claudeSettingsContent, "utf8");
+  return { cwd, settingsPath };
+}
+
 describe("CLI smoke tests", () => {
   beforeAll(async () => {
-    if (!existsSync(CLI)) {
-      await exec("npx", ["tsup"], { cwd: path.resolve(".") });
-    }
+    await exec("npx", ["tsup"], { cwd: path.resolve(".") });
   }, 30_000);
   it("prints help and exits 0", async () => {
     const { stdout } = await exec("node", [CLI, "--help"]);
@@ -28,10 +64,15 @@ describe("CLI smoke tests", () => {
     expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
   }, 30_000);
 
-  it("compile fails without ANTHROPIC_API_KEY", async () => {
+  it("compile fails without Anthropic credentials", async () => {
     try {
       await exec("node", [CLI, "compile"], {
-        env: { ...process.env, ANTHROPIC_API_KEY: "" },
+        env: {
+          ...process.env,
+          ANTHROPIC_API_KEY: "",
+          ANTHROPIC_AUTH_TOKEN: "",
+          ANTHROPIC_BASE_URL: "http://localhost:11434",
+        },
       });
       expect.fail("should have thrown");
     } catch (err: unknown) {
@@ -41,6 +82,63 @@ describe("CLI smoke tests", () => {
     }
   });
 
+  it("compile without sources works with ANTHROPIC_AUTH_TOKEN", async () => {
+    const stdout = await runCompileWithoutSources("compile-token", {
+      ANTHROPIC_AUTH_TOKEN: "dummy-token",
+      ANTHROPIC_API_KEY: "",
+    });
+    expect(stdout).not.toContain("ANTHROPIC_API_KEY");
+  }, 30_000);
+
+  it("compile without sources works with Claude settings auth-token fallback", async () => {
+    const workspace = await createCompileWorkspace(
+      "compile-claude-settings",
+      JSON.stringify({ env: { ANTHROPIC_AUTH_TOKEN: "fallback-token", ANTHROPIC_MODEL: "Kimi-2.5" } }),
+    );
+
+    try {
+      const { stdout } = await exec("node", [CLI, "compile"], {
+        cwd: workspace.cwd,
+        env: {
+          ...process.env,
+          ANTHROPIC_API_KEY: "",
+          ANTHROPIC_AUTH_TOKEN: "",
+          LLMWIKI_CLAUDE_SETTINGS_PATH: workspace.settingsPath,
+        },
+      });
+      expect(stdout).not.toContain("Anthropic credentials are required");
+    } finally {
+      await cleanupDirectory(workspace.cwd);
+    }
+  }, 30_000);
+
+  it("compile reports malformed Claude settings with formatted CLI error", async () => {
+    const workspace = await createCompileWorkspace(
+      "compile-malformed-claude-settings",
+      "{ malformed-json",
+    );
+
+    try {
+      await exec("node", [CLI, "compile"], {
+        cwd: workspace.cwd,
+        env: {
+          ...process.env,
+          ANTHROPIC_API_KEY: "",
+          ANTHROPIC_AUTH_TOKEN: "",
+          LLMWIKI_CLAUDE_SETTINGS_PATH: workspace.settingsPath,
+        },
+      });
+      expect.fail("should have thrown");
+    } catch (err: unknown) {
+      const error = err as { stderr?: string; code?: number };
+      expect(error.code).not.toBe(0);
+      expect(error.stderr ?? "").toContain("Error:");
+      expect(error.stderr ?? "").toContain("Failed to parse Claude settings");
+    } finally {
+      await cleanupDirectory(workspace.cwd);
+    }
+  }, 30_000);
+
   it("ingest shows next-step hint", async () => {
     const cwd = path.join(tmpdir(), `llmwiki-test-ingest-${Date.now()}`);
     await mkdir(cwd, { recursive: true });
@@ -49,22 +147,12 @@ describe("CLI smoke tests", () => {
       const { stdout } = await exec("node", [CLI, "ingest", fixture], { cwd });
       expect(stdout).toContain("Next: llmwiki compile");
     } finally {
-      await rm(path.join(cwd, "sources"), { recursive: true, force: true });
-      await rm(cwd, { recursive: true, force: true });
+      await cleanupDirectory(cwd);
     }
   }, 30_000);
 
   it("compile without sources does not show query hint", async () => {
-    const cwd = path.join(tmpdir(), `llmwiki-test-compile-${Date.now()}`);
-    await mkdir(path.join(cwd, "sources"), { recursive: true });
-    try {
-      const { stdout } = await exec("node", [CLI, "compile"], {
-        cwd,
-        env: { ...process.env, ANTHROPIC_API_KEY: "dummy" },
-      });
-      expect(stdout).not.toContain("Next: llmwiki query");
-    } finally {
-      await rm(cwd, { recursive: true, force: true });
-    }
+    const stdout = await runCompileWithoutSources("compile", { ANTHROPIC_API_KEY: "dummy" });
+    expect(stdout).not.toContain("Next: llmwiki query");
   }, 30_000);
 });

--- a/test/provider-anthropic.test.ts
+++ b/test/provider-anthropic.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for Anthropic provider client options.
+ * Verifies that Anthropic client options are correctly built based on baseURL.
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildAnthropicClientOptions } from "../src/providers/anthropic.js";
+
+describe("buildAnthropicClientOptions", () => {
+  it("returns base options when baseURL is not provided", () => {
+    const options = buildAnthropicClientOptions();
+    expect(options).toEqual({});
+  });
+
+  it("includes baseURL when explicitly provided", () => {
+    const baseURL = "https://custom.anthropic.com";
+    const options = buildAnthropicClientOptions({ baseURL });
+    expect(options).toEqual({ baseURL });
+  });
+
+  it("omits baseURL when provide with empty string", () => {
+    const options = buildAnthropicClientOptions({ baseURL: "" });
+    expect(options).toEqual({});
+  });
+
+  it("omits baseURL when provide with undefined", () => {
+    const options = buildAnthropicClientOptions({ baseURL: undefined });
+    expect(options).toEqual({});
+  });
+
+  it("normalizes trailing slash in baseURL", () => {
+    const baseURL = "https://custom.anthropic.com/";
+    const options = buildAnthropicClientOptions({ baseURL });
+    expect(options.baseURL).toBe("https://custom.anthropic.com");
+  });
+
+  it("treats whitespace-only baseURL as unset", () => {
+    const options = buildAnthropicClientOptions({ baseURL: "   " });
+    expect(options).toEqual({});
+  });
+
+  it("includes auth token when provided", () => {
+    const options = buildAnthropicClientOptions({ authToken: " token-value " });
+    expect(options).toEqual({ authToken: "token-value" });
+  });
+
+  it("includes API key when provided", () => {
+    const options = buildAnthropicClientOptions({ apiKey: " key-value " });
+    expect(options).toEqual({ apiKey: "key-value" });
+  });
+
+  it("combines auth and path endpoint options", () => {
+    const options = buildAnthropicClientOptions({
+      authToken: "token-value",
+      baseURL: "https://api.kimi.com/coding/",
+    });
+
+    expect(options).toEqual({
+      authToken: "token-value",
+      baseURL: "https://api.kimi.com/coding",
+    });
+  });
+});

--- a/test/provider-factory.test.ts
+++ b/test/provider-factory.test.ts
@@ -4,15 +4,80 @@
  */
 
 import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { getProvider } from "../src/utils/provider.js";
 import { AnthropicProvider } from "../src/providers/anthropic.js";
 import { OpenAIProvider } from "../src/providers/openai.js";
 import { OllamaProvider } from "../src/providers/ollama.js";
 
+const TEST_SETTINGS_PATH_ENV = "LLMWIKI_CLAUDE_SETTINGS_PATH";
+const tempDirs: string[] = [];
+
+function withClaudeSettings(settings: unknown): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "llmwiki-provider-factory-"));
+  tempDirs.push(dir);
+  const settingsPath = path.join(dir, "settings.json");
+  writeFileSync(settingsPath, JSON.stringify(settings), "utf8");
+  return settingsPath;
+}
+
+function withMalformedClaudeSettings(prefix: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  const settingsPath = path.join(dir, "settings.json");
+  writeFileSync(settingsPath, "{ invalid-json", "utf8");
+  return settingsPath;
+}
+
+function setClaudeAnthropicModelFallback(model: string): void {
+  process.env[TEST_SETTINGS_PATH_ENV] = withClaudeSettings({
+    env: { ANTHROPIC_MODEL: model },
+  });
+}
+
+function expectAnthropicModel(expectedModel: string): void {
+  const provider = getProvider();
+  expect(provider).toBeInstanceOf(AnthropicProvider);
+  expect(Reflect.get(provider, "model")).toBe(expectedModel);
+}
+
 describe("getProvider", () => {
   afterEach(() => {
     delete process.env.LLMWIKI_PROVIDER;
     delete process.env.LLMWIKI_MODEL;
+    delete process.env.ANTHROPIC_BASE_URL;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
+    delete process.env[TEST_SETTINGS_PATH_ENV];
+
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("defaults to official anthropic endpoint when base url is unset", () => {
+    delete process.env.ANTHROPIC_BASE_URL;
+    const provider = getProvider();
+    expect(provider).toBeInstanceOf(AnthropicProvider);
+  });
+
+  it("uses configured anthropic base url", () => {
+    process.env.ANTHROPIC_BASE_URL = "https://custom.anthropic.com";
+    const provider = getProvider();
+    expect(provider).toBeInstanceOf(AnthropicProvider);
+  });
+
+  it("rejects invalid anthropic base url", () => {
+    process.env.ANTHROPIC_BASE_URL = "not-a-url";
+    expect(() => getProvider()).toThrow('Invalid ANTHROPIC_BASE_URL: "not-a-url"');
+  });
+
+  it("accepts anthropic base url with path endpoint", () => {
+    process.env.ANTHROPIC_BASE_URL = "https://api.anthropic.com/v1";
+    const provider = getProvider();
+    expect(provider).toBeInstanceOf(AnthropicProvider);
   });
 
   it("returns AnthropicProvider when LLMWIKI_PROVIDER is unset", () => {
@@ -52,5 +117,74 @@ describe("getProvider", () => {
     // The model is stored as a protected field; verify it was accepted
     // by checking the provider was created without throwing
     expect(provider).toBeDefined();
+  });
+
+  it("ignores anthropic base url for non-anthropic providers", () => {
+    process.env.LLMWIKI_PROVIDER = "openai";
+    process.env.ANTHROPIC_BASE_URL = "https://invalid-host.com/v1";
+    const provider = getProvider();
+    expect(provider).toBeInstanceOf(OpenAIProvider);
+    expect(provider).toBeDefined();
+  });
+
+  it("treats whitespace-only ANTHROPIC_BASE_URL as unset", () => {
+    process.env.ANTHROPIC_BASE_URL = "  ";
+    const provider = getProvider();
+    expect(provider).toBeInstanceOf(AnthropicProvider);
+  });
+
+  it("uses Claude settings fallback for anthropic base URL", () => {
+    process.env[TEST_SETTINGS_PATH_ENV] = withClaudeSettings({
+      env: { ANTHROPIC_BASE_URL: "https://api.kimi.com/coding/" },
+    });
+
+    const provider = getProvider();
+    expect(provider).toBeInstanceOf(AnthropicProvider);
+  });
+
+  it("uses Claude settings fallback for anthropic model", () => {
+    setClaudeAnthropicModelFallback("Kimi-2.5");
+    expectAnthropicModel("Kimi-2.5");
+  });
+
+  it("prefers explicit LLMWIKI_MODEL over Claude settings fallback model", () => {
+    process.env.LLMWIKI_MODEL = "explicit-model";
+    setClaudeAnthropicModelFallback("Kimi-2.5");
+    expectAnthropicModel("explicit-model");
+  });
+
+  it("does not read Claude fallback for openai when explicit settings are sufficient", () => {
+    const settingsPath = withMalformedClaudeSettings("llmwiki-provider-factory-bad-json-");
+
+    process.env.LLMWIKI_PROVIDER = "openai";
+    process.env.LLMWIKI_MODEL = "gpt-4o-mini";
+    process.env[TEST_SETTINGS_PATH_ENV] = settingsPath;
+
+    const provider = getProvider();
+    expect(provider).toBeInstanceOf(OpenAIProvider);
+  });
+
+  it("throws when Claude settings JSON is malformed and anthropic fallback is required", () => {
+    const settingsPath = withMalformedClaudeSettings("llmwiki-provider-factory-malformed-");
+
+    process.env[TEST_SETTINGS_PATH_ENV] = settingsPath;
+    delete process.env.ANTHROPIC_BASE_URL;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
+    delete process.env.LLMWIKI_MODEL;
+
+    expect(() => getProvider()).toThrow("Failed to parse Claude settings");
+  });
+
+  it("ignores malformed Claude settings for optional fallback fields when explicit auth is present", () => {
+    const settingsPath = withMalformedClaudeSettings("llmwiki-provider-factory-malformed-optional-");
+
+    process.env[TEST_SETTINGS_PATH_ENV] = settingsPath;
+    process.env.ANTHROPIC_AUTH_TOKEN = "explicit-token";
+    delete process.env.ANTHROPIC_BASE_URL;
+    delete process.env.LLMWIKI_MODEL;
+
+    const provider = getProvider();
+    expect(provider).toBeInstanceOf(AnthropicProvider);
   });
 });


### PR DESCRIPTION
## Summary
- add Anthropic credential/model/base URL fallback loading from `~/.claude/settings.json` (`env` block) while preserving explicit env precedence
- support both `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN`, and allow path-style custom endpoints such as `https://api.kimi.com/coding/`
- improve CLI error handling so provider validation failures are surfaced through the existing formatted command error path
- expand provider/CLI coverage with regression tests for fallback behavior and malformed Claude settings

## Verification
- npx tsc --noEmit
- npm run build
- npm test
- npx fallow --score --fail-on-issues