### PR TITLE
Add embedding-based semantic search for query routing

### DIFF
--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -19,6 +19,7 @@ import { atomicWrite, safeReadFile, slugify, buildFrontmatter, parseFrontmatter 
 import { generateIndex } from "../compiler/indexgen.js";
 import * as output from "../utils/output.js";
 import { QUERY_PAGE_LIMIT, INDEX_FILE, CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
+import { findRelevantPages, updateEmbeddings } from "../utils/embeddings.js";
 
 /** Directories to search when loading selected pages, in priority order. */
 const PAGE_DIRS = [CONCEPTS_DIR, QUERIES_DIR];
@@ -81,6 +82,55 @@ async function selectPages(
     };
   } catch {
     return { pages: [], reasoning: "Failed to parse page selection response" };
+  }
+}
+
+/** Render a list of candidate pages in the same bullet format selectPages() consumes. */
+function buildFilteredIndex(
+  candidates: Array<{ slug: string; title: string; summary: string }>,
+): string {
+  return candidates
+    .map((entry) => `- **${entry.slug}**: ${entry.title} — ${entry.summary}`)
+    .join("\n");
+}
+
+interface SelectedPages {
+  pages: string[];
+  rawPages: string[];
+  reasoning: string;
+}
+
+/**
+ * Pick relevant pages using embedding pre-filter when available.
+ * Falls back to sending the full wiki index when no embeddings store exists
+ * or when the embedding call fails.
+ */
+async function selectRelevantPages(root: string, question: string): Promise<SelectedPages> {
+  const candidates = await tryFindRelevantPages(root, question);
+
+  if (candidates.length > 0) {
+    const filteredIndex = buildFilteredIndex(candidates);
+    const { pages: rawPages, reasoning } = await selectPages(question, filteredIndex);
+    // Tool output holds slugs directly in the semantic path — no slugify needed.
+    return { pages: rawPages, rawPages, reasoning };
+  }
+
+  const indexContent = await safeReadFile(path.join(root, INDEX_FILE));
+  const { pages: rawPages, reasoning } = await selectPages(question, indexContent);
+  return { pages: rawPages.map((p) => slugify(p)), rawPages, reasoning };
+}
+
+/** Embedding-based candidate lookup that never throws. */
+async function tryFindRelevantPages(
+  root: string,
+  question: string,
+): Promise<Array<{ slug: string; title: string; summary: string }>> {
+  try {
+    return await findRelevantPages(root, question);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    output.status("!", output.dim(`Semantic pre-filter unavailable (${message}); using full index.`));
+    return [];
   }
 }
 
@@ -184,6 +234,15 @@ async function saveQueryPage(root: string, question: string, answer: string): Pr
   // Regenerate the index so the saved query is immediately discoverable
   // by the next query's page-selection step.
   await generateIndex(root);
+
+  // Index the new query so semantic search retrieves it on the next question.
+  // Non-critical: embedding failures (e.g. missing VOYAGE_API_KEY) don't block save.
+  try {
+    await updateEmbeddings(root, [slug]);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    output.status("!", output.warn(`Skipped embeddings update: ${message}`));
+  }
 }
 
 /**
@@ -205,9 +264,7 @@ export default async function queryCommand(
   // Step 1: Select relevant pages
   output.header("Selecting relevant pages");
 
-  const indexContent = await safeReadFile(path.join(root, INDEX_FILE));
-  const { pages: rawPages, reasoning } = await selectPages(question, indexContent);
-  const pages = rawPages.map((p) => slugify(p));
+  const { pages, rawPages, reasoning } = await selectRelevantPages(root, question);
 
   output.status("i", output.dim(`Reasoning: ${reasoning}`));
   output.status("*", output.info(`Selected ${pages.length} page(s): ${rawPages.join(", ")}`));

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -40,6 +40,7 @@ import { markOrphaned, orphanUnownedFrozenPages } from "./orphan.js";
 import { resolveLinks } from "./resolver.js";
 import { generateIndex } from "./indexgen.js";
 import { addObsidianMeta, generateMOC } from "./obsidian.js";
+import { updateEmbeddings } from "../utils/embeddings.js";
 import * as output from "../utils/output.js";
 import {
   COMPILE_CONCURRENCY,
@@ -166,6 +167,7 @@ async function runCompilePipeline(root: string): Promise<void> {
 
   await generateIndex(root);
   await generateMOC(root);
+  await safelyUpdateEmbeddings(root, allChangedSlugs);
 
   output.header("Compilation complete");
   output.status("✓", output.success(
@@ -378,6 +380,20 @@ async function writePageIfValid(
   }
 
   await atomicWrite(pagePath, content);
+}
+
+/**
+ * Refresh the embeddings store without failing compilation.
+ * Semantic search is a non-critical enhancement — missing API keys or
+ * transient provider errors should produce a warning, not a broken build.
+ */
+async function safelyUpdateEmbeddings(root: string, changedSlugs: string[]): Promise<void> {
+  try {
+    await updateEmbeddings(root, changedSlugs);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    output.status("!", output.warn(`Skipped embeddings update: ${message}`));
+  }
 }
 
 /**

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -7,6 +7,9 @@
 
 import Anthropic, { type ClientOptions } from "@anthropic-ai/sdk";
 import type { LLMProvider, LLMMessage, LLMTool } from "../utils/provider.js";
+import { EMBEDDING_MODELS } from "../utils/constants.js";
+
+const VOYAGE_EMBEDDINGS_URL = "https://api.voyageai.com/v1/embeddings";
 
 /**
  * Builds the client options for the Anthropic SDK.
@@ -126,5 +129,41 @@ export class AnthropicProvider implements LLMProvider {
 
     const textBlock = response.content.find((block) => block.type === "text");
     return textBlock?.type === "text" ? textBlock.text : "";
+  }
+
+  /**
+   * Produce a single embedding vector via the Voyage API.
+   *
+   * Anthropic does not ship a first-party embeddings endpoint, so we delegate
+   * to Voyage (their recommended partner). Requires VOYAGE_API_KEY.
+   */
+  async embed(text: string): Promise<number[]> {
+    const apiKey = process.env.VOYAGE_API_KEY?.trim();
+    if (!apiKey) {
+      throw new Error(
+        "VOYAGE_API_KEY is not set. Anthropic embeddings use Voyage — set VOYAGE_API_KEY to enable semantic search.",
+      );
+    }
+
+    const response = await fetch(VOYAGE_EMBEDDINGS_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ input: text, model: EMBEDDING_MODELS.anthropic }),
+    });
+
+    if (!response.ok) {
+      const detail = await response.text();
+      throw new Error(`Voyage embeddings request failed (${response.status}): ${detail}`);
+    }
+
+    const json = (await response.json()) as { data?: Array<{ embedding?: number[] }> };
+    const vector = json.data?.[0]?.embedding;
+    if (!Array.isArray(vector)) {
+      throw new Error("Voyage embeddings response did not include a vector.");
+    }
+    return vector;
   }
 }

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -6,10 +6,16 @@
  */
 
 import { OpenAIProvider } from "./openai.js";
+import { EMBEDDING_MODELS } from "../utils/constants.js";
 
 /** Ollama-backed LLM provider using the OpenAI-compatible endpoint. */
 export class OllamaProvider extends OpenAIProvider {
   constructor(model: string, baseURL: string) {
     super(model, baseURL, "ollama");
+  }
+
+  /** Ollama ships a dedicated embedding model (nomic-embed-text). */
+  protected override embeddingModel(): string {
+    return EMBEDDING_MODELS.ollama;
   }
 }

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -7,6 +7,7 @@
 
 import OpenAI from "openai";
 import type { LLMProvider, LLMMessage, LLMTool } from "../utils/provider.js";
+import { EMBEDDING_MODELS } from "../utils/constants.js";
 
 /** Translate an Anthropic-style LLMTool to an OpenAI ChatCompletionTool. */
 export function translateToolToOpenAI(
@@ -97,5 +98,27 @@ export class OpenAIProvider implements LLMProvider {
     }
 
     return response.choices[0]?.message?.content ?? "";
+  }
+
+  /**
+   * Produce a single embedding vector via the OpenAI embeddings API.
+   * Subclasses (e.g. Ollama) override embeddingModel() to pick a different model.
+   */
+  async embed(text: string): Promise<number[]> {
+    const response = await this.client.embeddings.create({
+      model: this.embeddingModel(),
+      input: text,
+    });
+
+    const vector = response.data[0]?.embedding;
+    if (!Array.isArray(vector)) {
+      throw new Error("OpenAI embeddings response did not include a vector.");
+    }
+    return vector;
+  }
+
+  /** Default embedding model for this provider. Subclasses may override. */
+  protected embeddingModel(): string {
+    return EMBEDDING_MODELS.openai;
   }
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -43,3 +43,14 @@ export const STATE_FILE = ".llmwiki/state.json";
 export const LOCK_FILE = ".llmwiki/lock";
 export const INDEX_FILE = "wiki/index.md";
 export const MOC_FILE = "wiki/MOC.md";
+export const EMBEDDINGS_FILE = ".llmwiki/embeddings.json";
+
+/** Number of most similar pages to return from embedding-based pre-filter. */
+export const EMBEDDING_TOP_K = 15;
+
+/** Embedding model to use per provider. */
+export const EMBEDDING_MODELS: Record<string, string> = {
+  anthropic: "voyage-3-lite",
+  openai: "text-embedding-3-small",
+  ollama: "nomic-embed-text",
+};

--- a/src/utils/embeddings.ts
+++ b/src/utils/embeddings.ts
@@ -1,0 +1,229 @@
+/**
+ * Embedding-based semantic search utilities.
+ *
+ * Maintains a persistent store of page embeddings in .llmwiki/embeddings.json
+ * and provides cosine-similarity retrieval so the query command can narrow
+ * hundreds of pages down to a small top-K before calling the selection LLM.
+ *
+ * The store is additive: successful embedding calls update entries; failures
+ * degrade gracefully (caller falls back to full-index selection).
+ */
+
+import { readFile, readdir } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import { getProvider, getActiveProviderName } from "./provider.js";
+import { atomicWrite, safeReadFile, parseFrontmatter } from "./markdown.js";
+import {
+  CONCEPTS_DIR,
+  QUERIES_DIR,
+  EMBEDDINGS_FILE,
+  EMBEDDING_TOP_K,
+  EMBEDDING_MODELS,
+} from "./constants.js";
+import * as output from "./output.js";
+
+/** A single embedded page record. */
+export interface EmbeddingEntry {
+  slug: string;
+  title: string;
+  summary: string;
+  vector: number[];
+  updatedAt: string;
+}
+
+/** Root shape of .llmwiki/embeddings.json. */
+export interface EmbeddingStore {
+  version: 1;
+  model: string;
+  dimensions: number;
+  entries: EmbeddingEntry[];
+}
+
+/** A retrievable page record on disk (concepts/ or queries/). */
+interface PageRecord {
+  slug: string;
+  title: string;
+  summary: string;
+}
+
+/**
+ * Cosine similarity between two equal-length vectors.
+ * Returns 0 when either vector has zero magnitude (safer than NaN for ranking).
+ */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length || a.length === 0) return 0;
+
+  let dot = 0;
+  let magA = 0;
+  let magB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    magA += a[i] * a[i];
+    magB += b[i] * b[i];
+  }
+
+  if (magA === 0 || magB === 0) return 0;
+  return dot / (Math.sqrt(magA) * Math.sqrt(magB));
+}
+
+/** Return the top-K entries most similar to the query vector, sorted descending. */
+export function findTopK(
+  queryVec: number[],
+  store: EmbeddingStore,
+  k: number,
+): EmbeddingEntry[] {
+  const scored = store.entries.map((entry) => ({
+    entry,
+    score: cosineSimilarity(queryVec, entry.vector),
+  }));
+  scored.sort((left, right) => right.score - left.score);
+  return scored.slice(0, k).map((item) => item.entry);
+}
+
+/** Read .llmwiki/embeddings.json, returning null if it does not exist. */
+export async function readEmbeddingStore(root: string): Promise<EmbeddingStore | null> {
+  const filePath = path.join(root, EMBEDDINGS_FILE);
+  if (!existsSync(filePath)) return null;
+  const raw = await readFile(filePath, "utf-8");
+  return JSON.parse(raw) as EmbeddingStore;
+}
+
+/** Atomically persist the embedding store. */
+export async function writeEmbeddingStore(root: string, store: EmbeddingStore): Promise<void> {
+  const filePath = path.join(root, EMBEDDINGS_FILE);
+  await atomicWrite(filePath, JSON.stringify(store, null, 2));
+}
+
+/**
+ * Embed the question, look up top-K matches, and return lightweight page records.
+ * Returns [] when no store exists so callers can transparently fall back.
+ */
+export async function findRelevantPages(
+  root: string,
+  question: string,
+): Promise<Array<{ slug: string; title: string; summary: string }>> {
+  const store = await readEmbeddingStore(root);
+  if (!store || store.entries.length === 0) return [];
+
+  const queryVec = await getProvider().embed(question);
+  return findTopK(queryVec, store, EMBEDDING_TOP_K).map((entry) => ({
+    slug: entry.slug,
+    title: entry.title,
+    summary: entry.summary,
+  }));
+}
+
+/** Scan concepts/ and queries/ directories, returning retrievable pages. */
+async function collectPageRecords(root: string): Promise<PageRecord[]> {
+  const records: PageRecord[] = [];
+  for (const dir of [CONCEPTS_DIR, QUERIES_DIR]) {
+    const absDir = path.join(root, dir);
+    let files: string[];
+    try {
+      files = await readdir(absDir);
+    } catch {
+      continue;
+    }
+    for (const file of files.filter((f) => f.endsWith(".md"))) {
+      const content = await safeReadFile(path.join(absDir, file));
+      const { meta } = parseFrontmatter(content);
+      if (meta.orphaned || typeof meta.title !== "string") continue;
+      records.push({
+        slug: file.replace(/\.md$/, ""),
+        title: meta.title,
+        summary: typeof meta.summary === "string" ? meta.summary : "",
+      });
+    }
+  }
+  return records;
+}
+
+/** Build the text that represents a page in the embedding space. */
+function buildEmbeddingText(record: PageRecord): string {
+  return record.summary
+    ? `${record.title}\n\n${record.summary}`
+    : record.title;
+}
+
+/**
+ * Embed every page in `records` whose slug appears in `slugsToEmbed`,
+ * returning the new entries. Failures bubble up to the caller.
+ */
+async function embedPages(
+  records: PageRecord[],
+  slugsToEmbed: Set<string>,
+): Promise<EmbeddingEntry[]> {
+  const provider = getProvider();
+  const now = new Date().toISOString();
+  const fresh: EmbeddingEntry[] = [];
+
+  for (const record of records) {
+    if (!slugsToEmbed.has(record.slug)) continue;
+    const vector = await provider.embed(buildEmbeddingText(record));
+    fresh.push({
+      slug: record.slug,
+      title: record.title,
+      summary: record.summary,
+      vector,
+      updatedAt: now,
+    });
+  }
+  return fresh;
+}
+
+/** Choose the active embedding model name, defaulting to anthropic's voyage model. */
+function resolveEmbeddingModel(): string {
+  return EMBEDDING_MODELS[getActiveProviderName()] ?? EMBEDDING_MODELS.anthropic;
+}
+
+/** Merge fresh embeddings into an existing store, dropping slugs not in liveSlugs. */
+function mergeEntries(
+  existing: EmbeddingEntry[],
+  fresh: EmbeddingEntry[],
+  liveSlugs: Set<string>,
+): EmbeddingEntry[] {
+  const bySlug = new Map<string, EmbeddingEntry>();
+  for (const entry of existing) {
+    if (liveSlugs.has(entry.slug)) bySlug.set(entry.slug, entry);
+  }
+  for (const entry of fresh) {
+    bySlug.set(entry.slug, entry);
+  }
+  return Array.from(bySlug.values());
+}
+
+/**
+ * Re-embed the given changed slugs and prune any entries whose pages no longer
+ * exist on disk. Changed slugs not present as live pages are silently skipped.
+ */
+export async function updateEmbeddings(root: string, changedSlugs: string[]): Promise<void> {
+  const records = await collectPageRecords(root);
+  const liveSlugs = new Set(records.map((r) => r.slug));
+  const toEmbed = new Set(changedSlugs.filter((slug) => liveSlugs.has(slug)));
+
+  const existingStore = await readEmbeddingStore(root);
+  const previousEntries = existingStore?.entries ?? [];
+
+  // Cold start: embed every page so the store is immediately useful.
+  if (!existingStore) {
+    for (const record of records) toEmbed.add(record.slug);
+  }
+
+  if (toEmbed.size === 0 && previousEntries.every((e) => liveSlugs.has(e.slug))) {
+    return;
+  }
+
+  const freshEntries = await embedPages(records, toEmbed);
+  const mergedEntries = mergeEntries(previousEntries, freshEntries, liveSlugs);
+
+  const dimensions = mergedEntries[0]?.vector.length ?? 0;
+  const store: EmbeddingStore = {
+    version: 1,
+    model: resolveEmbeddingModel(),
+    dimensions,
+    entries: mergedEntries,
+  };
+  await writeEmbeddingStore(root, store);
+  output.status("*", output.dim(`Embeddings updated (${mergedEntries.length} pages).`));
+}

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -45,6 +45,8 @@ export interface LLMProvider {
     tools: LLMTool[],
     maxTokens: number,
   ): Promise<string>;
+  /** Return a single embedding vector for the given text. */
+  embed(text: string): Promise<number[]>;
 }
 
 const SUPPORTED_PROVIDERS: ReadonlySet<string> = new Set(["anthropic", "openai", "ollama", "minimax"]);
@@ -110,4 +112,9 @@ function getProviderName(): string {
     );
   }
   return providerName;
+}
+
+/** Expose the resolved provider name for callers that need model lookup. */
+export function getActiveProviderName(): string {
+  return getProviderName();
 }

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for the embed() method on each provider.
+ *
+ * OpenAI: stub the underlying openai SDK client so we can assert the model
+ * and input passed to embeddings.create().
+ *
+ * Anthropic: verify the missing-key error surfaces before any network call.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { OpenAIProvider } from "../src/providers/openai.js";
+import { AnthropicProvider } from "../src/providers/anthropic.js";
+import { EMBEDDING_MODELS } from "../src/utils/constants.js";
+
+interface StubCall {
+  model: string;
+  input: string;
+}
+
+function stubOpenAIClient(provider: OpenAIProvider, vector: number[]): StubCall[] {
+  const calls: StubCall[] = [];
+  const fakeClient = {
+    embeddings: {
+      create: async ({ model, input }: { model: string; input: string }) => {
+        calls.push({ model, input });
+        return { data: [{ embedding: vector }] };
+      },
+    },
+  };
+  // The OpenAI SDK client is a protected field; override for testing.
+  Reflect.set(provider, "client", fakeClient);
+  return calls;
+}
+
+describe("OpenAIProvider.embed", () => {
+  it("calls the embeddings API with text-embedding-3-small and returns the vector", async () => {
+    const provider = new OpenAIProvider("gpt-4o", undefined, "test-key");
+    const expected = [0.1, 0.2, 0.3];
+    const calls = stubOpenAIClient(provider, expected);
+
+    const result = await provider.embed("hello world");
+
+    expect(result).toEqual(expected);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].model).toBe(EMBEDDING_MODELS.openai);
+    expect(calls[0].input).toBe("hello world");
+  });
+
+  it("throws a clear error when the response is missing a vector", async () => {
+    const provider = new OpenAIProvider("gpt-4o", undefined, "test-key");
+    Reflect.set(provider, "client", {
+      embeddings: {
+        create: async () => ({ data: [] }),
+      },
+    });
+
+    await expect(provider.embed("anything")).rejects.toThrow(/did not include a vector/);
+  });
+});
+
+describe("AnthropicProvider.embed", () => {
+  const SAVED_KEY = process.env.VOYAGE_API_KEY;
+
+  afterEach(() => {
+    if (SAVED_KEY === undefined) {
+      delete process.env.VOYAGE_API_KEY;
+    } else {
+      process.env.VOYAGE_API_KEY = SAVED_KEY;
+    }
+  });
+
+  it("throws a clear error when VOYAGE_API_KEY is missing", async () => {
+    delete process.env.VOYAGE_API_KEY;
+    const provider = new AnthropicProvider("claude-sonnet-4-20250514", { apiKey: "sk-test" });
+    await expect(provider.embed("hello")).rejects.toThrow(/VOYAGE_API_KEY is not set/);
+  });
+
+  it("throws a clear error when VOYAGE_API_KEY is whitespace", async () => {
+    process.env.VOYAGE_API_KEY = "   ";
+    const provider = new AnthropicProvider("claude-sonnet-4-20250514", { apiKey: "sk-test" });
+    await expect(provider.embed("hello")).rejects.toThrow(/VOYAGE_API_KEY is not set/);
+  });
+});

--- a/test/embeddings.test.ts
+++ b/test/embeddings.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for cosine-similarity, top-K ranking, and embedding store I/O.
+ * Avoids real network calls — we test the pure helpers and JSON roundtrips.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdtemp, writeFile, mkdir } from "fs/promises";
+import path from "path";
+import os from "os";
+import {
+  cosineSimilarity,
+  findTopK,
+  readEmbeddingStore,
+  writeEmbeddingStore,
+  type EmbeddingStore,
+  type EmbeddingEntry,
+} from "../src/utils/embeddings.js";
+
+const STORE_PATH = ".llmwiki/embeddings.json";
+
+function makeEntry(slug: string, vector: number[]): EmbeddingEntry {
+  return {
+    slug,
+    title: slug,
+    summary: `Summary for ${slug}`,
+    vector,
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function makeStore(entries: EmbeddingEntry[]): EmbeddingStore {
+  return {
+    version: 1,
+    model: "test-model",
+    dimensions: entries[0]?.vector.length ?? 0,
+    entries,
+  };
+}
+
+async function makeRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "llmwiki-embed-"));
+  await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+  return root;
+}
+
+describe("cosineSimilarity", () => {
+  it("returns 1 for identical vectors", () => {
+    expect(cosineSimilarity([1, 2, 3], [1, 2, 3])).toBeCloseTo(1);
+  });
+
+  it("returns 0 for orthogonal vectors", () => {
+    expect(cosineSimilarity([1, 0], [0, 1])).toBe(0);
+  });
+
+  it("returns -1 for opposite vectors", () => {
+    expect(cosineSimilarity([1, 2], [-1, -2])).toBeCloseTo(-1);
+  });
+
+  it("returns 0 (not NaN) when the first vector is zero-magnitude", () => {
+    expect(cosineSimilarity([0, 0, 0], [1, 2, 3])).toBe(0);
+  });
+
+  it("returns 0 (not NaN) when the second vector is zero-magnitude", () => {
+    expect(cosineSimilarity([1, 2, 3], [0, 0, 0])).toBe(0);
+  });
+
+  it("returns 0 when vectors differ in length", () => {
+    expect(cosineSimilarity([1, 2], [1, 2, 3])).toBe(0);
+  });
+
+  it("returns 0 for empty vectors", () => {
+    expect(cosineSimilarity([], [])).toBe(0);
+  });
+});
+
+describe("findTopK", () => {
+  const store = makeStore([
+    makeEntry("a", [1, 0, 0]),
+    makeEntry("b", [0, 1, 0]),
+    makeEntry("c", [1, 1, 0]),
+    makeEntry("d", [-1, 0, 0]),
+  ]);
+
+  it("returns the k most similar entries in descending order", () => {
+    const top = findTopK([1, 0, 0], store, 2);
+    expect(top.map((e) => e.slug)).toEqual(["a", "c"]);
+  });
+
+  it("returns all entries when k exceeds the store size", () => {
+    const top = findTopK([1, 0, 0], store, 99);
+    expect(top).toHaveLength(store.entries.length);
+    expect(top[0].slug).toBe("a");
+  });
+
+  it("returns an empty array when the store is empty", () => {
+    const empty = makeStore([]);
+    expect(findTopK([1, 0, 0], empty, 5)).toEqual([]);
+  });
+});
+
+describe("embedding store persistence", () => {
+  it("returns null when the store file does not exist", async () => {
+    const root = await makeRoot();
+    const store = await readEmbeddingStore(root);
+    expect(store).toBeNull();
+  });
+
+  it("roundtrips a store through write + read", async () => {
+    const root = await makeRoot();
+    const original = makeStore([
+      makeEntry("alpha", [0.1, 0.2, 0.3]),
+      makeEntry("beta", [0.4, 0.5, 0.6]),
+    ]);
+
+    await writeEmbeddingStore(root, original);
+    const loaded = await readEmbeddingStore(root);
+
+    expect(loaded).not.toBeNull();
+    expect(loaded).toEqual(original);
+  });
+
+  it("writes JSON that is human-readable (pretty-printed)", async () => {
+    const root = await makeRoot();
+    const original = makeStore([makeEntry("alpha", [0.1, 0.2])]);
+    await writeEmbeddingStore(root, original);
+
+    const { readFile } = await import("fs/promises");
+    const raw = await readFile(path.join(root, STORE_PATH), "utf-8");
+    // Pretty-printed JSON contains newlines between fields.
+    expect(raw).toContain("\n");
+    expect(JSON.parse(raw)).toEqual(original);
+  });
+
+  it("returns null for a missing store even when .llmwiki directory exists but file doesn't", async () => {
+    const root = await makeRoot();
+    // Create an unrelated file to confirm readEmbeddingStore checks the file, not the dir.
+    await writeFile(path.join(root, ".llmwiki/other.json"), "{}");
+    expect(await readEmbeddingStore(root)).toBeNull();
+  });
+});


### PR DESCRIPTION
### Summary

- Adds embed() to the LLMProvider interface with implementations for Anthropic (Voyage voyage-3-lite), OpenAI (text-embedding-3-small), and Ollama (nomic-embed-text)
- New src/utils/embeddings.ts with cosine similarity (zero-magnitude guarded), top-K search, and .llmwiki/embeddings.json persistence
- Query integration: if embeddings exist, pre-filter the wiki index to the top 15 most similar pages before sending to the selection LLM. Builds a filtered index with stable slug identifiers, eliminating the lossy
  title-to-slug reconstruction on the fallback path. Graceful fallback when no embeddings file exists.
- Embedding store lifecycle: updated after generateIndex/generateMOC in the compile pipeline, after saveQueryPage() in the query command, and prunes orphaned entries automatically
- Anthropic path gracefully degrades if VOYAGE_API_KEY is unset — warns and falls back to full-index selection rather than failing compile

### Test plan

- 15 new embedding tests (similarity, top-K, store I/O) + 5 new provider embed tests (stubbed OpenAI client, Anthropic missing-key error)
- npm test — 193 tests pass
- fallow — clean (0 issues)