### PR TITLE
Add husky pre-commit and pre-push hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+npx fallow
+npx tsc --noEmit

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,2 @@
+npm run build
+npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,16 +34,23 @@ npm test         # Run all tests
 npm run dev      # Watch mode for development
 ```
 
-**Before submitting a PR, run all checks:**
+**Automatic checks via git hooks:**
+
+After `npm install`, husky wires up hooks that run automatically:
+
+- **pre-commit** — `fallow` (codebase health) and `npx tsc --noEmit` (type check)
+- **pre-push** — `npm run build` and `npm test`
+
+If a hook fails, fix the underlying issue rather than bypassing with `--no-verify`. Use `fallow fix --yes` to auto-fix unused exports, then address remaining issues manually.
+
+You can also run the full suite manually:
 
 ```bash
 npx tsc --noEmit   # Type-check
 npm run build       # Build
 npm test            # Tests
-fallow              # Codebase health (dead code, duplication, complexity)
+npx fallow          # Codebase health (dead code, duplication, complexity)
 ```
-
-All tests must pass and fallow must report no issues. Use `fallow fix --yes` to auto-fix unused exports, then fix any remaining issues manually.
 
 ### Code Style
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,8 @@
         "@types/js-yaml": "^4.0.9",
         "@types/jsdom": "^21.1.0",
         "@types/turndown": "^5.0.0",
+        "fallow": "2.42.0",
+        "husky": "^9.1.7",
         "tsup": "^8.0.0",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
@@ -164,6 +166,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -186,6 +189,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -631,6 +635,104 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@fallow-cli/darwin-arm64": {
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-arm64/-/darwin-arm64-2.42.0.tgz",
+      "integrity": "sha512-q8stSKzu4dXm7xQgTSqjkLxMs3MT+W/B+QU1WcbHgT6DacDHRmqPQvtHkapwb/+nyqXxwcAm1Ru/bsXi7nL8mQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@fallow-cli/darwin-x64": {
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-x64/-/darwin-x64-2.42.0.tgz",
+      "integrity": "sha512-NnKyrQfkTrmLkrO/I1Y7wa3pAbFsXQXK5paMziD3GA9Fbp5jeo85wGFEGKje8n2imao9fAPHA9Q8neWBVX/2rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-arm64-gnu": {
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-gnu/-/linux-arm64-gnu-2.42.0.tgz",
+      "integrity": "sha512-22SGHnIgt8YA4FRVBzpoBbvxtSXeejFXB55fscoZy+Ea5bJthWWcMz3Y9ei1SFnV+smepELGrRqlySasVvkxVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-arm64-musl": {
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-musl/-/linux-arm64-musl-2.42.0.tgz",
+      "integrity": "sha512-luwSD51Bs13lg2aN0ab8J7QKhNYxsGPicQLshHqLQ1PThCkTT7kktpIRdPU0hhqvonNj5AT6oJIKQ4PW2yvUig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-x64-gnu": {
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-gnu/-/linux-x64-gnu-2.42.0.tgz",
+      "integrity": "sha512-Xc40+hxkVpPa2VoKKzyYmSdStjIYdu/kQF7zBwR5ZtdOSqW0rj7bcqDZtt7l9/mp2SjlTol/0n+aRofggYWb+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-x64-musl": {
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-musl/-/linux-x64-musl-2.42.0.tgz",
+      "integrity": "sha512-NoO5ZmwUKej6vx8/C2+AnLSlmwolwc0HFo0YAd5awGyjVve5WK+UBy7U41CnmFoWSkg2ROnpEWyhKAM3ugzpKA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/win32-x64-msvc": {
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/win32-x64-msvc/-/win32-x64-msvc-2.42.0.tgz",
+      "integrity": "sha512-mxiTCFPQ1hvmoKTEEJltT2k23rmoKpxTemR3aGstoCG4TwHhT+7az26XWW2kgUV2vEC8bufcZoFKxAYMs5UJjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
@@ -1723,6 +1825,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.4.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
@@ -1835,6 +1947,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1940,6 +2053,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1994,6 +2108,34 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
+      }
+    },
+    "node_modules/fallow": {
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/fallow/-/fallow-2.42.0.tgz",
+      "integrity": "sha512-NOUQ07heEvL6RlPD2bBsY11WtvhN19sSTmuM+oeqR4wAFVx4LdsQZUz0cTxRrmob0nH429khsTH24e2lVOMfXw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "2.1.2"
+      },
+      "bin": {
+        "fallow": "bin/fallow",
+        "fallow-lsp": "bin/fallow-lsp",
+        "fallow-mcp": "bin/fallow-mcp"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@fallow-cli/darwin-arm64": "2.42.0",
+        "@fallow-cli/darwin-x64": "2.42.0",
+        "@fallow-cli/linux-arm64-gnu": "2.42.0",
+        "@fallow-cli/linux-arm64-musl": "2.42.0",
+        "@fallow-cli/linux-x64-gnu": "2.42.0",
+        "@fallow-cli/linux-x64-musl": "2.42.0",
+        "@fallow-cli/win32-x64-msvc": "2.42.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2260,6 +2402,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2329,6 +2472,22 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -2432,6 +2591,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -2886,6 +3046,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2944,6 +3105,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3658,6 +3820,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3703,6 +3866,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3988,6 +4152,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4036,6 +4201,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",
-    "prepublishOnly": "npm run build && npm test"
+    "prepublishOnly": "npm run build && npm test",
+    "prepare": "husky"
   },
   "keywords": [
     "knowledge",
@@ -57,6 +58,8 @@
     "@types/js-yaml": "^4.0.9",
     "@types/jsdom": "^21.1.0",
     "@types/turndown": "^5.0.0",
+    "fallow": "2.42.0",
+    "husky": "^9.1.7",
     "tsup": "^8.0.0",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"


### PR DESCRIPTION
Adds git hooks via husky so local development catches regressions before they reach CI.

- **pre-commit** runs the fast checks: `npx fallow` + `npx tsc --noEmit` (~1s total)
- **pre-push** runs the slow checks: `npm run build` + `npm test` (~15s)

This matches the "fast on commit, slow on push" pattern so the inner loop stays tight while still catching test regressions before they leave the machine.

Also pins `fallow` to `2.42.0` as a devDependency. Combined with the CI pin in #16, local and CI now use the same fallow version. `npx fallow` in the hook resolves to the pinned local copy.

CONTRIBUTING.md updated to describe the hook behavior.

## Test plan
- [x] Pre-commit hook fires on commit and passes cleanly
- [x] Pre-push hook fires on push and passes cleanly
- [ ] CI is green on this PR