### PR TITLE
Refresh README roadmap with post-0.2.0 themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,17 +269,26 @@ Karpathy describes an abstract pattern for turning raw data into compiled knowle
 
 ## Roadmap
 
+Shipped in 0.2.0:
+
 - ✅ Better provenance (paragraph-level source attribution)
 - ✅ Linting pass for wiki quality checks
 - ✅ Multi-provider support (OpenAI, Ollama, MiniMax)
 - ✅ Larger-corpus query strategy (semantic search, embeddings)
 - ✅ Deeper Obsidian integration (tags, aliases, Map of Content)
 - ✅ MCP server for agent integration
-- Image support
-- Marp slides
-- Fine-tuning
 
-If you want to contribute, these are the highest-leverage areas right now. Issues and PRs are welcome.
+Next up:
+
+- Candidate review queue (approve compile output before pages are written)
+- Confidence and contradiction metadata on compiled pages
+- Claim-level provenance with source ranges
+- Multimodal ingest (images, PDFs, transcripts)
+- Chunked retrieval with reranking
+- Export bundle (`llms.txt`, JSON, JSON-LD, GraphML, Marp)
+- Session-history adapters (Claude, Codex, Cursor exports)
+
+If you like ambitious problems: **claim-level provenance**, **chunked retrieval with reranking**, and **confidence/contradiction metadata** are the meatiest. Open an issue to claim one or kick off a design discussion.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

The README roadmap still lists "Image support / Marp slides / Fine-tuning" from before 0.2.0. Replaces it with the seven themes from our internal next-feature plan, plus a callout pointing ambitious contributors at the meatiest items.

## Changes

- Splits the roadmap into "Shipped in 0.2.0" (the existing ✅ list) and "Next up" (the new themes)
- Adds an invitation line flagging claim-level provenance, chunked retrieval, and confidence/contradiction metadata as the most challenging items

The Karpathy-pattern table is unchanged — those items map his concepts and remain accurate as "not yet implemented."

## Test plan

- [x] README renders correctly (markdown only, no code changes)