### PR TITLE
Release v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-wiki-compiler",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-wiki-compiler",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-wiki-compiler",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "A knowledge compiler CLI — raw sources in, interlinked wiki out",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Bump version to 0.2.0 to mark completion of the initial roadmap.

## What shipped in 0.2.0

- **Paragraph-level source attribution** — `^[filename.md]` citation markers (#1)
- **`llmwiki lint` command** — 6 quality rules for wiki health (#2)
- **Obsidian integration** — tags, aliases, and auto-generated Map of Content (#3)
- **Multi-provider support** — OpenAI and Ollama backends alongside Anthropic (#2, then extended in #4 & #5 with Claude Code settings fallback and MiniMax)
- **Semantic search** — embedding-based query routing with top-K pre-filter (#6)
- **MCP server** — `llmwiki serve` exposes the automated pipelines as MCP tools and resources for AI agents (#7)

Tests grew from 91 → 211. Fallow clean (0 issues). CI blocks merges on type-check, build, tests, and fallow.