### PR TITLE
Add MCP server with tools and resources for agent integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Pages include source attribution in frontmatter. Paragraphs are annotated with `
 | `llmwiki query "question" --save` | Answer and save the result as a wiki page |
 | `llmwiki lint` | Check wiki quality (broken links, orphans, empty pages, etc.) |
 | `llmwiki watch` | Auto-recompile when `sources/` changes |
+| `llmwiki serve [--root <dir>]` | Start an MCP server exposing wiki tools to AI agents |
 
 ## Output
 
@@ -150,6 +151,62 @@ llmwiki query "What terms did Andrej coin?"
 
 See `examples/basic/` in the repo for pre-generated output you can browse without an API key.
 
+## MCP Server
+
+llmwiki ships an MCP (Model Context Protocol) server so AI agents (Claude Desktop, Cursor, Claude Code, etc.) can drive the full pipeline directly: ingest sources, compile, query, search, lint, and read pages — without scraping CLI output.
+
+Where [llm-wiki-kit](https://github.com/iamsashank09/llm-wiki-kit) gives agents raw CRUD against wiki pages, llmwiki exposes the **automated pipelines**: agents get intelligent compilation, incremental change detection, and semantic query routing built in.
+
+### Setup
+
+Start the server (stdio transport, no API key required at startup):
+
+```bash
+llmwiki serve --root /path/to/your/wiki-project
+```
+
+### Claude Desktop / Cursor configuration
+
+Add to your client's MCP config (e.g. `claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "llmwiki": {
+      "command": "npx",
+      "args": ["llm-wiki-compiler", "serve", "--root", "/path/to/wiki-project"],
+      "env": {
+        "ANTHROPIC_API_KEY": "sk-ant-..."
+      }
+    }
+  }
+}
+```
+
+Tools that need an LLM (`compile_wiki`, `query_wiki`, `search_pages`) check for a configured provider on each call. Read-only tools (`read_page`, `lint_wiki`, `wiki_status`) and `ingest_source` work without any credentials.
+
+### Tools
+
+| Tool | What it does |
+|------|--------------|
+| `ingest_source` | Fetch a URL or local file into `sources/`. |
+| `compile_wiki` | Run the incremental compile pipeline; returns counts, slugs, errors. |
+| `query_wiki` | Two-step grounded answer with optional `--save`. |
+| `search_pages` | Return full content of pages relevant to a question. |
+| `read_page` | Read a single page by slug (concepts/ then queries/). |
+| `lint_wiki` | Run quality checks; returns structured diagnostics. |
+| `wiki_status` | Page count, source count, orphans, pending changes (read-only). |
+
+### Resources
+
+| URI | Returns |
+|-----|---------|
+| `llmwiki://index` | Full `wiki/index.md` content. |
+| `llmwiki://concept/{slug}` | A single concept page (frontmatter + body). |
+| `llmwiki://query/{slug}` | A single saved query page. |
+| `llmwiki://sources` | List of ingested source files with metadata. |
+| `llmwiki://state` | Compilation state (per-source hashes, last compile times). |
+
 ## Limitations
 
 Early software. Best for small, high-signal corpora (a few dozen sources). Query routing is index-based.
@@ -168,6 +225,7 @@ Karpathy describes an abstract pattern for turning raw data into compiled knowle
 | Output filing (save answers back) | `llmwiki query --save` | Implemented |
 | Auto-recompile | `llmwiki watch` | Implemented |
 | Linting / health-check pass | `llmwiki lint` | Implemented |
+| Agent integration | `llmwiki serve` (MCP server) | Implemented |
 | Image support | — | Not yet implemented |
 | Marp slides | — | Not yet implemented |
 | Fine-tuning | — | Not yet implemented |
@@ -176,10 +234,13 @@ Karpathy describes an abstract pattern for turning raw data into compiled knowle
 
 - ✅ Better provenance (paragraph-level source attribution)
 - ✅ Linting pass for wiki quality checks
-- Multi-provider support (OpenAI, local models)
-- Larger-corpus query strategy (semantic search, embeddings)
-- Deeper Obsidian integration
-- MCP server for agent integration
+- ✅ Multi-provider support (OpenAI, Ollama, MiniMax)
+- ✅ Larger-corpus query strategy (semantic search, embeddings)
+- ✅ Deeper Obsidian integration (tags, aliases, Map of Content)
+- ✅ MCP server for agent integration
+- Image support
+- Marp slides
+- Fine-tuning
 
 If you want to contribute, these are the highest-leverage areas right now. Issues and PRs are welcome.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@mozilla/readability": "^0.5.0",
         "chokidar": "^4.0.0",
         "commander": "^13.0.0",
@@ -18,7 +19,8 @@
         "jsdom": "^25.0.0",
         "openai": "^4.0.0",
         "p-limit": "^6.0.0",
-        "turndown": "^7.2.0"
+        "turndown": "^7.2.0",
+        "zod": "^3.25.76"
       },
       "bin": {
         "llmwiki": "dist/cli.js"
@@ -632,6 +634,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -676,6 +690,46 @@
       "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
       "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
     },
     "node_modules/@mozilla/readability": {
       "version": "0.5.0",
@@ -1081,12 +1135,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -1240,6 +1294,19 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1274,6 +1341,39 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -1303,6 +1403,30 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/bundle-require": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
@@ -1317,6 +1441,15 @@
       },
       "peerDependencies": {
         "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/cac": {
@@ -1340,6 +1473,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chai": {
@@ -1422,6 +1571,77 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/cssstyle": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
@@ -1496,10 +1716,19 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dotenv": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.0.tgz",
-      "integrity": "sha512-kCKF62fwtzwYm0IGBNjRUjtJgMfGapII+FslMHIjMR5KTnwEmBmWLDRSnc3XSNP8bNy34tekgQyDT0hr7pERRQ==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -1520,6 +1749,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/entities": {
@@ -1629,6 +1873,12 @@
         "@esbuild/win32-x64": "0.27.7"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1637,6 +1887,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/event-target-shim": {
@@ -1648,6 +1907,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1657,6 +1937,90 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1674,6 +2038,27 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/fix-dts-default-cjs-exports": {
@@ -1710,6 +2095,27 @@
       "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
       "license": "MIT"
     },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/formdata-node": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
@@ -1721,6 +2127,24 @@
       },
       "engines": {
         "node": ">= 12.20"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fsevents": {
@@ -1835,6 +2259,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -1845,6 +2279,26 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -1883,15 +2337,43 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -1899,6 +2381,27 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/joycon": {
       "version": "3.1.1",
@@ -1970,6 +2473,18 @@
         }
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -2032,25 +2547,50 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
-        "mime-db": "1.52.0"
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mlly": {
@@ -2101,6 +2641,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/node-domexception": {
@@ -2175,10 +2724,42 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/openai": {
@@ -2253,6 +2834,34 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -2301,6 +2910,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/pkg-types": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
@@ -2314,9 +2932,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -2386,6 +3004,19 @@
         }
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2393,6 +3024,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/readdirp": {
@@ -2406,6 +3076,15 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -2463,6 +3142,22 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
@@ -2485,6 +3180,150 @@
       },
       "engines": {
         "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -2520,6 +3359,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -2618,14 +3466,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2681,6 +3529,15 @@
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "license": "MIT"
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
@@ -2789,6 +3646,20 @@
         "npm": ">=9"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2812,18 +3683,35 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3032,6 +3920,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
@@ -3054,6 +3954,21 @@
         "node": ">=18"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3070,6 +3985,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.20.0",
@@ -3118,6 +4039,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -41,15 +41,17 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@mozilla/readability": "^0.5.0",
     "chokidar": "^4.0.0",
     "commander": "^13.0.0",
     "dotenv": "^17.4.0",
     "js-yaml": "^4.1.1",
-    "openai": "^4.0.0",
     "jsdom": "^25.0.0",
+    "openai": "^4.0.0",
     "p-limit": "^6.0.0",
-    "turndown": "^7.2.0"
+    "turndown": "^7.2.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import compileCommand from "./commands/compile.js";
 import queryCommand from "./commands/query.js";
 import watchCommand from "./commands/watch.js";
 import lintCommand from "./commands/lint.js";
+import { startMCPServer } from "./mcp/server.js";
 import { DEFAULT_PROVIDER } from "./utils/constants.js";
 import { resolveAnthropicAuthFromEnv } from "./utils/claude-settings.js";
 
@@ -85,6 +86,21 @@ program
   .action(async () => {
     try {
       await lintCommand();
+    } catch (err) {
+      console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
+      process.exit(1);
+    }
+  });
+
+program
+  .command("serve")
+  .description("Start an MCP server exposing wiki tools and resources over stdio")
+  .option("--root <dir>", "Project root directory", process.cwd())
+  .action(async (options: { root: string }) => {
+    try {
+      // Per-tool credential checks happen inside the MCP layer so read-only
+      // tools and ingest still work without an API key.
+      await startMCPServer({ root: options.root, version });
     } catch (err) {
       console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
       process.exit(1);

--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -12,6 +12,7 @@ import { MAX_SOURCE_CHARS, MIN_SOURCE_CHARS, SOURCES_DIR } from "../utils/consta
 import * as output from "../utils/output.js";
 import ingestWeb from "../ingest/web.js";
 import ingestFile from "../ingest/file.js";
+import type { IngestResult } from "../utils/types.js";
 
 /** Check whether a source string looks like a URL. */
 function isUrl(source: string): boolean {
@@ -96,10 +97,14 @@ async function saveSource(title: string, document: string): Promise<string> {
 }
 
 /**
- * Ingest a source (URL or local file) and save it to the sources/ directory.
+ * Programmatic ingest entry point. Identical fetch + write logic to the CLI
+ * command but returns a structured IngestResult instead of writing to stdout.
+ * Used by the MCP server's ingest_source tool.
+ *
  * @param source - A URL (http/https) or a local file path (.md or .txt).
+ * @returns Saved filename, character count, truncation flag, and source URI.
  */
-export default async function ingest(source: string): Promise<void> {
+export async function ingestSource(source: string): Promise<IngestResult> {
   output.status("*", output.info(`Ingesting: ${source}`));
 
   const { title, content } = isUrl(source)
@@ -111,9 +116,25 @@ export default async function ingest(source: string): Promise<void> {
   const document = buildDocument(title, source, result);
   const savedPath = await saveSource(title, document);
 
+  return {
+    filename: path.basename(savedPath),
+    charCount: result.content.length,
+    truncated: result.truncated,
+    source,
+  };
+}
+
+/**
+ * Ingest a source (URL or local file) and save it to the sources/ directory.
+ * @param source - A URL (http/https) or a local file path (.md or .txt).
+ */
+export default async function ingest(source: string): Promise<void> {
+  const result = await ingestSource(source);
+  const savedPath = path.join(SOURCES_DIR, result.filename);
+
   output.status(
     "+",
-    output.success(`Saved ${output.bold(title)} → ${output.source(savedPath)}`)
+    output.success(`Saved ${output.bold(result.filename)} → ${output.source(savedPath)}`)
   );
   output.status("→", output.dim("Next: llmwiki compile"));
 }

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -20,6 +20,7 @@ import { generateIndex } from "../compiler/indexgen.js";
 import * as output from "../utils/output.js";
 import { QUERY_PAGE_LIMIT, INDEX_FILE, CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
 import { findRelevantPages, updateEmbeddings } from "../utils/embeddings.js";
+import type { QueryResult } from "../utils/types.js";
 
 /** Directories to search when loading selected pages, in priority order. */
 const PAGE_DIRS = [CONCEPTS_DIR, QUERIES_DIR];
@@ -59,7 +60,7 @@ interface PageSelectionResult {
  * @param indexContent - The full text of wiki/index.md.
  * @returns Parsed page slugs and reasoning from Claude.
  */
-async function selectPages(
+export async function selectPages(
   question: string,
   indexContent: string,
 ): Promise<PageSelectionResult> {
@@ -166,30 +167,29 @@ export async function loadSelectedPages(root: string, slugs: string[]): Promise<
   return sections.join("\n\n");
 }
 
+/** Shared system prompt for the answer-generation step. */
+const ANSWER_SYSTEM_PROMPT =
+  "You are a knowledge assistant. Answer the question using ONLY the wiki content provided. " +
+  "Cite specific pages using [[Page Title]] wikilinks. " +
+  "If the wiki doesn't contain enough information, say so.";
+
 /**
- * Stream an answer from Claude using the loaded wiki pages as context.
- * @param question - The user's natural language question.
- * @param pagesContent - Combined content of the selected wiki pages.
- * @returns The full answer text after streaming completes.
+ * Call the LLM with the loaded wiki pages as grounding context.
+ * Streams to the provided onToken callback when one is supplied,
+ * otherwise returns the full answer without streaming.
  */
-async function streamAnswer(question: string, pagesContent: string): Promise<string> {
-  const systemPrompt =
-    "You are a knowledge assistant. Answer the question using ONLY the wiki content provided. " +
-    "Cite specific pages using [[Page Title]] wikilinks. " +
-    "If the wiki doesn't contain enough information, say so.";
-
+async function callAnswerLLM(
+  question: string,
+  pagesContent: string,
+  onToken?: (text: string) => void,
+): Promise<string> {
   const userMessage = `Question: ${question}\n\nRelevant wiki pages:\n${pagesContent}`;
-
-  const answer = await callClaude({
-    system: systemPrompt,
+  return callClaude({
+    system: ANSWER_SYSTEM_PROMPT,
     messages: [{ role: "user", content: userMessage }],
-    stream: true,
-    onToken: (text: string) => process.stdout.write(text),
+    stream: Boolean(onToken),
+    onToken,
   });
-
-  // Ensure terminal output ends on a new line after streaming
-  process.stdout.write("\n");
-  return answer;
 }
 
 /**
@@ -212,7 +212,7 @@ export function summarizeAnswer(answer: string): string {
  * @param question - The original question used as the page title.
  * @param answer - The generated answer body.
  */
-async function saveQueryPage(root: string, question: string, answer: string): Promise<void> {
+async function saveQueryPage(root: string, question: string, answer: string): Promise<string> {
   const slug = slugify(question);
   const filePath = path.join(root, QUERIES_DIR, `${slug}.md`);
 
@@ -243,6 +243,56 @@ async function saveQueryPage(root: string, question: string, answer: string): Pr
     const message = err instanceof Error ? err.message : String(err);
     output.status("!", output.warn(`Skipped embeddings update: ${message}`));
   }
+
+  return slug;
+}
+
+/** Options for generateAnswer — programmatic-friendly. */
+interface GenerateAnswerOptions {
+  /** Persist the answer as a wiki query page when set. */
+  save?: boolean;
+  /** Per-token callback for streaming. Omit for non-streaming usage. */
+  onToken?: (text: string) => void;
+  /** Callback fired once page selection completes — lets CLIs print reasoning before streaming. */
+  onPageSelection?: (pages: string[], reasoning: string) => void;
+}
+
+/**
+ * Run the two-step page-selection + answer-generation pipeline and return
+ * a structured QueryResult. This is the programmatic entry point used by
+ * the MCP server and any non-CLI consumer.
+ *
+ * @param root - Absolute path to the project root directory.
+ * @param question - The natural language question to answer.
+ * @param options - Streaming + save behaviour controls.
+ * @returns Answer text, selected slugs, reasoning, and saved slug if applicable.
+ */
+export async function generateAnswer(
+  root: string,
+  question: string,
+  options: GenerateAnswerOptions = {},
+): Promise<QueryResult> {
+  if (!existsSync(path.join(root, INDEX_FILE))) {
+    throw new Error("Wiki index not found. Run `llmwiki compile` first.");
+  }
+
+  const { pages, reasoning } = await selectRelevantPages(root, question);
+  options.onPageSelection?.(pages, reasoning);
+
+  const pagesContent = await loadSelectedPages(root, pages);
+
+  if (!pagesContent) {
+    return { answer: "", selectedPages: pages, reasoning };
+  }
+
+  const answer = await callAnswerLLM(question, pagesContent, options.onToken);
+
+  let saved: string | undefined;
+  if (options.save) {
+    saved = await saveQueryPage(root, question, answer);
+  }
+
+  return { answer, selectedPages: pages, reasoning, saved };
 }
 
 /**
@@ -261,29 +311,27 @@ export default async function queryCommand(
     return;
   }
 
-  // Step 1: Select relevant pages
   output.header("Selecting relevant pages");
 
-  const { pages, rawPages, reasoning } = await selectRelevantPages(root, question);
+  const result = await generateAnswer(root, question, {
+    save: options.save,
+    onToken: (text) => process.stdout.write(text),
+    onPageSelection: (pages, reasoning) => {
+      output.status("i", output.dim(`Reasoning: ${reasoning}`));
+      output.status("*", output.info(`Selected ${pages.length} page(s): ${pages.join(", ")}`));
+      output.header("Generating answer");
+    },
+  });
 
-  output.status("i", output.dim(`Reasoning: ${reasoning}`));
-  output.status("*", output.info(`Selected ${pages.length} page(s): ${rawPages.join(", ")}`));
+  // Newline after streamed answer so subsequent terminal output formats cleanly.
+  process.stdout.write("\n");
 
-  // Step 2: Load pages and stream the answer
-  output.header("Generating answer");
-
-  const pagesContent = await loadSelectedPages(root, pages);
-
-  if (!pagesContent) {
+  if (!result.answer) {
     output.status("!", output.error("No matching pages found. Try refining your question."));
     return;
   }
 
-  const answer = await streamAnswer(question, pagesContent);
-
-  // Optional: save the answer as a query page
-  if (options.save) {
-    await saveQueryPage(root, question, answer);
+  if (result.saved) {
     output.status("→", output.dim("Saved. Future queries will use this answer as context."));
   } else {
     output.status("→", output.dim("Tip: use --save to add this answer to your wiki"));

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -49,7 +49,18 @@ import {
   SOURCES_DIR,
 } from "../utils/constants.js";
 import pLimit from "p-limit";
-import type { ExtractedConcept, SourceState, SourceChange } from "../utils/types.js";
+import type {
+  CompileResult,
+  ExtractedConcept,
+  SourceChange,
+  SourceState,
+  WikiState,
+} from "../utils/types.js";
+
+/** Empty CompileResult used when no pipeline work runs (e.g. lock contention). */
+function emptyCompileResult(): CompileResult {
+  return { compiled: 0, skipped: 0, deleted: 0, concepts: [], pages: [], errors: [] };
+}
 
 /**
  * Run the full compilation pipeline with lock protection.
@@ -58,108 +69,207 @@ import type { ExtractedConcept, SourceState, SourceChange } from "../utils/types
  * @param root - Project root directory.
  */
 export async function compile(root: string): Promise<void> {
+  await compileAndReport(root);
+}
+
+/**
+ * Run the full compilation pipeline and return a structured result.
+ * Same behaviour as compile() but exposes counts, slugs, and errors so
+ * non-CLI consumers (the MCP server, programmatic callers) can report
+ * meaningful data without scraping terminal output.
+ * @param root - Project root directory.
+ * @returns Structured result describing what was compiled.
+ */
+export async function compileAndReport(root: string): Promise<CompileResult> {
   output.header("llmwiki compile");
 
   const locked = await acquireLock(root);
   if (!locked) {
     output.status("!", output.error("Could not acquire lock. Try again later."));
-    return;
+    return {
+      ...emptyCompileResult(),
+      errors: ["Could not acquire .llmwiki/lock — another compile is in progress."],
+    };
   }
 
   try {
-    await runCompilePipeline(root);
+    return await runCompilePipeline(root);
   } finally {
     await releaseLock(root);
   }
 }
 
-/** Inner pipeline, runs under lock protection. */
-async function runCompilePipeline(root: string): Promise<void> {
-  const state = await readState(root);
-  const changes = await detectChanges(root, state);
+/** Buckets of source changes used by the compile pipeline. */
+interface ChangeBuckets {
+  toCompile: SourceChange[];
+  deleted: SourceChange[];
+  unchanged: SourceChange[];
+}
 
-  // Semantic dependency tracking: find unchanged sources that share concepts
-  // with changed sources and need recompilation to preserve cross-source content
-  const affectedFiles = findAffectedSources(state, changes);
-  for (const file of affectedFiles) {
-    output.status("~", output.info(`${file} [affected by shared concept]`));
-    changes.push({ file, status: "changed" });
+/** Sort source changes into the buckets the pipeline acts on. */
+function bucketChanges(changes: SourceChange[]): ChangeBuckets {
+  return {
+    toCompile: changes.filter((c) => c.status === "new" || c.status === "changed"),
+    deleted: changes.filter((c) => c.status === "deleted"),
+    unchanged: changes.filter((c) => c.status === "unchanged"),
+  };
+}
+
+/** Result of phase 2: page writes plus any errors collected along the way. */
+interface PageGenerationResult {
+  pages: MergedConcept[];
+  errors: string[];
+}
+
+/** Phase 2: generate pages for merged concepts in parallel, capturing errors. */
+async function generatePagesPhase(
+  root: string,
+  extractions: ExtractionResult[],
+  frozenSlugs: Set<string>,
+): Promise<PageGenerationResult> {
+  const merged = mergeExtractions(extractions, frozenSlugs);
+  const limit = pLimit(COMPILE_CONCURRENCY);
+  const errors: string[] = [];
+  const pages = await Promise.all(
+    merged.map((entry) => limit(async () => {
+      const writeError = await generateMergedPage(root, entry);
+      if (writeError) errors.push(writeError);
+      return entry;
+    })),
+  );
+  return { pages, errors };
+}
+
+/** Persist source state for every extraction that produced concepts. */
+async function persistExtractionStates(
+  root: string,
+  extractions: ExtractionResult[],
+): Promise<void> {
+  for (const result of extractions) {
+    if (result.concepts.length === 0) continue;
+    await persistSourceState(root, result.sourcePath, result.sourceFile, result.concepts);
+  }
+}
+
+/** Build the structured CompileResult and emit the CLI completion banner. */
+function summarizeCompile(
+  buckets: ChangeBuckets,
+  generation: PageGenerationResult,
+  extractions: ExtractionResult[],
+): CompileResult {
+  output.header("Compilation complete");
+  output.status("✓", output.success(
+    `${buckets.toCompile.length} compiled, ${buckets.unchanged.length} skipped, ${buckets.deleted.length} deleted`,
+  ));
+  if (buckets.toCompile.length > 0) {
+    output.status("→", output.dim('Next: llmwiki query "your question here"'));
   }
 
-  const toCompile = changes.filter((c) => c.status === "new" || c.status === "changed");
-  const deleted = changes.filter((c) => c.status === "deleted");
-  const unchanged = changes.filter((c) => c.status === "unchanged");
+  const errors = [...generation.errors];
+  for (const result of extractions) {
+    if (result.concepts.length === 0) {
+      errors.push(`No concepts extracted from ${result.sourceFile}`);
+    }
+  }
 
-  if (toCompile.length === 0 && deleted.length === 0) {
+  return {
+    compiled: buckets.toCompile.length,
+    skipped: buckets.unchanged.length,
+    deleted: buckets.deleted.length,
+    concepts: generation.pages.map((entry) => entry.concept.concept),
+    pages: generation.pages.map((entry) => entry.slug),
+    errors,
+  };
+}
+
+/** Inner pipeline, runs under lock protection. Returns structured CompileResult. */
+async function runCompilePipeline(root: string): Promise<CompileResult> {
+  const state = await readState(root);
+  const changes = await detectChanges(root, state);
+  augmentWithAffectedSources(changes, findAffectedSources(state, changes));
+
+  const buckets = bucketChanges(changes);
+  if (buckets.toCompile.length === 0 && buckets.deleted.length === 0) {
     output.status("✓", output.success("Nothing to compile — all sources up to date."));
-    return;
+    return { ...emptyCompileResult(), skipped: buckets.unchanged.length };
   }
 
   printChangesSummary(changes);
+  await markDeletedAsOrphaned(root, buckets.deleted, state);
 
-  // Handle deleted sources: mark their wiki pages as orphaned
+  const frozenSlugs = findFrozenSlugs(state, changes);
+  reportFrozenSlugs(frozenSlugs);
+
+  const extractions = await runExtractionPhases(root, buckets.toCompile, state, changes);
+  await freezeFailedExtractions(root, extractions, frozenSlugs);
+
+  const generation = await generatePagesPhase(root, extractions, frozenSlugs);
+  await persistExtractionStates(root, extractions);
+
+  if (frozenSlugs.size > 0) {
+    await orphanUnownedFrozenPages(root, frozenSlugs);
+  }
+  await persistFrozenSlugs(root, frozenSlugs, extractions);
+
+  await finalizeWiki(root, generation.pages);
+  return summarizeCompile(buckets, generation, extractions);
+}
+
+/** Append affected-source changes (logging each addition) to the change list. */
+function augmentWithAffectedSources(changes: SourceChange[], affected: string[]): void {
+  for (const file of affected) {
+    output.status("~", output.info(`${file} [affected by shared concept]`));
+    changes.push({ file, status: "changed" });
+  }
+}
+
+/** Mark wiki pages owned solely by deleted sources as orphaned. */
+async function markDeletedAsOrphaned(
+  root: string,
+  deleted: SourceChange[],
+  state: WikiState,
+): Promise<void> {
   for (const del of deleted) {
     await markOrphaned(root, del.file, state);
   }
+}
 
-  // Frozen slugs: shared concepts that lost a contributor (deleted source).
-  const frozenSlugs = findFrozenSlugs(state, changes);
+/** Log frozen slugs (shared concepts whose deletion-pinned content must persist). */
+function reportFrozenSlugs(frozenSlugs: Set<string>): void {
   for (const slug of frozenSlugs) {
     output.status("i", output.dim(`Frozen: ${slug} (shared with deleted source)`));
   }
+}
 
-  // Phase 1: Extract concepts for ALL sources before generating any pages.
-  // This eliminates order-dependence: we know which extractions failed
-  // before committing any page writes.
+/**
+ * Phase 1: extract concepts for the directly-changed batch, then expand to
+ * any unchanged sources whose concepts overlap with newly extracted slugs.
+ */
+async function runExtractionPhases(
+  root: string,
+  toCompile: SourceChange[],
+  state: WikiState,
+  allChanges: SourceChange[],
+): Promise<ExtractionResult[]> {
   const extractions: ExtractionResult[] = [];
   for (const change of toCompile) {
     extractions.push(await extractForSource(root, change.file));
   }
 
-  // Post-extraction dependency check: new sources may extract concepts
-  // that existing unchanged sources already own. findAffectedSources
-  // couldn't detect this earlier because new sources had no state entry.
-  const lateAffected = findLateAffectedSources(extractions, state, changes);
+  const lateAffected = findLateAffectedSources(extractions, state, allChanges);
   for (const file of lateAffected) {
     output.status("~", output.info(`${file} [shares concept with new source]`));
     extractions.push(await extractForSource(root, file));
   }
 
-  // Freeze concepts from failed extractions before page generation.
-  await freezeFailedExtractions(root, extractions, frozenSlugs);
+  return extractions;
+}
 
-  // Phase 2: Merge shared concepts across sources, then generate pages.
-  // When multiple sources extract the same concept, combine their content
-  // so the LLM sees all contributing material in a single generation call.
-  const merged = mergeExtractions(extractions, frozenSlugs);
-  const limit = pLimit(COMPILE_CONCURRENCY);
-  const pageResults = await Promise.all(
-    merged.map((entry) => limit(async () => {
-      await generateMergedPage(root, entry);
-      return entry;
-    })),
-  );
-  const allChangedSlugs = pageResults.map((e) => e.slug);
-  const allNewSlugs = pageResults
-    .filter((e) => e.concept.is_new)
-    .map((e) => e.slug);
+/** Resolve interlinks, regenerate index/MOC, refresh embeddings post-write. */
+async function finalizeWiki(root: string, pages: MergedConcept[]): Promise<void> {
+  const allChangedSlugs = pages.map((entry) => entry.slug);
+  const allNewSlugs = pages.filter((entry) => entry.concept.is_new).map((entry) => entry.slug);
 
-  // Persist state for each successfully extracted source.
-  for (const result of extractions) {
-    if (result.concepts.length === 0) continue;
-    await persistSourceState(root, result.sourcePath, result.sourceFile, result.concepts);
-  }
-
-  // Orphan frozen pages that lost all owners after recompilation.
-  if (frozenSlugs.size > 0) {
-    await orphanUnownedFrozenPages(root, frozenSlugs);
-  }
-
-  // Persist frozen slugs: unfreeze any that are now safe to regenerate
-  // (all current owners compiled and extracted them), keep the rest.
-  await persistFrozenSlugs(root, frozenSlugs, extractions);
-
-  // Interlink resolution: outbound on changed, inbound for new titles
   if (allChangedSlugs.length > 0) {
     output.status("🔗", output.info("Resolving interlinks..."));
     await resolveLinks(root, allChangedSlugs, allNewSlugs);
@@ -168,14 +278,6 @@ async function runCompilePipeline(root: string): Promise<void> {
   await generateIndex(root);
   await generateMOC(root);
   await safelyUpdateEmbeddings(root, allChangedSlugs);
-
-  output.header("Compilation complete");
-  output.status("✓", output.success(
-    `${toCompile.length} compiled, ${unchanged.length} skipped, ${deleted.length} deleted`,
-  ));
-  if (toCompile.length > 0) {
-    output.status("→", output.dim('Next: llmwiki query "your question here"'));
-  }
 }
 
 /** Print a summary of detected source file changes. */
@@ -269,7 +371,7 @@ function mergeExtractions(
 async function generateMergedPage(
   root: string,
   entry: MergedConcept,
-): Promise<void> {
+): Promise<string | null> {
   const pagePath = path.join(root, CONCEPTS_DIR, `${entry.slug}.md`);
   const existingPage = await safeReadFile(pagePath);
   const relatedPages = await loadRelatedPages(root, entry.slug);
@@ -303,7 +405,7 @@ async function generateMergedPage(
   addObsidianMeta(frontmatterFields, entry.concept.concept, entry.concept.tags ?? []);
   const frontmatter = buildFrontmatter(frontmatterFields);
   const fullPage = `${frontmatter}\n\n${pageBody}\n`;
-  await writePageIfValid(pagePath, fullPage, entry.concept.concept);
+  return await writePageIfValid(pagePath, fullPage, entry.concept.concept);
 }
 
 /**
@@ -373,13 +475,14 @@ async function writePageIfValid(
   pagePath: string,
   content: string,
   conceptTitle: string,
-): Promise<void> {
+): Promise<string | null> {
   if (!validateWikiPage(content)) {
     output.status("!", output.warn(`Invalid page for "${conceptTitle}" — skipped.`));
-    return;
+    return `Invalid page for "${conceptTitle}" — failed validation`;
   }
 
   await atomicWrite(pagePath, content);
+  return null;
 }
 
 /**

--- a/src/compiler/indexgen.ts
+++ b/src/compiler/indexgen.ts
@@ -36,37 +36,54 @@ export async function generateIndex(root: string): Promise<void> {
   output.status("+", output.success(`Index updated with ${total} pages.`));
 }
 
-/**
- * Scan the concepts directory and extract page summaries from frontmatter.
- * @param conceptsPath - Absolute path to wiki/concepts/.
- * @returns Array of page summary objects.
- */
-async function collectPageSummaries(
-  conceptsPath: string,
-): Promise<PageSummary[]> {
-  let files: string[];
+/** A scanned page paired with its parsed frontmatter. */
+interface ScannedPage {
+  slug: string;
+  meta: Record<string, unknown>;
+}
 
+/**
+ * Scan a wiki directory and return every .md page paired with its parsed
+ * frontmatter. Read-only utility shared by index generation and the MCP
+ * server's status tool.
+ * @param dirPath - Absolute path to a wiki page directory.
+ * @returns Array of {slug, meta} entries — empty when the directory is missing.
+ */
+export async function scanWikiPages(dirPath: string): Promise<ScannedPage[]> {
+  let files: string[];
   try {
-    files = await readdir(conceptsPath);
+    files = await readdir(dirPath);
   } catch {
     return [];
   }
 
-  const pages: PageSummary[] = [];
-
+  const scanned: ScannedPage[] = [];
   for (const file of files.filter((f) => f.endsWith(".md"))) {
-    const content = await safeReadFile(path.join(conceptsPath, file));
+    const content = await safeReadFile(path.join(dirPath, file));
     const { meta } = parseFrontmatter(content);
-    if (meta.title && typeof meta.title === "string" && !meta.orphaned) {
-      pages.push({
-        title: meta.title,
-        slug: file.replace(/\.md$/, ""),
-        summary: typeof meta.summary === "string" ? meta.summary : "",
-      });
-    }
+    scanned.push({ slug: file.replace(/\.md$/, ""), meta });
   }
+  return scanned;
+}
 
-  return pages;
+/**
+ * Project a wiki directory into PageSummary entries (excludes orphaned and
+ * untitled pages). Built on top of scanWikiPages so the MCP server can share
+ * the underlying scan logic without re-reading the directory.
+ * @param conceptsPath - Absolute path to wiki/concepts/.
+ * @returns Array of page summary objects.
+ */
+export async function collectPageSummaries(
+  conceptsPath: string,
+): Promise<PageSummary[]> {
+  const scanned = await scanWikiPages(conceptsPath);
+  return scanned
+    .filter(({ meta }) => meta.title && typeof meta.title === "string" && !meta.orphaned)
+    .map(({ slug, meta }) => ({
+      title: meta.title as string,
+      slug,
+      summary: typeof meta.summary === "string" ? meta.summary : "",
+    }));
 }
 
 /** Strip [[wikilink]] brackets from text, leaving the inner text intact. */

--- a/src/mcp/provider-check.ts
+++ b/src/mcp/provider-check.ts
@@ -1,0 +1,52 @@
+/**
+ * Per-tool provider validation for the MCP server.
+ *
+ * The MCP server starts without any API key check so read-only tools
+ * (read_page, lint_wiki, wiki_status) and the ingest tool always work.
+ * Tools that need an LLM call (compile, query, search) invoke this guard
+ * to surface a clean error if credentials are missing.
+ */
+
+import { DEFAULT_PROVIDER } from "../utils/constants.js";
+import { resolveAnthropicAuthFromEnv } from "../utils/claude-settings.js";
+
+/** Map of provider name to the env var that satisfies it. Null = no key needed. */
+const PROVIDER_KEY_VARS: Record<string, string | null> = {
+  anthropic: "ANTHROPIC_API_KEY",
+  openai: "OPENAI_API_KEY",
+  ollama: null,
+  minimax: "MINIMAX_API_KEY",
+};
+
+/**
+ * Throw if the active LLM provider is missing credentials.
+ * Anthropic accepts either ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN
+ * (resolved through the Claude Code settings fallback chain).
+ */
+export function ensureProviderAvailable(): void {
+  const provider = process.env.LLMWIKI_PROVIDER ?? DEFAULT_PROVIDER;
+
+  if (provider === "anthropic") {
+    const auth = resolveAnthropicAuthFromEnv();
+    if (!auth.apiKey && !auth.authToken) {
+      throw new Error(
+        'Anthropic credentials are required for the "anthropic" provider. ' +
+          "Set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN.",
+      );
+    }
+    return;
+  }
+
+  const keyVar = PROVIDER_KEY_VARS[provider];
+  if (keyVar === undefined) {
+    throw new Error(
+      `Unknown provider "${provider}". Supported: ${Object.keys(PROVIDER_KEY_VARS).join(", ")}`,
+    );
+  }
+
+  if (keyVar && !process.env[keyVar]) {
+    throw new Error(
+      `${keyVar} environment variable is required for the "${provider}" provider.`,
+    );
+  }
+}

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -1,0 +1,195 @@
+/**
+ * MCP resource registrations for llmwiki.
+ *
+ * Resources expose read-only views of the wiki under the llmwiki:// URI
+ * scheme. Hosts can attach these as context without invoking a tool —
+ * useful for letting agents browse the wiki passively.
+ */
+
+import path from "path";
+import { readdir } from "fs/promises";
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  CONCEPTS_DIR,
+  INDEX_FILE,
+  QUERIES_DIR,
+  SOURCES_DIR,
+  STATE_FILE,
+} from "../utils/constants.js";
+import { safeReadFile, parseFrontmatter } from "../utils/markdown.js";
+import { readState } from "../utils/state.js";
+
+/** Standard JSON content block for an MCP resource read result. */
+function jsonContent(uri: URL, payload: unknown): {
+  uri: string;
+  mimeType: string;
+  text: string;
+} {
+  return {
+    uri: uri.href,
+    mimeType: "application/json",
+    text: JSON.stringify(payload, null, 2),
+  };
+}
+
+/** Standard markdown content block for an MCP resource read result. */
+function markdownContent(uri: URL, text: string): {
+  uri: string;
+  mimeType: string;
+  text: string;
+} {
+  return {
+    uri: uri.href,
+    mimeType: "text/markdown",
+    text,
+  };
+}
+
+/** Register all 5 read-only wiki resources on the given MCP server. */
+export function registerWikiResources(server: McpServer, root: string): void {
+  registerIndexResource(server, root);
+  registerSourcesResource(server, root);
+  registerStateResource(server, root);
+  registerConceptResource(server, root);
+  registerQueryResource(server, root);
+}
+
+function registerIndexResource(server: McpServer, root: string): void {
+  server.registerResource(
+    "wiki-index",
+    "llmwiki://index",
+    {
+      title: "Wiki Index",
+      description: "Full content of wiki/index.md (auto-generated table of contents).",
+      mimeType: "text/markdown",
+    },
+    async (uri) => {
+      const content = await safeReadFile(path.join(root, INDEX_FILE));
+      return { contents: [markdownContent(uri, content)] };
+    },
+  );
+}
+
+function registerSourcesResource(server: McpServer, root: string): void {
+  server.registerResource(
+    "wiki-sources",
+    "llmwiki://sources",
+    {
+      title: "Wiki Sources",
+      description: "List of ingested source files with frontmatter metadata.",
+      mimeType: "application/json",
+    },
+    async (uri) => ({
+      contents: [jsonContent(uri, await listSources(root))],
+    }),
+  );
+}
+
+function registerStateResource(server: McpServer, root: string): void {
+  server.registerResource(
+    "wiki-state",
+    "llmwiki://state",
+    {
+      title: "Compilation State",
+      description: "Per-source hashes, concepts, and last compile times from .llmwiki/state.json.",
+      mimeType: "application/json",
+    },
+    async (uri) => {
+      const state = await readState(root);
+      return { contents: [jsonContent(uri, state)] };
+    },
+  );
+}
+
+function registerConceptResource(server: McpServer, root: string): void {
+  server.registerResource(
+    "wiki-concept",
+    new ResourceTemplate("llmwiki://concept/{slug}", {
+      list: async () => listPagesUnder(root, CONCEPTS_DIR, "concept"),
+    }),
+    {
+      title: "Wiki Concept",
+      description: "A single concept page from wiki/concepts/ — frontmatter plus body.",
+      mimeType: "application/json",
+    },
+    async (uri, { slug }) => ({
+      contents: [jsonContent(uri, await loadPageWithMeta(root, CONCEPTS_DIR, String(slug)))],
+    }),
+  );
+}
+
+function registerQueryResource(server: McpServer, root: string): void {
+  server.registerResource(
+    "wiki-query",
+    new ResourceTemplate("llmwiki://query/{slug}", {
+      list: async () => listPagesUnder(root, QUERIES_DIR, "query"),
+    }),
+    {
+      title: "Wiki Query",
+      description: "A single saved query page from wiki/queries/ — frontmatter plus body.",
+      mimeType: "application/json",
+    },
+    async (uri, { slug }) => ({
+      contents: [jsonContent(uri, await loadPageWithMeta(root, QUERIES_DIR, String(slug)))],
+    }),
+  );
+}
+
+/** Source listing: filename, frontmatter (truncation, source URL, etc.). */
+async function listSources(root: string): Promise<Array<Record<string, unknown>>> {
+  const sourcesPath = path.join(root, SOURCES_DIR);
+  let files: string[];
+  try {
+    files = await readdir(sourcesPath);
+  } catch {
+    return [];
+  }
+
+  const records: Array<Record<string, unknown>> = [];
+  for (const file of files.filter((f) => f.endsWith(".md"))) {
+    const content = await safeReadFile(path.join(sourcesPath, file));
+    const { meta } = parseFrontmatter(content);
+    records.push({ filename: file, ...meta });
+  }
+  return records;
+}
+
+/** Read a single page and return a structured payload (slug, meta, body). */
+async function loadPageWithMeta(
+  root: string,
+  dir: string,
+  slug: string,
+): Promise<{ slug: string; meta: Record<string, unknown>; body: string }> {
+  const filePath = path.join(root, dir, `${slug}.md`);
+  const content = await safeReadFile(filePath);
+  if (!content) {
+    throw new Error(`Page not found: ${dir}/${slug}.md`);
+  }
+
+  const { meta, body } = parseFrontmatter(content);
+  return { slug, meta, body: body.trim() };
+}
+
+/** Build a resource list payload by enumerating .md files in a wiki directory. */
+async function listPagesUnder(
+  root: string,
+  dir: string,
+  scheme: "concept" | "query",
+): Promise<{ resources: Array<{ uri: string; name: string }> }> {
+  const pagesPath = path.join(root, dir);
+  let files: string[];
+  try {
+    files = await readdir(pagesPath);
+  } catch {
+    return { resources: [] };
+  }
+
+  const resources = files
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => {
+      const slug = f.replace(/\.md$/, "");
+      return { uri: `llmwiki://${scheme}/${slug}`, name: slug };
+    });
+
+  return { resources };
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,48 @@
+/**
+ * MCP (Model Context Protocol) server entry point for llmwiki.
+ *
+ * Exposes llmwiki's automated pipelines (ingest, compile, query, search,
+ * lint, read, status) as MCP tools so AI agents can drive the compiler
+ * without scraping CLI output. Read-only wiki views are exposed as
+ * MCP resources for direct context injection.
+ *
+ * Transport: stdio. The server reads JSON-RPC messages on stdin and
+ * writes responses on stdout, which is the standard surface area for
+ * Claude Desktop, Cursor, and other MCP-aware clients.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { registerWikiTools } from "./tools.js";
+import { registerWikiResources } from "./resources.js";
+
+interface ServerOptions {
+  /** Project root directory the server operates on. */
+  root: string;
+  /** Server version surfaced to MCP clients in the initialize handshake. */
+  version: string;
+}
+
+/**
+ * Start the MCP server bound to stdio transport.
+ * Resolves once the transport closes (typically when the parent process exits).
+ *
+ * @param options - Root directory and server version (the CLI passes its own
+ *                  version so the server doesn't need to read package.json).
+ */
+export async function startMCPServer(options: ServerOptions): Promise<void> {
+  const { root, version } = options;
+  const server = new McpServer({ name: "llmwiki", version }, {
+    instructions:
+      "llmwiki is a knowledge compiler. Use ingest_source to add raw sources, " +
+      "compile_wiki to run the LLM pipeline, query_wiki for grounded answers, " +
+      "and search_pages to retrieve relevant pages. read_page, lint_wiki, and " +
+      "wiki_status work without an API key.",
+  });
+
+  registerWikiTools(server, root);
+  registerWikiResources(server, root);
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,0 +1,296 @@
+/**
+ * MCP tool registrations for llmwiki.
+ *
+ * Each tool wraps an existing pipeline function (ingest, compile, query,
+ * search, read, lint, status) and converts its structured result into
+ * an MCP CallToolResult. Tools that need an LLM provider validate the
+ * provider lazily — the server itself starts without credentials so
+ * read-only tools always work.
+ */
+
+import path from "path";
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ingestSource } from "../commands/ingest.js";
+import { compileAndReport } from "../compiler/index.js";
+import { generateAnswer, selectPages } from "../commands/query.js";
+import { lint } from "../linter/index.js";
+import { collectPageSummaries, scanWikiPages } from "../compiler/indexgen.js";
+import { detectChanges } from "../compiler/hasher.js";
+import { readState } from "../utils/state.js";
+import { safeReadFile, parseFrontmatter } from "../utils/markdown.js";
+import { findRelevantPages } from "../utils/embeddings.js";
+import {
+  CONCEPTS_DIR,
+  INDEX_FILE,
+  QUERIES_DIR,
+} from "../utils/constants.js";
+import { ensureProviderAvailable } from "./provider-check.js";
+
+/** Directories searched (in priority order) when resolving a page slug. */
+const PAGE_DIRS = [CONCEPTS_DIR, QUERIES_DIR];
+
+/** Shape returned by search_pages for each matching page. */
+interface PageRecord {
+  slug: string;
+  title: string;
+  summary: string;
+  body: string;
+}
+
+/**
+ * Wrap an arbitrary JSON value as the standard MCP CallToolResult.
+ * MCP requires content blocks even for structured payloads, so we mirror
+ * the JSON in a text block for clients that don't read structuredContent.
+ */
+function jsonResult(payload: unknown): {
+  content: Array<{ type: "text"; text: string }>;
+  structuredContent: { result: unknown };
+} {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+    structuredContent: { result: payload },
+  };
+}
+
+/** Register all 7 wiki tools on the given MCP server instance. */
+export function registerWikiTools(server: McpServer, root: string): void {
+  registerIngestTool(server, root);
+  registerCompileTool(server, root);
+  registerQueryTool(server, root);
+  registerSearchTool(server, root);
+  registerReadTool(server, root);
+  registerLintTool(server, root);
+  registerStatusTool(server, root);
+}
+
+function registerIngestTool(server: McpServer, root: string): void {
+  server.registerTool(
+    "ingest_source",
+    {
+      title: "Ingest Source",
+      description:
+        "Fetch a URL or copy a local file into sources/. Returns the saved filename, " +
+        "character count, and whether content was truncated to fit the size limit.",
+      inputSchema: {
+        source: z
+          .string()
+          .describe("URL (http/https) or absolute path to a .md/.txt file"),
+      },
+    },
+    async ({ source }) => {
+      const previousCwd = process.cwd();
+      try {
+        process.chdir(root);
+        const result = await ingestSource(source);
+        return jsonResult(result);
+      } finally {
+        process.chdir(previousCwd);
+      }
+    },
+  );
+}
+
+function registerCompileTool(server: McpServer, root: string): void {
+  server.registerTool(
+    "compile_wiki",
+    {
+      title: "Compile Wiki",
+      description:
+        "Run the incremental compile pipeline: extract concepts from new/changed " +
+        "sources, generate wiki pages, resolve interlinks, and rebuild the index. " +
+        "Requires an LLM provider with credentials.",
+      inputSchema: {},
+    },
+    async () => {
+      ensureProviderAvailable();
+      const result = await compileAndReport(root);
+      return jsonResult(result);
+    },
+  );
+}
+
+function registerQueryTool(server: McpServer, root: string): void {
+  server.registerTool(
+    "query_wiki",
+    {
+      title: "Query Wiki",
+      description:
+        "Ask a natural-language question. Selects relevant pages with the LLM, " +
+        "loads them, and returns a grounded answer with citations. Set save=true " +
+        "to persist the answer as a wiki page. Requires an LLM provider.",
+      inputSchema: {
+        question: z.string().describe("The natural-language question to answer."),
+        save: z
+          .boolean()
+          .optional()
+          .describe("Persist the answer as a wiki/queries/ page when true."),
+      },
+    },
+    async ({ question, save }) => {
+      ensureProviderAvailable();
+      const result = await generateAnswer(root, question, { save });
+      return jsonResult(result);
+    },
+  );
+}
+
+function registerSearchTool(server: McpServer, root: string): void {
+  server.registerTool(
+    "search_pages",
+    {
+      title: "Search Pages",
+      description:
+        "Select pages relevant to a question and return their full content. " +
+        "Uses semantic embeddings when available, falling back to LLM-based " +
+        "selection over the wiki index. Requires an LLM provider.",
+      inputSchema: {
+        question: z.string().describe("The query used to rank pages."),
+      },
+    },
+    async ({ question }) => {
+      ensureProviderAvailable();
+      const slugs = await pickSearchSlugs(root, question);
+      const records = await loadPageRecords(root, slugs);
+      return jsonResult({ pages: records });
+    },
+  );
+}
+
+/** Resolve search candidates: prefer semantic search, fall back to LLM selection. */
+async function pickSearchSlugs(root: string, question: string): Promise<string[]> {
+  try {
+    const candidates = await findRelevantPages(root, question);
+    if (candidates.length > 0) return candidates.map((c) => c.slug);
+  } catch {
+    // Embeddings unavailable — fall through to index-based selection.
+  }
+
+  const indexContent = await safeReadFile(path.join(root, INDEX_FILE));
+  const { pages } = await selectPages(question, indexContent);
+  return pages;
+}
+
+function registerReadTool(server: McpServer, root: string): void {
+  server.registerTool(
+    "read_page",
+    {
+      title: "Read Page",
+      description:
+        "Read a single wiki page by slug. Searches concepts/ first, then queries/. " +
+        "Returns the parsed frontmatter and body. No LLM call required.",
+      inputSchema: {
+        slug: z.string().describe("Page slug, without .md extension."),
+      },
+    },
+    async ({ slug }) => {
+      const page = await readPage(root, slug);
+      if (!page) {
+        throw new Error(`Page not found: ${slug}`);
+      }
+      return jsonResult(page);
+    },
+  );
+}
+
+function registerLintTool(server: McpServer, root: string): void {
+  server.registerTool(
+    "lint_wiki",
+    {
+      title: "Lint Wiki",
+      description:
+        "Run rule-based quality checks (broken wikilinks, orphans, duplicates, " +
+        "empty pages, broken citations). Returns structured diagnostics. No LLM call.",
+      inputSchema: {},
+    },
+    async () => {
+      const summary = await lint(root);
+      return jsonResult(summary);
+    },
+  );
+}
+
+function registerStatusTool(server: McpServer, root: string): void {
+  server.registerTool(
+    "wiki_status",
+    {
+      title: "Wiki Status",
+      description:
+        "Summarize the wiki: page count, source count, last compile time, " +
+        "orphaned pages, and pending source changes. Read-only — never " +
+        "modifies the workspace.",
+      inputSchema: {},
+    },
+    async () => jsonResult(await collectStatus(root)),
+  );
+}
+
+/** Read-only status snapshot used by the wiki_status tool. */
+async function collectStatus(root: string): Promise<WikiStatus> {
+  const concepts = await collectPageSummaries(path.join(root, CONCEPTS_DIR));
+  const queries = await collectPageSummaries(path.join(root, QUERIES_DIR));
+  const state = await readState(root);
+  const changes = await detectChanges(root, state);
+  const orphans = await findOrphanedSlugs(root);
+  const compileTimes = Object.values(state.sources).map((s) => s.compiledAt);
+  const lastCompile = compileTimes.length > 0
+    ? compileTimes.sort().slice(-1)[0]
+    : null;
+
+  return {
+    pages: { concepts: concepts.length, queries: queries.length, total: concepts.length + queries.length },
+    sources: Object.keys(state.sources).length,
+    lastCompiledAt: lastCompile,
+    orphanedPages: orphans,
+    pendingChanges: changes
+      .filter((c) => c.status !== "unchanged")
+      .map((c) => ({ file: c.file, status: c.status })),
+  };
+}
+
+interface WikiStatus {
+  pages: { concepts: number; queries: number; total: number };
+  sources: number;
+  lastCompiledAt: string | null;
+  orphanedPages: string[];
+  pendingChanges: Array<{ file: string; status: string }>;
+}
+
+/** Find concept slugs whose pages are flagged as orphaned. */
+async function findOrphanedSlugs(root: string): Promise<string[]> {
+  const scanned = await scanWikiPages(path.join(root, CONCEPTS_DIR));
+  return scanned.filter(({ meta }) => meta.orphaned).map(({ slug }) => slug);
+}
+
+/** Load full content for a list of slugs, skipping missing/orphaned pages. */
+async function loadPageRecords(root: string, slugs: string[]): Promise<PageRecord[]> {
+  const records: PageRecord[] = [];
+  for (const slug of slugs) {
+    const page = await readPage(root, slug);
+    if (page) records.push(page);
+  }
+  return records;
+}
+
+/**
+ * Locate a page by slug across the priority-ordered page directories,
+ * skipping orphaned entries to match the query pipeline's behaviour.
+ */
+export async function readPage(root: string, slug: string): Promise<PageRecord | null> {
+  for (const dir of PAGE_DIRS) {
+    const content = await safeReadFile(path.join(root, dir, `${slug}.md`));
+    if (!content) continue;
+
+    const { meta, body } = parseFrontmatter(content);
+    if (meta.orphaned) continue;
+
+    return {
+      slug,
+      title: typeof meta.title === "string" ? meta.title : slug,
+      summary: typeof meta.summary === "string" ? meta.summary : "",
+      body: body.trim(),
+    };
+  }
+  return null;
+}
+

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -51,3 +51,29 @@ export interface PageSummary {
   slug: string;
   summary: string;
 }
+
+/** Structured result returned by the compile pipeline. */
+export interface CompileResult {
+  compiled: number;
+  skipped: number;
+  deleted: number;
+  concepts: string[];
+  pages: string[];
+  errors: string[];
+}
+
+/** Structured result returned by the query pipeline. */
+export interface QueryResult {
+  answer: string;
+  selectedPages: string[];
+  reasoning: string;
+  saved?: string;
+}
+
+/** Structured result returned by the ingest pipeline. */
+export interface IngestResult {
+  filename: string;
+  charCount: number;
+  truncated: boolean;
+  source: string;
+}

--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Tests for the MCP server's tool registration, resource resolution, and
+ * structured-output contracts. Avoids spinning up stdio transport — instead
+ * we drive registered handlers directly via the McpServer's internal maps,
+ * mirroring what an MCP client would invoke over the wire.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdir, rm, writeFile } from "fs/promises";
+import path from "path";
+import os from "os";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerWikiTools, readPage } from "../src/mcp/tools.js";
+import { registerWikiResources } from "../src/mcp/resources.js";
+import { writePage } from "./fixtures/write-page.js";
+
+let root: string;
+
+beforeEach(async () => {
+  root = path.join(os.tmpdir(), `llmwiki-mcp-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  await mkdir(path.join(root, "wiki/concepts"), { recursive: true });
+  await mkdir(path.join(root, "wiki/queries"), { recursive: true });
+  await mkdir(path.join(root, "sources"), { recursive: true });
+  await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+/** Build a fresh McpServer with all wiki tools and resources registered. */
+function buildServer(): McpServer {
+  const server = new McpServer({ name: "llmwiki-test", version: "0.0.0" });
+  registerWikiTools(server, root);
+  registerWikiResources(server, root);
+  return server;
+}
+
+/** Internal helper: read the server's registered-tool map. */
+function getRegisteredTools(server: McpServer): Record<string, unknown> {
+  return (server as unknown as { _registeredTools: Record<string, unknown> })._registeredTools;
+}
+
+/** Internal helper: read the server's registered-resource map. */
+function getRegisteredResources(server: McpServer): Record<string, unknown> {
+  return (server as unknown as { _registeredResources: Record<string, unknown> })._registeredResources;
+}
+
+/** Internal helper: read the server's registered resource-template map. */
+function getRegisteredResourceTemplates(server: McpServer): Record<string, unknown> {
+  return (server as unknown as { _registeredResourceTemplates: Record<string, unknown> })._registeredResourceTemplates;
+}
+
+/** Invoke a registered tool's handler and return its raw result. */
+async function callTool(
+  server: McpServer,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ content: Array<{ type: string; text: string }>; structuredContent?: { result: unknown } }> {
+  const tools = getRegisteredTools(server);
+  const tool = tools[name] as { handler: (args: Record<string, unknown>) => Promise<unknown> };
+  return tool.handler(args) as Promise<{ content: Array<{ type: string; text: string }>; structuredContent?: { result: unknown } }>;
+}
+
+describe("MCP server tool registration", () => {
+  it("registers all 7 expected tools", () => {
+    const server = buildServer();
+    const names = Object.keys(getRegisteredTools(server)).sort();
+    expect(names).toEqual([
+      "compile_wiki",
+      "ingest_source",
+      "lint_wiki",
+      "query_wiki",
+      "read_page",
+      "search_pages",
+      "wiki_status",
+    ]);
+  });
+
+  it("registers all 5 expected resources", () => {
+    const server = buildServer();
+    const staticUris = Object.keys(getRegisteredResources(server)).sort();
+    const templateNames = Object.keys(getRegisteredResourceTemplates(server)).sort();
+    expect(staticUris).toEqual(["llmwiki://index", "llmwiki://sources", "llmwiki://state"]);
+    expect(templateNames).toEqual(["wiki-concept", "wiki-query"]);
+  });
+});
+
+describe("ingest_source tool", () => {
+  it("returns IngestResult shape for a local file", async () => {
+    const sourceFile = path.join(root, "input.md");
+    await writeFile(
+      sourceFile,
+      "# Sample\n\nLong enough body to satisfy the minimum source character threshold for ingest.",
+    );
+
+    const server = buildServer();
+    const result = await callTool(server, "ingest_source", { source: sourceFile });
+    const payload = result.structuredContent?.result as Record<string, unknown>;
+
+    expect(payload).toMatchObject({
+      filename: expect.any(String),
+      charCount: expect.any(Number),
+      truncated: false,
+      source: sourceFile,
+    });
+  });
+});
+
+describe("compile_wiki tool", () => {
+  it("returns CompileResult shape when no sources exist", async () => {
+    process.env.ANTHROPIC_API_KEY = "test-key-not-actually-used";
+    const server = buildServer();
+    const result = await callTool(server, "compile_wiki", {});
+    const payload = result.structuredContent?.result as Record<string, unknown>;
+
+    expect(payload).toEqual(expect.objectContaining({
+      compiled: expect.any(Number),
+      skipped: expect.any(Number),
+      deleted: expect.any(Number),
+      concepts: expect.any(Array),
+      pages: expect.any(Array),
+      errors: expect.any(Array),
+    }));
+  });
+});
+
+describe("read_page tool and helper", () => {
+  it("reads a concept page", async () => {
+    await writePage(
+      path.join(root, "wiki/concepts"),
+      "neural-networks",
+      { title: "Neural Networks", summary: "ML model" },
+      "Deep learning basics.",
+    );
+
+    const page = await readPage(root, "neural-networks");
+    expect(page).toEqual({
+      slug: "neural-networks",
+      title: "Neural Networks",
+      summary: "ML model",
+      body: "Deep learning basics.",
+    });
+  });
+
+  it("falls back to queries dir when concept missing", async () => {
+    await writePage(
+      path.join(root, "wiki/queries"),
+      "what-is-x",
+      { title: "What is X?", summary: "An answer" },
+      "Saved query body.",
+    );
+
+    const page = await readPage(root, "what-is-x");
+    expect(page?.title).toBe("What is X?");
+    expect(page?.body).toBe("Saved query body.");
+  });
+
+  it("returns null when slug exists in neither directory", async () => {
+    expect(await readPage(root, "missing")).toBeNull();
+  });
+
+  it("read_page tool throws an error for missing pages", async () => {
+    const server = buildServer();
+    await expect(callTool(server, "read_page", { slug: "missing" })).rejects.toThrow(/not found/);
+  });
+});
+
+describe("wiki_status tool", () => {
+  it("returns expected status shape and does not modify the workspace", async () => {
+    await writePage(
+      path.join(root, "wiki/concepts"),
+      "alpha",
+      { title: "Alpha", summary: "First" },
+      "Body content.",
+    );
+
+    const beforeFiles = await snapshotWorkspace(root);
+    const server = buildServer();
+    const result = await callTool(server, "wiki_status", {});
+    const afterFiles = await snapshotWorkspace(root);
+
+    const status = result.structuredContent?.result as Record<string, unknown>;
+    expect(status).toEqual(expect.objectContaining({
+      pages: expect.objectContaining({ concepts: 1, queries: 0, total: 1 }),
+      sources: expect.any(Number),
+      orphanedPages: expect.any(Array),
+      pendingChanges: expect.any(Array),
+    }));
+    expect(afterFiles).toEqual(beforeFiles);
+  });
+});
+
+describe("error handling", () => {
+  it("query_wiki throws when wiki state is missing", async () => {
+    process.env.ANTHROPIC_API_KEY = "test-key";
+    const server = buildServer();
+    await expect(callTool(server, "query_wiki", { question: "anything" })).rejects.toThrow(/index not found/);
+  });
+
+  it("compile_wiki surfaces missing-credential errors", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
+    const originalSettingsPath = process.env.LLMWIKI_CLAUDE_SETTINGS_PATH;
+    process.env.LLMWIKI_CLAUDE_SETTINGS_PATH = path.join(root, "no-such-settings.json");
+    const server = buildServer();
+
+    try {
+      await expect(callTool(server, "compile_wiki", {})).rejects.toThrow(/Anthropic credentials/);
+    } finally {
+      if (originalSettingsPath !== undefined) {
+        process.env.LLMWIKI_CLAUDE_SETTINGS_PATH = originalSettingsPath;
+      } else {
+        delete process.env.LLMWIKI_CLAUDE_SETTINGS_PATH;
+      }
+    }
+  });
+});
+
+describe("MCP resources", () => {
+  it("resolves the wiki-index static resource", async () => {
+    await writeFile(path.join(root, "wiki/index.md"), "# Test Index\n");
+    const server = buildServer();
+    const resource = (getRegisteredResources(server) as Record<string, { readCallback: (uri: URL) => Promise<{ contents: Array<{ text: string }> }> }>)["llmwiki://index"];
+    const result = await resource.readCallback(new URL("llmwiki://index"));
+    expect(result.contents[0].text).toContain("Test Index");
+  });
+
+  it("resolves the wiki-state static resource", async () => {
+    const server = buildServer();
+    const resource = (getRegisteredResources(server) as Record<string, { readCallback: (uri: URL) => Promise<{ contents: Array<{ text: string }> }> }>)["llmwiki://state"];
+    const result = await resource.readCallback(new URL("llmwiki://state"));
+    const parsed = JSON.parse(result.contents[0].text);
+    expect(parsed).toMatchObject({ version: 1, sources: expect.any(Object) });
+  });
+
+  it("resolves the wiki-sources static resource", async () => {
+    await writeFile(
+      path.join(root, "sources/article.md"),
+      "---\ntitle: Article\nsource: example.com\n---\n\nbody",
+    );
+    const server = buildServer();
+    const resource = (getRegisteredResources(server) as Record<string, { readCallback: (uri: URL) => Promise<{ contents: Array<{ text: string }> }> }>)["llmwiki://sources"];
+    const result = await resource.readCallback(new URL("llmwiki://sources"));
+    const parsed = JSON.parse(result.contents[0].text);
+    expect(parsed).toEqual([expect.objectContaining({ filename: "article.md", title: "Article" })]);
+  });
+
+  it("resolves a wiki-concept template resource", async () => {
+    await writePage(
+      path.join(root, "wiki/concepts"),
+      "alpha",
+      { title: "Alpha", summary: "First" },
+      "Concept body.",
+    );
+
+    const server = buildServer();
+    const template = (getRegisteredResourceTemplates(server) as Record<string, { readCallback: (uri: URL, vars: Record<string, string>) => Promise<{ contents: Array<{ text: string }> }> }>)["wiki-concept"];
+    const result = await template.readCallback(
+      new URL("llmwiki://concept/alpha"),
+      { slug: "alpha" },
+    );
+    const parsed = JSON.parse(result.contents[0].text);
+    expect(parsed).toMatchObject({ slug: "alpha", body: "Concept body." });
+  });
+
+  it("resolves a wiki-query template resource", async () => {
+    await writePage(
+      path.join(root, "wiki/queries"),
+      "what-is-x",
+      { title: "What is X?", summary: "An answer" },
+      "Saved query body.",
+    );
+
+    const server = buildServer();
+    const template = (getRegisteredResourceTemplates(server) as Record<string, { readCallback: (uri: URL, vars: Record<string, string>) => Promise<{ contents: Array<{ text: string }> }> }>)["wiki-query"];
+    const result = await template.readCallback(
+      new URL("llmwiki://query/what-is-x"),
+      { slug: "what-is-x" },
+    );
+    const parsed = JSON.parse(result.contents[0].text);
+    expect(parsed).toMatchObject({ slug: "what-is-x", body: "Saved query body." });
+  });
+});
+
+/** Snapshot every file under root by relative path so we can detect mutations. */
+async function snapshotWorkspace(rootDir: string): Promise<string[]> {
+  const { readdir } = await import("fs/promises");
+  const entries: string[] = [];
+  async function walk(dir: string): Promise<void> {
+    const items = await readdir(dir, { withFileTypes: true });
+    for (const item of items) {
+      const full = path.join(dir, item.name);
+      if (item.isDirectory()) {
+        await walk(full);
+      } else {
+        entries.push(path.relative(rootDir, full));
+      }
+    }
+  }
+  await walk(rootDir);
+  return entries.sort();
+}
+


### PR DESCRIPTION
## Summary

Adds an MCP (Model Context Protocol) server (`llmwiki serve`) that exposes llmwiki's automated pipelines as tools so AI agents can ingest, compile, query, search, lint, and read pages programmatically.

Design philosophy: rather than handing agents raw CRUD primitives and making them do the bookkeeping, the MCP server exposes the automated pipelines — agents get intelligent compilation, incremental change detection, and semantic query routing built in.

## Changes

**API extraction (commit 1 — `33ced5c`)**
- New result types: `CompileResult`, `QueryResult`, `IngestResult` in `src/utils/types.ts`
- `compileAndReport()` returns structured compilation results; `runCompilePipeline` decomposed into focused phase helpers
- `generateAnswer()` extracted from `queryCommand()`, returns structured `QueryResult` (streams via `onToken` callback)
- `ingestSource()` extracted from `ingestCommand()`, returns `IngestResult`
- Exported `selectPages()` and `collectPageSummaries()` for MCP reuse

**MCP server (commit 2 — `60e72ef`)**
- `src/mcp/server.ts` — `startMCPServer()` wires `StdioServerTransport` to `McpServer`
- `src/mcp/tools.ts` — 7 tools: `ingest_source`, `compile_wiki`, `query_wiki`, `search_pages`, `read_page`, `lint_wiki`, `wiki_status`. Zod input schemas, structured + text output for client compatibility
- `src/mcp/resources.ts` — 5 resources: `llmwiki://index`, `llmwiki://sources`, `llmwiki://state`, `llmwiki://concept/{slug}`, `llmwiki://query/{slug}`
- `src/mcp/provider-check.ts` — per-tool credential validation (server starts without API keys; only LLM-using tools require them)
- `llmwiki serve [--root <dir>]` registered in CLI
- README updated: roadmap items marked ✅, new MCP Server section with Claude Desktop config example, tools/resources tables

## Test plan

- 16 new MCP server tests (211 total)
- `npm test` — all pass
- `fallow` — exit 0
- Live smoke test via stdio JSON-RPC: `initialize`, `tools/list`, `resources/list`, `resources/templates/list` all return correct shapes