### PR TITLE
Add MiniMax as a supported LLM provider using the OpenAI-compatible endpoint

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,6 +96,7 @@ const PROVIDER_KEY_VARS: Record<string, string | null> = {
   anthropic: "ANTHROPIC_API_KEY",
   openai: "OPENAI_API_KEY",
   ollama: null,
+  minimax: "MINIMAX_API_KEY",
 };
 
 /** Exit with a helpful message if the selected provider's API key is missing. */

--- a/src/providers/minimax.ts
+++ b/src/providers/minimax.ts
@@ -1,0 +1,18 @@
+/**
+ * MiniMax LLM provider implementation.
+ *
+ * Extends OpenAIProvider since MiniMax exposes an OpenAI-compatible API.
+ * Overrides only the constructor to set MiniMax's base URL and API key.
+ */
+
+import { OpenAIProvider } from "./openai.js";
+
+/** MiniMax API base URL. */
+const MINIMAX_BASE_URL = "https://api.minimax.io/v1";
+
+/** MiniMax-backed LLM provider using the OpenAI-compatible endpoint. */
+export class MiniMaxProvider extends OpenAIProvider {
+  constructor(model: string, apiKey: string) {
+    super(model, MINIMAX_BASE_URL, apiKey);
+  }
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -28,6 +28,7 @@ export const PROVIDER_MODELS: Record<string, string> = {
   anthropic: "claude-sonnet-4-20250514",
   openai: "gpt-4o",
   ollama: "llama3.1",
+  minimax: "MiniMax-M2.7",
 };
 
 /** Default Ollama API base URL. */

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -3,13 +3,14 @@
  *
  * Defines the LLMProvider interface and a factory function that reads
  * LLMWIKI_PROVIDER and LLMWIKI_MODEL env vars to instantiate the
- * appropriate backend (Anthropic, OpenAI, or Ollama).
+ * appropriate backend (Anthropic, OpenAI, Ollama, or MiniMax).
  */
 
 import { DEFAULT_PROVIDER, PROVIDER_MODELS, OLLAMA_DEFAULT_HOST } from "./constants.js";
 import { AnthropicProvider } from "../providers/anthropic.js";
 import { OpenAIProvider } from "../providers/openai.js";
 import { OllamaProvider } from "../providers/ollama.js";
+import { MiniMaxProvider } from "../providers/minimax.js";
 import {
   resolveAnthropicAuthFromEnv,
   resolveAnthropicBaseURLFromEnv,
@@ -46,7 +47,7 @@ export interface LLMProvider {
   ): Promise<string>;
 }
 
-const SUPPORTED_PROVIDERS: ReadonlySet<string> = new Set(["anthropic", "openai", "ollama"]);
+const SUPPORTED_PROVIDERS: ReadonlySet<string> = new Set(["anthropic", "openai", "ollama", "minimax"]);
 
 /**
  * Factory that returns the appropriate LLMProvider based on env vars.
@@ -68,13 +69,26 @@ export function getProvider(): LLMProvider {
         getModelForProvider("ollama"),
         process.env.OLLAMA_HOST ?? OLLAMA_DEFAULT_HOST,
       );
+    case "minimax":
+      return getMiniMaxProvider();
     default:
       throw new Error(`Unhandled provider: ${providerName}`);
   }
 }
 
-function getModelForProvider(providerName: "openai" | "ollama"): string {
+function getModelForProvider(providerName: "openai" | "ollama" | "minimax"): string {
   return process.env.LLMWIKI_MODEL ?? PROVIDER_MODELS[providerName];
+}
+
+function getMiniMaxProvider(): MiniMaxProvider {
+  const apiKey = process.env.MINIMAX_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "MiniMax provider requires MINIMAX_API_KEY environment variable.\n" +
+      '  Set it with: export MINIMAX_API_KEY=your_key',
+    );
+  }
+  return new MiniMaxProvider(getModelForProvider("minimax"), apiKey);
 }
 
 function getAnthropicProvider(): AnthropicProvider {

--- a/test/provider-factory.test.ts
+++ b/test/provider-factory.test.ts
@@ -11,6 +11,7 @@ import { getProvider } from "../src/utils/provider.js";
 import { AnthropicProvider } from "../src/providers/anthropic.js";
 import { OpenAIProvider } from "../src/providers/openai.js";
 import { OllamaProvider } from "../src/providers/ollama.js";
+import { MiniMaxProvider } from "../src/providers/minimax.js";
 
 const TEST_SETTINGS_PATH_ENV = "LLMWIKI_CLAUDE_SETTINGS_PATH";
 const tempDirs: string[] = [];
@@ -51,6 +52,7 @@ describe("getProvider", () => {
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.ANTHROPIC_AUTH_TOKEN;
     delete process.env[TEST_SETTINGS_PATH_ENV];
+    delete process.env.MINIMAX_API_KEY;
 
     for (const dir of tempDirs.splice(0)) {
       rmSync(dir, { recursive: true, force: true });
@@ -107,6 +109,19 @@ describe("getProvider", () => {
   it("throws for unknown provider", () => {
     process.env.LLMWIKI_PROVIDER = "gemini";
     expect(() => getProvider()).toThrow('Unknown provider "gemini"');
+  });
+
+  it("returns MiniMaxProvider when LLMWIKI_PROVIDER=minimax", () => {
+    process.env.LLMWIKI_PROVIDER = "minimax";
+    process.env.MINIMAX_API_KEY = "test-key";
+    const provider = getProvider();
+    expect(provider).toBeInstanceOf(MiniMaxProvider);
+  });
+
+  it("throws when MINIMAX_API_KEY is absent for minimax provider", () => {
+    process.env.LLMWIKI_PROVIDER = "minimax";
+    delete process.env.MINIMAX_API_KEY;
+    expect(() => getProvider()).toThrow("MINIMAX_API_KEY");
   });
 
   it("respects LLMWIKI_MODEL override", () => {


### PR DESCRIPTION
Changes:
   - Add `MiniMaxProvider` class extending `OpenAIProvider` with api.minimax.io/v1 base URL
   - Add `minimax` to `SUPPORTED_PROVIDERS` and `PROVIDER_MODELS` (default: MiniMax-M2.7)
   - Add `minimax` to `PROVIDER_KEY_VARS` (uses `LLMWIKI_API_KEY` env var)