### PR TITLE
Warn when embedding store is stale after a model change

### DIFF
--- a/src/utils/embeddings.ts
+++ b/src/utils/embeddings.ts
@@ -105,7 +105,11 @@ export async function findRelevantPages(
 ): Promise<Array<{ slug: string; title: string; summary: string }>> {
   const store = await readEmbeddingStore(root);
   if (!store || store.entries.length === 0) return [];
-  if (store.model !== resolveEmbeddingModel()) return [];
+  const activeModel = resolveEmbeddingModel();
+  if (store.model !== activeModel) {
+    warnStaleEmbeddingStore(store.model, activeModel);
+    return [];
+  }
 
   const queryVec = await getProvider().embed(question);
   return findTopK(queryVec, store, EMBEDDING_TOP_K).map((entry) => ({
@@ -171,6 +175,28 @@ async function embedPages(
     });
   }
   return fresh;
+}
+
+/** Tracks which (stored, active) model pairs have already been warned about. */
+const warnedStaleModels = new Set<string>();
+
+/** Warn once per (stored, active) model pair so queries stay quiet on repeat runs. */
+function warnStaleEmbeddingStore(storedModel: string, activeModel: string): void {
+  const key = `${storedModel}→${activeModel}`;
+  if (warnedStaleModels.has(key)) return;
+  warnedStaleModels.add(key);
+  output.status(
+    "!",
+    output.warn(
+      `Embedding store was built with "${storedModel}" but active embedding model is "${activeModel}". ` +
+      `Falling back to full-index selection. Run 'llmwiki compile' to rebuild embeddings.`,
+    ),
+  );
+}
+
+/** Test-only hook: clear the warned-pair cache so each test sees a fresh warning. */
+export function resetStaleEmbeddingWarnings(): void {
+  warnedStaleModels.clear();
 }
 
 /** Choose the active embedding model name, defaulting to anthropic's voyage model. */

--- a/test/embeddings.test.ts
+++ b/test/embeddings.test.ts
@@ -12,6 +12,7 @@ import {
   findTopK,
   findRelevantPages,
   readEmbeddingStore,
+  resetStaleEmbeddingWarnings,
   resolveEmbeddingModel,
   updateEmbeddings,
   writeEmbeddingStore,
@@ -58,6 +59,7 @@ afterEach(() => {
   delete process.env.LLMWIKI_PROVIDER;
   delete process.env.LLMWIKI_EMBEDDING_MODEL;
   delete process.env.OPENAI_API_KEY;
+  resetStaleEmbeddingWarnings();
   vi.restoreAllMocks();
 });
 
@@ -179,6 +181,23 @@ describe("embedding model selection", () => {
     const result = await findRelevantPages(root, "alpha");
 
     expect(result).toEqual([]);
+  });
+
+  it("warns once when the stored model differs from the active model", async () => {
+    const root = await makeRoot();
+    process.env.LLMWIKI_PROVIDER = "openai";
+    process.env.LLMWIKI_EMBEDDING_MODEL = "new-model";
+    await writeEmbeddingStore(root, makeStore([makeEntry("alpha", [1, 0])]));
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await findRelevantPages(root, "alpha");
+    await findRelevantPages(root, "alpha");
+
+    const warnings = log.mock.calls.filter(([line]) =>
+      typeof line === "string" && line.includes("Falling back to full-index"),
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0][0]).toContain('"new-model"');
   });
 
   it("rebuilds live page embeddings when the stored model changes", async () => {

--- a/test/embeddings.test.ts
+++ b/test/embeddings.test.ts
@@ -173,10 +173,7 @@ describe("embedding model selection", () => {
   });
 
   it("ignores a mismatched store during semantic lookup", async () => {
-    const root = await makeRoot();
-    process.env.LLMWIKI_PROVIDER = "openai";
-    process.env.LLMWIKI_EMBEDDING_MODEL = "new-model";
-    await writeEmbeddingStore(root, makeStore([makeEntry("alpha", [1, 0])]));
+    const root = await setupOpenAIWithStaleStore();
 
     const result = await findRelevantPages(root, "alpha");
 
@@ -184,10 +181,7 @@ describe("embedding model selection", () => {
   });
 
   it("warns once when the stored model differs from the active model", async () => {
-    const root = await makeRoot();
-    process.env.LLMWIKI_PROVIDER = "openai";
-    process.env.LLMWIKI_EMBEDDING_MODEL = "new-model";
-    await writeEmbeddingStore(root, makeStore([makeEntry("alpha", [1, 0])]));
+    const root = await setupOpenAIWithStaleStore();
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
 
     await findRelevantPages(root, "alpha");
@@ -201,13 +195,10 @@ describe("embedding model selection", () => {
   });
 
   it("rebuilds live page embeddings when the stored model changes", async () => {
-    const root = await makeRoot();
-    process.env.LLMWIKI_PROVIDER = "openai";
-    process.env.LLMWIKI_EMBEDDING_MODEL = "new-model";
+    const root = await setupOpenAIWithStaleStore();
     process.env.OPENAI_API_KEY = "test-key";
     vi.spyOn(OpenAIProvider.prototype, "embed").mockResolvedValue([0.9, 0.1]);
     await writeConceptPage(root, "alpha");
-    await writeEmbeddingStore(root, makeStore([makeEntry("alpha", [1, 0])]));
 
     await updateEmbeddings(root, []);
     const store = await readEmbeddingStore(root);
@@ -217,3 +208,12 @@ describe("embedding model selection", () => {
     expect(store?.entries[0].vector).toEqual([0.9, 0.1]);
   });
 });
+
+/** Set up an OpenAI provider with an embedding store whose model is now stale. */
+async function setupOpenAIWithStaleStore(): Promise<string> {
+  const root = await makeRoot();
+  process.env.LLMWIKI_PROVIDER = "openai";
+  process.env.LLMWIKI_EMBEDDING_MODEL = "new-model";
+  await writeEmbeddingStore(root, makeStore([makeEntry("alpha", [1, 0])]));
+  return root;
+}


### PR DESCRIPTION
## Summary

Followup to #12. When the embedding store on disk was built with a different model than the one currently active (e.g. user switched `LLMWIKI_EMBEDDING_MODEL` mid-project), `findRelevantPages` silently returns `[]` and falls back to full-index selection. Users had no way to know their semantic search was degraded until the next `compile`.

This PR adds a one-time warning per `(stored, active)` model pair pointing them at `llmwiki compile` to rebuild.

## Why one-time?

Queries are interactive — repeating the same warning on every call would be noisy. The dedup is keyed on the stored/active pair so a second mismatch (e.g. user switches models again) still warns.

## Test plan

- [x] `npm test` — 222 passing (new test verifies warning fires once across two `findRelevantPages` calls)
- [x] `npm run build` — builds clean
- [x] `npx tsc --noEmit` — type-check clean
- [x] `fallow` — 0 issues