### PR TITLE
Pin fallow CI version to 2.42.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: fallow-rs/fallow@v2
         with:
+          version: 2.42.0
           format: sarif
           fail-on-issues: true
       - uses: github/codeql-action/upload-sarif@v4


### PR DESCRIPTION
The `fallow-rs/fallow@v2` action installs the latest fallow binary by default. Between Apr 21 and Apr 22 the floating tag advanced from 2.42.0 to 2.45.0, which raised complexity thresholds and started flagging two preexisting functions (`requireProvider` in `src/cli.ts`, `triggerCompile` in `src/commands/watch.ts`). This broke CI on PR #15 even though that PR doesn't touch either file.

Pinning the binary to 2.42.0 restores deterministic CI. Future fallow upgrades should be intentional bumps, not silent ones from a floating tag.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, re-run CI on PR #15 (or click "Update branch") and confirm codebase-health is green