### PR TITLE
Add optional split embedding endpoints for OpenAI-compatible providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,43 @@ Example with zero exports (Claude Code already configured):
 llmwiki compile
 ```
 
+### OpenAI-Compatible Local Servers
+
+Use the OpenAI provider for local OpenAI-compatible servers such as
+`llama-server`. `OPENAI_BASE_URL` is used for chat/tool calls, and
+`OPENAI_EMBEDDINGS_BASE_URL` is optional. Set it only when embeddings are
+served from a different endpoint; when unset, embeddings use the same client
+and base URL as chat. Include `/v1` in custom URLs.
+
+Split endpoint example:
+
+```bash
+export LLMWIKI_PROVIDER=openai
+export LLMWIKI_MODEL=qwen3.6-35b
+export LLMWIKI_EMBEDDING_MODEL=text-embedding-model
+export OPENAI_API_KEY=sk-local
+export OPENAI_BASE_URL=http://host_url:port/v1
+export OPENAI_EMBEDDINGS_BASE_URL=http://host_url:port/v1
+```
+
+`OPENAI_API_KEY` is still required by the CLI and OpenAI SDK. For local
+servers that do not check authentication, any dummy value is sufficient.
+
+### Ollama
+
+Ollama uses its OpenAI-compatible endpoint. Set `OLLAMA_HOST` for chat and
+optionally set `OLLAMA_EMBEDDINGS_HOST` only when embeddings are served from a
+different endpoint. When unset, embeddings use `OLLAMA_HOST`. Include `/v1` in
+custom URLs.
+
+```bash
+export LLMWIKI_PROVIDER=ollama
+export LLMWIKI_MODEL=llama3.1
+export LLMWIKI_EMBEDDING_MODEL=nomic-embed-text
+export OLLAMA_HOST=http://ollama_host:11434/v1
+export OLLAMA_EMBEDDINGS_HOST=http://ollama_host:11435/v1
+```
+
 ## Why not just RAG?
 
 RAG retrieves chunks at query time. Every question re-discovers the same relationships from scratch. Nothing accumulates.

--- a/package-lock.json
+++ b/package-lock.json
@@ -164,7 +164,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -187,7 +186,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1837,7 +1835,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1943,7 +1940,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2264,7 +2260,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2437,7 +2432,6 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -2892,7 +2886,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2951,7 +2944,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3666,7 +3658,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3997,7 +3988,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4046,7 +4036,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/providers/minimax.ts
+++ b/src/providers/minimax.ts
@@ -13,6 +13,6 @@ const MINIMAX_BASE_URL = "https://api.minimax.io/v1";
 /** MiniMax-backed LLM provider using the OpenAI-compatible endpoint. */
 export class MiniMaxProvider extends OpenAIProvider {
   constructor(model: string, apiKey: string) {
-    super(model, MINIMAX_BASE_URL, apiKey);
+    super(model, { baseURL: MINIMAX_BASE_URL, apiKey });
   }
 }

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -8,14 +8,26 @@
 import { OpenAIProvider } from "./openai.js";
 import { EMBEDDING_MODELS } from "../utils/constants.js";
 
+/** Construction options for an Ollama-compatible provider. */
+interface OllamaProviderOptions {
+  baseURL: string;
+  embeddingsBaseURL?: string;
+  embeddingModel?: string;
+}
+
 /** Ollama-backed LLM provider using the OpenAI-compatible endpoint. */
 export class OllamaProvider extends OpenAIProvider {
-  constructor(model: string, baseURL: string) {
-    super(model, baseURL, "ollama");
+  constructor(model: string, options: OllamaProviderOptions) {
+    super(model, {
+      baseURL: options.baseURL,
+      apiKey: "ollama",
+      embeddingsBaseURL: options.embeddingsBaseURL,
+      embeddingModel: options.embeddingModel,
+    });
   }
 
   /** Ollama ships a dedicated embedding model (nomic-embed-text). */
   protected override embeddingModel(): string {
-    return EMBEDDING_MODELS.ollama;
+    return this.configuredEmbeddingModel ?? EMBEDDING_MODELS.ollama;
   }
 }

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -9,6 +9,14 @@ import OpenAI from "openai";
 import type { LLMProvider, LLMMessage, LLMTool } from "../utils/provider.js";
 import { EMBEDDING_MODELS } from "../utils/constants.js";
 
+/** Construction options for an OpenAI-compatible provider. */
+interface OpenAIProviderOptions {
+  baseURL?: string;
+  apiKey?: string;
+  embeddingsBaseURL?: string;
+  embeddingModel?: string;
+}
+
 /** Translate an Anthropic-style LLMTool to an OpenAI ChatCompletionTool. */
 export function translateToolToOpenAI(
   tool: LLMTool,
@@ -26,17 +34,23 @@ export function translateToolToOpenAI(
 /** OpenAI-backed LLM provider. */
 export class OpenAIProvider implements LLMProvider {
   protected readonly client: OpenAI;
+  protected readonly embeddingsClient: OpenAI;
   protected readonly model: string;
+  protected readonly configuredEmbeddingModel?: string;
 
-  constructor(model: string, baseURL?: string, apiKey?: string) {
+  constructor(model: string, options: OpenAIProviderOptions = {}) {
     this.model = model;
+    this.configuredEmbeddingModel = options.embeddingModel;
     // The OpenAI SDK validates OPENAI_API_KEY at construction time.
     // Pass the key explicitly so the provider controls when validation happens.
-    const resolvedKey = apiKey ?? process.env.OPENAI_API_KEY ?? "";
+    const resolvedKey = options.apiKey ?? process.env.OPENAI_API_KEY ?? "";
     this.client = new OpenAI({
       apiKey: resolvedKey,
-      ...(baseURL ? { baseURL } : {}),
+      baseURL: options.baseURL ?? null,
     });
+    this.embeddingsClient = options.embeddingsBaseURL
+      ? new OpenAI({ apiKey: resolvedKey, baseURL: options.embeddingsBaseURL })
+      : this.client;
   }
 
   /** Send a single non-streaming completion request. */
@@ -105,7 +119,7 @@ export class OpenAIProvider implements LLMProvider {
    * Subclasses (e.g. Ollama) override embeddingModel() to pick a different model.
    */
   async embed(text: string): Promise<number[]> {
-    const response = await this.client.embeddings.create({
+    const response = await this.embeddingsClient.embeddings.create({
       model: this.embeddingModel(),
       input: text,
     });
@@ -119,6 +133,6 @@ export class OpenAIProvider implements LLMProvider {
 
   /** Default embedding model for this provider. Subclasses may override. */
   protected embeddingModel(): string {
-    return EMBEDDING_MODELS.openai;
+    return this.configuredEmbeddingModel ?? EMBEDDING_MODELS.openai;
   }
 }

--- a/src/utils/embeddings.ts
+++ b/src/utils/embeddings.ts
@@ -105,6 +105,7 @@ export async function findRelevantPages(
 ): Promise<Array<{ slug: string; title: string; summary: string }>> {
   const store = await readEmbeddingStore(root);
   if (!store || store.entries.length === 0) return [];
+  if (store.model !== resolveEmbeddingModel()) return [];
 
   const queryVec = await getProvider().embed(question);
   return findTopK(queryVec, store, EMBEDDING_TOP_K).map((entry) => ({
@@ -173,7 +174,9 @@ async function embedPages(
 }
 
 /** Choose the active embedding model name, defaulting to anthropic's voyage model. */
-function resolveEmbeddingModel(): string {
+export function resolveEmbeddingModel(): string {
+  const configuredModel = process.env.LLMWIKI_EMBEDDING_MODEL?.trim();
+  if (configuredModel) return configuredModel;
   return EMBEDDING_MODELS[getActiveProviderName()] ?? EMBEDDING_MODELS.anthropic;
 }
 
@@ -200,17 +203,18 @@ function mergeEntries(
 export async function updateEmbeddings(root: string, changedSlugs: string[]): Promise<void> {
   const records = await collectPageRecords(root);
   const liveSlugs = new Set(records.map((r) => r.slug));
-  const toEmbed = new Set(changedSlugs.filter((slug) => liveSlugs.has(slug)));
-
+  const embeddingModel = resolveEmbeddingModel();
   const existingStore = await readEmbeddingStore(root);
-  const previousEntries = existingStore?.entries ?? [];
+  const modelChanged = Boolean(existingStore && existingStore.model !== embeddingModel);
+  const toEmbed = new Set(changedSlugs.filter((slug) => liveSlugs.has(slug)));
+  const previousEntries = modelChanged ? [] : existingStore?.entries ?? [];
 
   // Cold start: embed every page so the store is immediately useful.
-  if (!existingStore) {
+  if (!existingStore || modelChanged) {
     for (const record of records) toEmbed.add(record.slug);
   }
 
-  if (toEmbed.size === 0 && previousEntries.every((e) => liveSlugs.has(e.slug))) {
+  if (!modelChanged && toEmbed.size === 0 && previousEntries.every((e) => liveSlugs.has(e.slug))) {
     return;
   }
 
@@ -220,7 +224,7 @@ export async function updateEmbeddings(root: string, changedSlugs: string[]): Pr
   const dimensions = mergedEntries[0]?.vector.length ?? 0;
   const store: EmbeddingStore = {
     version: 1,
-    model: resolveEmbeddingModel(),
+    model: embeddingModel,
     dimensions,
     entries: mergedEntries,
   };

--- a/src/utils/embeddings.ts
+++ b/src/utils/embeddings.ts
@@ -175,9 +175,12 @@ async function embedPages(
 
 /** Choose the active embedding model name, defaulting to anthropic's voyage model. */
 export function resolveEmbeddingModel(): string {
+  const providerName = getActiveProviderName();
   const configuredModel = process.env.LLMWIKI_EMBEDDING_MODEL?.trim();
-  if (configuredModel) return configuredModel;
-  return EMBEDDING_MODELS[getActiveProviderName()] ?? EMBEDDING_MODELS.anthropic;
+  if (configuredModel && (providerName === "openai" || providerName === "ollama")) {
+    return configuredModel;
+  }
+  return EMBEDDING_MODELS[providerName] ?? EMBEDDING_MODELS.anthropic;
 }
 
 /** Merge fresh embeddings into an existing store, dropping slugs not in liveSlugs. */

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -65,17 +65,27 @@ export function getProvider(): LLMProvider {
     case "anthropic":
       return getAnthropicProvider();
     case "openai":
-      return new OpenAIProvider(getModelForProvider("openai"));
+      return new OpenAIProvider(getModelForProvider("openai"), {
+        baseURL: readOptionalEnv("OPENAI_BASE_URL"),
+        embeddingsBaseURL: readOptionalEnv("OPENAI_EMBEDDINGS_BASE_URL"),
+        embeddingModel: readOptionalEnv("LLMWIKI_EMBEDDING_MODEL"),
+      });
     case "ollama":
-      return new OllamaProvider(
-        getModelForProvider("ollama"),
-        process.env.OLLAMA_HOST ?? OLLAMA_DEFAULT_HOST,
-      );
+      return new OllamaProvider(getModelForProvider("ollama"), {
+        baseURL: readOptionalEnv("OLLAMA_HOST") ?? OLLAMA_DEFAULT_HOST,
+        embeddingsBaseURL: readOptionalEnv("OLLAMA_EMBEDDINGS_HOST"),
+        embeddingModel: readOptionalEnv("LLMWIKI_EMBEDDING_MODEL"),
+      });
     case "minimax":
       return getMiniMaxProvider();
     default:
       throw new Error(`Unhandled provider: ${providerName}`);
   }
+}
+
+function readOptionalEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
 }
 
 function getModelForProvider(providerName: "openai" | "ollama" | "minimax"): string {

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -19,7 +19,23 @@ interface StubCall {
 
 function stubOpenAIClient(provider: OpenAIProvider, vector: number[]): StubCall[] {
   const calls: StubCall[] = [];
-  const fakeClient = {
+  const fakeClient = makeEmbeddingStub(calls, vector);
+  // The OpenAI SDK clients are protected fields; override them for testing.
+  Reflect.set(provider, "client", fakeClient);
+  Reflect.set(provider, "embeddingsClient", fakeClient);
+  return calls;
+}
+
+function stubSplitClients(provider: OpenAIProvider): { chatCalls: StubCall[]; embedCalls: StubCall[] } {
+  const chatCalls: StubCall[] = [];
+  const embedCalls: StubCall[] = [];
+  Reflect.set(provider, "client", makeEmbeddingStub(chatCalls, [9]));
+  Reflect.set(provider, "embeddingsClient", makeEmbeddingStub(embedCalls, [1, 2, 3]));
+  return { chatCalls, embedCalls };
+}
+
+function makeEmbeddingStub(calls: StubCall[], vector: number[]): unknown {
+  return {
     embeddings: {
       create: async ({ model, input }: { model: string; input: string }) => {
         calls.push({ model, input });
@@ -27,14 +43,11 @@ function stubOpenAIClient(provider: OpenAIProvider, vector: number[]): StubCall[
       },
     },
   };
-  // The OpenAI SDK client is a protected field; override for testing.
-  Reflect.set(provider, "client", fakeClient);
-  return calls;
 }
 
 describe("OpenAIProvider.embed", () => {
   it("calls the embeddings API with text-embedding-3-small and returns the vector", async () => {
-    const provider = new OpenAIProvider("gpt-4o", undefined, "test-key");
+    const provider = new OpenAIProvider("gpt-4o", { apiKey: "test-key" });
     const expected = [0.1, 0.2, 0.3];
     const calls = stubOpenAIClient(provider, expected);
 
@@ -46,9 +59,42 @@ describe("OpenAIProvider.embed", () => {
     expect(calls[0].input).toBe("hello world");
   });
 
+  it("reuses the primary client when no embeddings URL is configured", () => {
+    const provider = new OpenAIProvider("gpt-4o", { apiKey: "test-key" });
+    expect(Reflect.get(provider, "embeddingsClient")).toBe(Reflect.get(provider, "client"));
+  });
+
+  it("uses a separate embeddings client when an embeddings URL is configured", async () => {
+    const provider = new OpenAIProvider("gpt-4o", {
+      apiKey: "test-key",
+      embeddingsBaseURL: "http://localhost:8081/v1",
+    });
+    const { chatCalls, embedCalls } = stubSplitClients(provider);
+
+    const result = await provider.embed("separate endpoint");
+
+    expect(result).toEqual([1, 2, 3]);
+    expect(chatCalls).toEqual([]);
+    expect(embedCalls).toEqual([
+      { model: EMBEDDING_MODELS.openai, input: "separate endpoint" },
+    ]);
+  });
+
+  it("uses a configured embedding model when provided", async () => {
+    const provider = new OpenAIProvider("gpt-4o", {
+      apiKey: "test-key",
+      embeddingModel: "local-embed",
+    });
+    const calls = stubOpenAIClient(provider, [0.4]);
+
+    await provider.embed("custom model");
+
+    expect(calls[0].model).toBe("local-embed");
+  });
+
   it("throws a clear error when the response is missing a vector", async () => {
-    const provider = new OpenAIProvider("gpt-4o", undefined, "test-key");
-    Reflect.set(provider, "client", {
+    const provider = new OpenAIProvider("gpt-4o", { apiKey: "test-key" });
+    Reflect.set(provider, "embeddingsClient", {
       embeddings: {
         create: async () => ({ data: [] }),
       },

--- a/test/embeddings.test.ts
+++ b/test/embeddings.test.ts
@@ -19,6 +19,7 @@ import {
   type EmbeddingEntry,
 } from "../src/utils/embeddings.js";
 import { OpenAIProvider } from "../src/providers/openai.js";
+import { EMBEDDING_MODELS } from "../src/utils/constants.js";
 
 const STORE_PATH = ".llmwiki/embeddings.json";
 
@@ -157,13 +158,21 @@ describe("embedding store persistence", () => {
 });
 
 describe("embedding model selection", () => {
-  it("uses LLMWIKI_EMBEDDING_MODEL when configured", () => {
+  it("uses LLMWIKI_EMBEDDING_MODEL when OpenAI is active", () => {
+    process.env.LLMWIKI_PROVIDER = "openai";
     process.env.LLMWIKI_EMBEDDING_MODEL = "local-embed";
     expect(resolveEmbeddingModel()).toBe("local-embed");
   });
 
+  it("ignores LLMWIKI_EMBEDDING_MODEL when Anthropic is active", () => {
+    process.env.LLMWIKI_PROVIDER = "anthropic";
+    process.env.LLMWIKI_EMBEDDING_MODEL = "local-embed";
+    expect(resolveEmbeddingModel()).toBe(EMBEDDING_MODELS.anthropic);
+  });
+
   it("ignores a mismatched store during semantic lookup", async () => {
     const root = await makeRoot();
+    process.env.LLMWIKI_PROVIDER = "openai";
     process.env.LLMWIKI_EMBEDDING_MODEL = "new-model";
     await writeEmbeddingStore(root, makeStore([makeEntry("alpha", [1, 0])]));
 

--- a/test/embeddings.test.ts
+++ b/test/embeddings.test.ts
@@ -3,18 +3,22 @@
  * Avoids real network calls — we test the pure helpers and JSON roundtrips.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { mkdtemp, writeFile, mkdir } from "fs/promises";
 import path from "path";
 import os from "os";
 import {
   cosineSimilarity,
   findTopK,
+  findRelevantPages,
   readEmbeddingStore,
+  resolveEmbeddingModel,
+  updateEmbeddings,
   writeEmbeddingStore,
   type EmbeddingStore,
   type EmbeddingEntry,
 } from "../src/utils/embeddings.js";
+import { OpenAIProvider } from "../src/providers/openai.js";
 
 const STORE_PATH = ".llmwiki/embeddings.json";
 
@@ -42,6 +46,19 @@ async function makeRoot(): Promise<string> {
   await mkdir(path.join(root, ".llmwiki"), { recursive: true });
   return root;
 }
+
+async function writeConceptPage(root: string, slug: string): Promise<void> {
+  await mkdir(path.join(root, "wiki/concepts"), { recursive: true });
+  const content = `---\ntitle: ${slug}\nsummary: Summary for ${slug}\n---\n\nBody`;
+  await writeFile(path.join(root, "wiki/concepts", `${slug}.md`), content);
+}
+
+afterEach(() => {
+  delete process.env.LLMWIKI_PROVIDER;
+  delete process.env.LLMWIKI_EMBEDDING_MODEL;
+  delete process.env.OPENAI_API_KEY;
+  vi.restoreAllMocks();
+});
 
 describe("cosineSimilarity", () => {
   it("returns 1 for identical vectors", () => {
@@ -136,5 +153,39 @@ describe("embedding store persistence", () => {
     // Create an unrelated file to confirm readEmbeddingStore checks the file, not the dir.
     await writeFile(path.join(root, ".llmwiki/other.json"), "{}");
     expect(await readEmbeddingStore(root)).toBeNull();
+  });
+});
+
+describe("embedding model selection", () => {
+  it("uses LLMWIKI_EMBEDDING_MODEL when configured", () => {
+    process.env.LLMWIKI_EMBEDDING_MODEL = "local-embed";
+    expect(resolveEmbeddingModel()).toBe("local-embed");
+  });
+
+  it("ignores a mismatched store during semantic lookup", async () => {
+    const root = await makeRoot();
+    process.env.LLMWIKI_EMBEDDING_MODEL = "new-model";
+    await writeEmbeddingStore(root, makeStore([makeEntry("alpha", [1, 0])]));
+
+    const result = await findRelevantPages(root, "alpha");
+
+    expect(result).toEqual([]);
+  });
+
+  it("rebuilds live page embeddings when the stored model changes", async () => {
+    const root = await makeRoot();
+    process.env.LLMWIKI_PROVIDER = "openai";
+    process.env.LLMWIKI_EMBEDDING_MODEL = "new-model";
+    process.env.OPENAI_API_KEY = "test-key";
+    vi.spyOn(OpenAIProvider.prototype, "embed").mockResolvedValue([0.9, 0.1]);
+    await writeConceptPage(root, "alpha");
+    await writeEmbeddingStore(root, makeStore([makeEntry("alpha", [1, 0])]));
+
+    await updateEmbeddings(root, []);
+    const store = await readEmbeddingStore(root);
+
+    expect(store?.model).toBe("new-model");
+    expect(store?.entries).toHaveLength(1);
+    expect(store?.entries[0].vector).toEqual([0.9, 0.1]);
   });
 });

--- a/test/provider-factory.test.ts
+++ b/test/provider-factory.test.ts
@@ -44,13 +44,23 @@ function expectAnthropicModel(expectedModel: string): void {
   expect(Reflect.get(provider, "model")).toBe(expectedModel);
 }
 
+function expectClientBaseURL(provider: object, field: string, expected: string): void {
+  expect(Reflect.get(Reflect.get(provider, field), "baseURL")).toBe(expected);
+}
+
 describe("getProvider", () => {
   afterEach(() => {
     delete process.env.LLMWIKI_PROVIDER;
     delete process.env.LLMWIKI_MODEL;
+    delete process.env.LLMWIKI_EMBEDDING_MODEL;
     delete process.env.ANTHROPIC_BASE_URL;
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.ANTHROPIC_AUTH_TOKEN;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_BASE_URL;
+    delete process.env.OPENAI_EMBEDDINGS_BASE_URL;
+    delete process.env.OLLAMA_HOST;
+    delete process.env.OLLAMA_EMBEDDINGS_HOST;
     delete process.env[TEST_SETTINGS_PATH_ENV];
     delete process.env.MINIMAX_API_KEY;
 
@@ -132,6 +142,47 @@ describe("getProvider", () => {
     // The model is stored as a protected field; verify it was accepted
     // by checking the provider was created without throwing
     expect(provider).toBeDefined();
+  });
+
+  it("passes OpenAI chat and embedding base URLs separately", () => {
+    process.env.LLMWIKI_PROVIDER = "openai";
+    process.env.OPENAI_BASE_URL = "http://localhost:8080/v1";
+    process.env.OPENAI_EMBEDDINGS_BASE_URL = "http://localhost:8081/v1";
+    process.env.LLMWIKI_EMBEDDING_MODEL = "local-embed";
+
+    const provider = getProvider();
+
+    expect(provider).toBeInstanceOf(OpenAIProvider);
+    expectClientBaseURL(provider, "client", "http://localhost:8080/v1");
+    expectClientBaseURL(provider, "embeddingsClient", "http://localhost:8081/v1");
+    expect(Reflect.get(provider, "configuredEmbeddingModel")).toBe("local-embed");
+  });
+
+  it("passes Ollama chat and embedding hosts separately", () => {
+    process.env.LLMWIKI_PROVIDER = "ollama";
+    process.env.OLLAMA_HOST = "http://localhost:11434/v1";
+    process.env.OLLAMA_EMBEDDINGS_HOST = "http://localhost:11435/v1";
+    process.env.LLMWIKI_EMBEDDING_MODEL = "nomic-local";
+
+    const provider = getProvider();
+
+    expect(provider).toBeInstanceOf(OllamaProvider);
+    expectClientBaseURL(provider, "client", "http://localhost:11434/v1");
+    expectClientBaseURL(provider, "embeddingsClient", "http://localhost:11435/v1");
+    expect(Reflect.get(provider, "configuredEmbeddingModel")).toBe("nomic-local");
+  });
+
+  it("ignores whitespace-only optional OpenAI endpoint vars", () => {
+    process.env.LLMWIKI_PROVIDER = "openai";
+    process.env.OPENAI_BASE_URL = "  ";
+    process.env.OPENAI_EMBEDDINGS_BASE_URL = "  ";
+    process.env.LLMWIKI_EMBEDDING_MODEL = "  ";
+
+    const provider = getProvider();
+
+    expect(provider).toBeInstanceOf(OpenAIProvider);
+    expect(Reflect.get(provider, "embeddingsClient")).toBe(Reflect.get(provider, "client"));
+    expect(Reflect.get(provider, "configuredEmbeddingModel")).toBeUndefined();
   });
 
   it("ignores anthropic base url for non-anthropic providers", () => {


### PR DESCRIPTION
Adds support for running chat and embeddings against separate OpenAI-compatible endpoints, which is useful for local/distributed setups where a chat model and embedding model are served by different processes. The feature is optional and preserves existing behavior when no separate embedding endpoint is configured.

Key Changes

- Add optional OPENAI_EMBEDDINGS_BASE_URL support for OpenAI-compatible providers
- Add optional OLLAMA_EMBEDDINGS_HOST support for Ollama
- Add LLMWIKI_EMBEDDING_MODEL for OpenAI/Ollama embedding model overrides
- Reuse the normal chat client for embeddings when no split endpoint is configured
- Rebuild or bypass embedding stores when the active embedding model changes
- Scope LLMWIKI_EMBEDDING_MODEL to OpenAI/Ollama so Anthropic continues using its Voyage default
- Update README docs with local split-endpoint examples and optional endpoint behavior
- Add tests for split clients, provider env wiring, embedding model overrides, and model mismatch handling

Why
Some local LLM serving setups, such as llama-server, run one model per server process (or the setup requires running servers on separate host devices). That means a chat model and an embedding model often need separate OpenAI-compatible endpoints. This change makes that setup possible without requiring a new provider or changing the default behavior for existing OpenAI/Ollama users.

Tested on my local llama-server setup by following these steps:

1. Build a local fork
```bash
npm install
npm run build
```

2. Launch local llama.cpp servers

```bash
# Chat model server
llama-server \
  -hf unsloth/gemma-4-E4B-it-GGUF \
  --host 0.0.0.0 \
  --port 8080 \
  --ctx-size 32768
```
```bash
# Embedding model server
llama-server \
  -hf nomic-ai/nomic-embed-text-v1.5-GGUF \
  --host 0.0.0.0 \
  --port 8081 \
  --embedding \
  --pooling cls
```

3. Create a Temporary wiki

```bash
mkdir -p /tmp/llmwiki-split-endpoint-test
cd /tmp/llmwiki-split-endpoint-test
node path/to/llm-wiki-compiler/dist/cli.js ingest https://en.wikipedia.org/wiki/Andrej_Karpathy
```

4. Configure an OpenAI-compatible split endpoint setup (or add them to local .env in the temporary wiki): 

```bash
export LLMWIKI_PROVIDER=openai
export LLMWIKI_MODEL=unsloth/gemma-4-E4B-it-GGUF
export LLMWIKI_EMBEDDING_MODEL=nomic-ai/nomic-embed-text-v1.5-GGUF:F32
export OPENAI_API_KEY=sk-whatever
export OPENAI_BASE_URL=http://127.0.0.1:8080/v1
export OPENAI_EMBEDDINGS_BASE_URL=http://127.0.0.1:8081/v1
```

5. Run the local build directly:
```bash
node /path/to/llm-wiki-compiler/dist/cli.js compile
node /path/to/llm-wiki-compiler/dist/cli.js query "What does the source say about embedding endpoints?"
```

