### PR TITLE
Add candidate review queue for compile outputs

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,10 @@ import compileCommand from "./commands/compile.js";
 import queryCommand from "./commands/query.js";
 import watchCommand from "./commands/watch.js";
 import lintCommand from "./commands/lint.js";
+import reviewListCommand from "./commands/review-list.js";
+import reviewShowCommand from "./commands/review-show.js";
+import reviewApproveCommand from "./commands/review-approve.js";
+import reviewRejectCommand from "./commands/review-reject.js";
 import { startMCPServer } from "./mcp/server.js";
 import { DEFAULT_PROVIDER } from "./utils/constants.js";
 import { resolveAnthropicAuthFromEnv } from "./utils/claude-settings.js";
@@ -43,10 +47,66 @@ program
 program
   .command("compile")
   .description("Compile sources/ into an interlinked wiki")
-  .action(async () => {
+  .option(
+    "--review",
+    "Write generated pages as review candidates under .llmwiki/candidates/ instead of mutating wiki/",
+  )
+  .action(async (options: { review?: boolean }) => {
     try {
       requireProvider();
-      await compileCommand();
+      await compileCommand({ review: options.review });
+    } catch (err) {
+      console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
+      process.exit(1);
+    }
+  });
+
+const reviewCommand = program
+  .command("review")
+  .description("Inspect and act on pending compile review candidates");
+
+reviewCommand
+  .command("list")
+  .description("List pending review candidates")
+  .action(async () => {
+    try {
+      await reviewListCommand();
+    } catch (err) {
+      console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
+      process.exit(1);
+    }
+  });
+
+reviewCommand
+  .command("show <id>")
+  .description("Print a single candidate's metadata and body")
+  .action(async (id: string) => {
+    try {
+      await reviewShowCommand(id);
+    } catch (err) {
+      console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
+      process.exit(1);
+    }
+  });
+
+reviewCommand
+  .command("approve <id>")
+  .description("Approve a candidate and promote it into wiki/concepts/")
+  .action(async (id: string) => {
+    try {
+      await reviewApproveCommand(id);
+    } catch (err) {
+      console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
+      process.exit(1);
+    }
+  });
+
+reviewCommand
+  .command("reject <id>")
+  .description("Reject a candidate and archive it without touching wiki/")
+  .action(async (id: string) => {
+    try {
+      await reviewRejectCommand(id);
     } catch (err) {
       console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
       process.exit(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,7 +49,7 @@ program
   .description("Compile sources/ into an interlinked wiki")
   .option(
     "--review",
-    "Write generated pages as review candidates under .llmwiki/candidates/ instead of mutating wiki/",
+    "Write generated pages as review candidates under .llmwiki/candidates/ instead of mutating wiki/. Orphan-marking for deleted sources is deferred until the next non-review compile.",
   )
   .action(async (options: { review?: boolean }) => {
     try {

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -8,12 +8,14 @@ import { existsSync } from "fs";
 import { compile } from "../compiler/index.js";
 import * as output from "../utils/output.js";
 import { SOURCES_DIR } from "../utils/constants.js";
+import type { CompileOptions } from "../utils/types.js";
 
 /**
  * Run the compile command from the current working directory.
  * Exits early if no sources directory exists yet.
+ * @param options - Optional behaviour overrides forwarded from the CLI flag set.
  */
-export default async function compileCommand(): Promise<void> {
+export default async function compileCommand(options: CompileOptions = {}): Promise<void> {
   if (!existsSync(SOURCES_DIR)) {
     output.status(
       "!",
@@ -22,5 +24,5 @@ export default async function compileCommand(): Promise<void> {
     return;
   }
 
-  await compile(process.cwd());
+  await compile(process.cwd(), options);
 }

--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -12,7 +12,11 @@ import {
   atomicWrite,
   validateWikiPage,
 } from "../utils/markdown.js";
-import { deleteCandidate, loadCandidateOrFail } from "../compiler/candidates.js";
+import {
+  deleteCandidate,
+  listCandidates,
+  loadCandidateOrFail,
+} from "../compiler/candidates.js";
 import { generateIndex } from "../compiler/indexgen.js";
 import { generateMOC } from "../compiler/obsidian.js";
 import { resolveLinks } from "../compiler/resolver.js";
@@ -50,6 +54,13 @@ export default async function reviewApproveCommand(id: string): Promise<void> {
  * compiled. Without this, approved candidates would re-appear on the next
  * `compile` run because the source still looks "new" or "changed" to the
  * change detector.
+ *
+ * When a single source produced multiple candidates (e.g. an extraction
+ * yielded several concepts), persisting state on the first approval would
+ * mark the source as fully compiled and silently strand the remaining
+ * pending candidates — the next `compile --review` would skip the source
+ * entirely. To avoid that, we only persist a source's state when no OTHER
+ * pending candidate still references that source filename.
  */
 async function persistCandidateSourceStates(
   root: string,
@@ -57,9 +68,29 @@ async function persistCandidateSourceStates(
 ): Promise<void> {
   const states = candidate.sourceStates;
   if (!states) return;
+  const otherSources = await collectOtherCandidateSources(root, candidate.id);
   for (const [sourceFile, entry] of Object.entries(states)) {
+    if (otherSources.has(sourceFile)) continue;
     await updateSourceState(root, sourceFile, entry);
   }
+}
+
+/**
+ * Build the set of source filenames referenced by every pending candidate
+ * other than the one currently being approved. Used to defer source-state
+ * persistence until the LAST candidate from a given source is reviewed.
+ */
+async function collectOtherCandidateSources(
+  root: string,
+  approvingId: string,
+): Promise<Set<string>> {
+  const pending = await listCandidates(root);
+  const sources = new Set<string>();
+  for (const candidate of pending) {
+    if (candidate.id === approvingId) continue;
+    for (const source of candidate.sources) sources.add(source);
+  }
+  return sources;
 }
 
 /** Refresh interlinks, index, MOC, and embeddings after writing a candidate. */

--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -5,6 +5,11 @@
  * wiki/concepts/<slug>.md, refreshes the index/MOC, updates embeddings, and
  * removes the candidate file. Approval never re-invokes the LLM — the body
  * stored in the candidate is written verbatim.
+ *
+ * All mutations are performed under `.llmwiki/lock` to prevent races with a
+ * concurrent compile or sibling approve/reject. The lock is acquired before
+ * the `listCandidates` call inside `persistCandidateSourceStates` so that the
+ * sibling-candidate read is also serialized.
  */
 
 import path from "path";
@@ -22,6 +27,7 @@ import { generateMOC } from "../compiler/obsidian.js";
 import { resolveLinks } from "../compiler/resolver.js";
 import { updateEmbeddings } from "../utils/embeddings.js";
 import { updateSourceState } from "../utils/state.js";
+import { acquireLock, releaseLock } from "../utils/lock.js";
 import { CONCEPTS_DIR } from "../utils/constants.js";
 import * as output from "../utils/output.js";
 import type { ReviewCandidate } from "../utils/types.js";
@@ -38,6 +44,29 @@ export default async function reviewApproveCommand(id: string): Promise<void> {
     return;
   }
 
+  const locked = await acquireLock(root);
+  if (!locked) {
+    output.status("!", output.error("Could not acquire lock. Try again later."));
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    await approveUnderLock(root, id, candidate);
+  } finally {
+    await releaseLock(root);
+  }
+}
+
+/**
+ * Perform all wiki mutations for an approval while holding the lock.
+ * Separated so the lock acquire/release wrapper stays under 40 lines.
+ */
+async function approveUnderLock(
+  root: string,
+  id: string,
+  candidate: ReviewCandidate,
+): Promise<void> {
   const pagePath = path.join(root, CONCEPTS_DIR, `${candidate.slug}.md`);
   await atomicWrite(pagePath, candidate.body);
   output.status("+", output.success(`Approved → ${output.source(pagePath)}`));

--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -17,8 +17,10 @@ import { generateIndex } from "../compiler/indexgen.js";
 import { generateMOC } from "../compiler/obsidian.js";
 import { resolveLinks } from "../compiler/resolver.js";
 import { updateEmbeddings } from "../utils/embeddings.js";
+import { updateSourceState } from "../utils/state.js";
 import { CONCEPTS_DIR } from "../utils/constants.js";
 import * as output from "../utils/output.js";
+import type { ReviewCandidate } from "../utils/types.js";
 
 /** Approve a pending candidate by promoting its body into wiki/concepts/. */
 export default async function reviewApproveCommand(id: string): Promise<void> {
@@ -36,9 +38,28 @@ export default async function reviewApproveCommand(id: string): Promise<void> {
   await atomicWrite(pagePath, candidate.body);
   output.status("+", output.success(`Approved → ${output.source(pagePath)}`));
 
+  await persistCandidateSourceStates(root, candidate);
   await refreshWikiAfterApproval(root, candidate.slug);
   await deleteCandidate(root, id);
   output.status("✓", output.dim(`Candidate ${id} cleared.`));
+}
+
+/**
+ * Flush the source-state snapshot stored on the candidate into
+ * `.llmwiki/state.json` so the contributing source files are marked
+ * compiled. Without this, approved candidates would re-appear on the next
+ * `compile` run because the source still looks "new" or "changed" to the
+ * change detector.
+ */
+async function persistCandidateSourceStates(
+  root: string,
+  candidate: ReviewCandidate,
+): Promise<void> {
+  const states = candidate.sourceStates;
+  if (!states) return;
+  for (const [sourceFile, entry] of Object.entries(states)) {
+    await updateSourceState(root, sourceFile, entry);
+  }
 }
 
 /** Refresh interlinks, index, MOC, and embeddings after writing a candidate. */

--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -7,9 +7,10 @@
  * stored in the candidate is written verbatim.
  *
  * All mutations are performed under `.llmwiki/lock` to prevent races with a
- * concurrent compile or sibling approve/reject. The lock is acquired before
- * the `listCandidates` call inside `persistCandidateSourceStates` so that the
- * sibling-candidate read is also serialized.
+ * concurrent compile or sibling approve/reject. The candidate is re-read under
+ * the lock (TOCTOU guard) — if it disappears between the fast-fail check and
+ * lock acquisition (e.g. a concurrent reject ran first), the approval aborts
+ * cleanly rather than writing a page from a stale in-memory snapshot.
  */
 
 import path from "path";
@@ -20,22 +21,31 @@ import {
 import {
   deleteCandidate,
   listCandidates,
-  loadCandidateOrFail,
 } from "../compiler/candidates.js";
 import { generateIndex } from "../compiler/indexgen.js";
 import { generateMOC } from "../compiler/obsidian.js";
 import { resolveLinks } from "../compiler/resolver.js";
 import { updateEmbeddings } from "../utils/embeddings.js";
 import { updateSourceState } from "../utils/state.js";
-import { acquireLock, releaseLock } from "../utils/lock.js";
 import { CONCEPTS_DIR } from "../utils/constants.js";
 import * as output from "../utils/output.js";
 import type { ReviewCandidate } from "../utils/types.js";
+import { runReviewUnderLock, readCandidateUnderLock } from "./review-helpers.js";
 
 /** Approve a pending candidate by promoting its body into wiki/concepts/. */
 export default async function reviewApproveCommand(id: string): Promise<void> {
-  const root = process.cwd();
-  const candidate = await loadCandidateOrFail(root, id);
+  await runReviewUnderLock(id, approveUnderLock);
+}
+
+/**
+ * Perform all wiki mutations for an approval while holding the lock.
+ *
+ * Re-reads the candidate under the lock so that a concurrent reject that ran
+ * between the pre-lock fast-fail and lock acquisition is detected. Aborts with
+ * exit code 1 if the candidate has disappeared or fails page validation.
+ */
+async function approveUnderLock(root: string, id: string): Promise<void> {
+  const candidate = await readCandidateUnderLock(root, id);
   if (!candidate) return;
 
   if (!validateWikiPage(candidate.body)) {
@@ -44,29 +54,6 @@ export default async function reviewApproveCommand(id: string): Promise<void> {
     return;
   }
 
-  const locked = await acquireLock(root);
-  if (!locked) {
-    output.status("!", output.error("Could not acquire lock. Try again later."));
-    process.exitCode = 1;
-    return;
-  }
-
-  try {
-    await approveUnderLock(root, id, candidate);
-  } finally {
-    await releaseLock(root);
-  }
-}
-
-/**
- * Perform all wiki mutations for an approval while holding the lock.
- * Separated so the lock acquire/release wrapper stays under 40 lines.
- */
-async function approveUnderLock(
-  root: string,
-  id: string,
-  candidate: ReviewCandidate,
-): Promise<void> {
   const pagePath = path.join(root, CONCEPTS_DIR, `${candidate.slug}.md`);
   await atomicWrite(pagePath, candidate.body);
   output.status("+", output.success(`Approved → ${output.source(pagePath)}`));

--- a/src/commands/review-approve.ts
+++ b/src/commands/review-approve.ts
@@ -1,0 +1,64 @@
+/**
+ * Commander action for `llmwiki review approve <id>`.
+ *
+ * Promotes a pending candidate into the live wiki: writes the page body to
+ * wiki/concepts/<slug>.md, refreshes the index/MOC, updates embeddings, and
+ * removes the candidate file. Approval never re-invokes the LLM — the body
+ * stored in the candidate is written verbatim.
+ */
+
+import path from "path";
+import {
+  atomicWrite,
+  validateWikiPage,
+} from "../utils/markdown.js";
+import { deleteCandidate, loadCandidateOrFail } from "../compiler/candidates.js";
+import { generateIndex } from "../compiler/indexgen.js";
+import { generateMOC } from "../compiler/obsidian.js";
+import { resolveLinks } from "../compiler/resolver.js";
+import { updateEmbeddings } from "../utils/embeddings.js";
+import { CONCEPTS_DIR } from "../utils/constants.js";
+import * as output from "../utils/output.js";
+
+/** Approve a pending candidate by promoting its body into wiki/concepts/. */
+export default async function reviewApproveCommand(id: string): Promise<void> {
+  const root = process.cwd();
+  const candidate = await loadCandidateOrFail(root, id);
+  if (!candidate) return;
+
+  if (!validateWikiPage(candidate.body)) {
+    output.status("!", output.error(`Candidate ${id} failed page validation; not approved.`));
+    process.exitCode = 1;
+    return;
+  }
+
+  const pagePath = path.join(root, CONCEPTS_DIR, `${candidate.slug}.md`);
+  await atomicWrite(pagePath, candidate.body);
+  output.status("+", output.success(`Approved → ${output.source(pagePath)}`));
+
+  await refreshWikiAfterApproval(root, candidate.slug);
+  await deleteCandidate(root, id);
+  output.status("✓", output.dim(`Candidate ${id} cleared.`));
+}
+
+/** Refresh interlinks, index, MOC, and embeddings after writing a candidate. */
+async function refreshWikiAfterApproval(root: string, slug: string): Promise<void> {
+  await resolveLinks(root, [slug], [slug]);
+  await generateIndex(root);
+  await generateMOC(root);
+  await safelyUpdateEmbeddings(root, [slug]);
+}
+
+/**
+ * Refresh the embeddings store without failing approval.
+ * Mirrors the compiler's tolerance: missing API keys / transient provider
+ * failures should warn, not abort the approval flow.
+ */
+async function safelyUpdateEmbeddings(root: string, slugs: string[]): Promise<void> {
+  try {
+    await updateEmbeddings(root, slugs);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    output.status("!", output.warn(`Skipped embeddings update: ${message}`));
+  }
+}

--- a/src/commands/review-helpers.ts
+++ b/src/commands/review-helpers.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared helpers for review subcommands (approve and reject).
+ *
+ * Both commands follow the same pattern:
+ *   1. Fast-fail: read the candidate before locking (cheap early exit for bad ids).
+ *   2. Acquire lock: serialize against concurrent compile / approve / reject.
+ *   3. Under-lock re-read: authoritative TOCTOU guard — abort if the candidate
+ *      was removed between steps 1 and 2 (e.g. a concurrent reject ran first).
+ *   4. Run the mutation.
+ *   5. Release lock.
+ *
+ * Extracting this pattern avoids duplicating the acquire/release boilerplate
+ * in both approve and reject.
+ */
+
+import {
+  loadCandidateOrFail,
+  loadCandidateUnderLockOrFail,
+} from "../compiler/candidates.js";
+import { acquireLock, releaseLock } from "../utils/lock.js";
+import * as output from "../utils/output.js";
+
+/** Re-export for use by the under-lock mutation functions in approve/reject. */
+export { loadCandidateUnderLockOrFail as readCandidateUnderLock };
+
+/**
+ * Run a review mutation under the `.llmwiki/lock`.
+ *
+ * Performs the pre-lock fast-fail, acquires the lock, then delegates to the
+ * provided `underLock` callback. The lock is released in a `finally` block.
+ *
+ * @param id - Candidate id to review.
+ * @param underLock - Async mutation to run while holding the lock.
+ */
+export async function runReviewUnderLock(
+  id: string,
+  underLock: (root: string, id: string) => Promise<void>,
+): Promise<void> {
+  const root = process.cwd();
+
+  // Fast-fail: surface a clear error for obviously missing ids.
+  // The authoritative check happens under the lock via loadCandidateUnderLockOrFail.
+  const preCheck = await loadCandidateOrFail(root, id);
+  if (!preCheck) return;
+
+  const locked = await acquireLock(root);
+  if (!locked) {
+    output.status("!", output.error("Could not acquire lock. Try again later."));
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    await underLock(root, id);
+  } finally {
+    await releaseLock(root);
+  }
+}

--- a/src/commands/review-list.ts
+++ b/src/commands/review-list.ts
@@ -1,0 +1,31 @@
+/**
+ * Commander action for `llmwiki review list`.
+ *
+ * Prints every pending review candidate (id, slug, sources, generated time)
+ * so reviewers can pick one to inspect with `llmwiki review show <id>`.
+ */
+
+import { listCandidates } from "../compiler/candidates.js";
+import * as output from "../utils/output.js";
+
+/** List every pending candidate from .llmwiki/candidates/. */
+export default async function reviewListCommand(): Promise<void> {
+  output.header("Pending review candidates");
+
+  const candidates = await listCandidates(process.cwd());
+  if (candidates.length === 0) {
+    output.status("✓", output.success("No pending candidates."));
+    return;
+  }
+
+  for (const candidate of candidates) {
+    const sources = candidate.sources.join(", ");
+    const meta = output.dim(`${candidate.generatedAt} | sources: ${sources}`);
+    output.status("?", `${output.info(candidate.id)} → ${candidate.slug} ${meta}`);
+  }
+
+  output.status(
+    "→",
+    output.dim(`Use \`llmwiki review show <id>\` to inspect a candidate.`),
+  );
+}

--- a/src/commands/review-reject.ts
+++ b/src/commands/review-reject.ts
@@ -1,0 +1,23 @@
+/**
+ * Commander action for `llmwiki review reject <id>`.
+ *
+ * Removes a candidate from the pending area without touching `wiki/`.
+ * Rejected candidates are moved into .llmwiki/candidates/archive/ so they
+ * remain auditable but never appear in `llmwiki review list` again.
+ */
+
+import { archiveCandidate, loadCandidateOrFail } from "../compiler/candidates.js";
+import * as output from "../utils/output.js";
+
+/** Reject a pending candidate by archiving its JSON record. */
+export default async function reviewRejectCommand(id: string): Promise<void> {
+  const root = process.cwd();
+  const candidate = await loadCandidateOrFail(root, id);
+  if (!candidate) return;
+
+  await archiveCandidate(root, id);
+  output.status(
+    "-",
+    output.warn(`Rejected candidate ${id} (${candidate.slug}) — archived, wiki unchanged.`),
+  );
+}

--- a/src/commands/review-reject.ts
+++ b/src/commands/review-reject.ts
@@ -8,32 +8,35 @@
  * The archive mutation is performed under `.llmwiki/lock` to serialize
  * concurrent approve/reject and approve-vs-compile operations, matching
  * the lock discipline used by compile and approve.
+ *
+ * The candidate is re-read under the lock (TOCTOU guard) — if it disappears
+ * between the pre-lock fast-fail and lock acquisition, the rejection aborts
+ * cleanly rather than silently succeeding on a stale handle.
  */
 
-import { archiveCandidate, loadCandidateOrFail } from "../compiler/candidates.js";
-import { acquireLock, releaseLock } from "../utils/lock.js";
+import { archiveCandidate } from "../compiler/candidates.js";
 import * as output from "../utils/output.js";
+import { runReviewUnderLock, readCandidateUnderLock } from "./review-helpers.js";
 
 /** Reject a pending candidate by archiving its JSON record. */
 export default async function reviewRejectCommand(id: string): Promise<void> {
-  const root = process.cwd();
-  const candidate = await loadCandidateOrFail(root, id);
+  await runReviewUnderLock(id, rejectUnderLock);
+}
+
+/**
+ * Perform the archive mutation while holding the lock.
+ *
+ * Re-reads the candidate under the lock so that a concurrent approve that ran
+ * between the pre-lock fast-fail and lock acquisition is detected. Aborts with
+ * exit code 1 if the candidate has disappeared.
+ */
+async function rejectUnderLock(root: string, id: string): Promise<void> {
+  const candidate = await readCandidateUnderLock(root, id);
   if (!candidate) return;
 
-  const locked = await acquireLock(root);
-  if (!locked) {
-    output.status("!", output.error("Could not acquire lock. Try again later."));
-    process.exitCode = 1;
-    return;
-  }
-
-  try {
-    await archiveCandidate(root, id);
-    output.status(
-      "-",
-      output.warn(`Rejected candidate ${id} (${candidate.slug}) — archived, wiki unchanged.`),
-    );
-  } finally {
-    await releaseLock(root);
-  }
+  await archiveCandidate(root, id);
+  output.status(
+    "-",
+    output.warn(`Rejected candidate ${id} (${candidate.slug}) — archived, wiki unchanged.`),
+  );
 }

--- a/src/commands/review-reject.ts
+++ b/src/commands/review-reject.ts
@@ -4,9 +4,14 @@
  * Removes a candidate from the pending area without touching `wiki/`.
  * Rejected candidates are moved into .llmwiki/candidates/archive/ so they
  * remain auditable but never appear in `llmwiki review list` again.
+ *
+ * The archive mutation is performed under `.llmwiki/lock` to serialize
+ * concurrent approve/reject and approve-vs-compile operations, matching
+ * the lock discipline used by compile and approve.
  */
 
 import { archiveCandidate, loadCandidateOrFail } from "../compiler/candidates.js";
+import { acquireLock, releaseLock } from "../utils/lock.js";
 import * as output from "../utils/output.js";
 
 /** Reject a pending candidate by archiving its JSON record. */
@@ -15,9 +20,20 @@ export default async function reviewRejectCommand(id: string): Promise<void> {
   const candidate = await loadCandidateOrFail(root, id);
   if (!candidate) return;
 
-  await archiveCandidate(root, id);
-  output.status(
-    "-",
-    output.warn(`Rejected candidate ${id} (${candidate.slug}) — archived, wiki unchanged.`),
-  );
+  const locked = await acquireLock(root);
+  if (!locked) {
+    output.status("!", output.error("Could not acquire lock. Try again later."));
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    await archiveCandidate(root, id);
+    output.status(
+      "-",
+      output.warn(`Rejected candidate ${id} (${candidate.slug}) — archived, wiki unchanged.`),
+    );
+  } finally {
+    await releaseLock(root);
+  }
 }

--- a/src/commands/review-show.ts
+++ b/src/commands/review-show.ts
@@ -1,0 +1,25 @@
+/**
+ * Commander action for `llmwiki review show <id>`.
+ *
+ * Prints a single candidate's metadata header followed by its full body so
+ * reviewers can read the proposed page before approving or rejecting.
+ */
+
+import { loadCandidateOrFail } from "../compiler/candidates.js";
+import * as output from "../utils/output.js";
+
+/** Print a single candidate's full content to stdout. */
+export default async function reviewShowCommand(id: string): Promise<void> {
+  const candidate = await loadCandidateOrFail(process.cwd(), id);
+  if (!candidate) return;
+
+  output.header(`Candidate ${candidate.id}`);
+  output.status("i", output.dim(`title:      ${candidate.title}`));
+  output.status("i", output.dim(`slug:       ${candidate.slug}`));
+  output.status("i", output.dim(`summary:    ${candidate.summary}`));
+  output.status("i", output.dim(`sources:    ${candidate.sources.join(", ")}`));
+  output.status("i", output.dim(`generated:  ${candidate.generatedAt}`));
+
+  console.log();
+  console.log(candidate.body);
+}

--- a/src/compiler/candidates.ts
+++ b/src/compiler/candidates.ts
@@ -1,0 +1,195 @@
+/**
+ * Review candidate persistence for the llmwiki compile pipeline.
+ *
+ * When `llmwiki compile --review` runs, generated wiki pages are routed
+ * here as JSON candidate records under `.llmwiki/candidates/` instead of
+ * being written directly to `wiki/`. Reviewers then approve or reject the
+ * proposals via the `llmwiki review` subcommands.
+ *
+ * Candidates are deliberately kept as standalone JSON so they survive across
+ * compile runs and can be inspected manually without the CLI. Each record
+ * stores the full page body so approval is a pure copy — the LLM is never
+ * called again at approval time.
+ */
+
+import { readdir, rename, unlink, writeFile, mkdir } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import { randomBytes } from "crypto";
+import { atomicWrite, safeReadFile } from "../utils/markdown.js";
+import * as output from "../utils/output.js";
+import {
+  CANDIDATES_DIR,
+  CANDIDATES_ARCHIVE_DIR,
+} from "../utils/constants.js";
+import type { ReviewCandidate } from "../utils/types.js";
+
+/** Length (bytes) of the random suffix appended to candidate ids. */
+const ID_SUFFIX_BYTES = 4;
+
+/** Filesystem extension used for candidate JSON files. */
+const CANDIDATE_EXT = ".json";
+
+/** Input shape for creating a new candidate (id + timestamp generated here). */
+interface CandidateDraft {
+  title: string;
+  slug: string;
+  summary: string;
+  sources: string[];
+  body: string;
+}
+
+/** Build a deterministic-but-unique id from a slug and a short random suffix. */
+function buildCandidateId(slug: string): string {
+  const suffix = randomBytes(ID_SUFFIX_BYTES).toString("hex");
+  return `${slug}-${suffix}`;
+}
+
+/** Absolute path to a candidate's JSON file. */
+function candidatePath(root: string, id: string): string {
+  return path.join(root, CANDIDATES_DIR, `${id}${CANDIDATE_EXT}`);
+}
+
+/** Absolute path to the archived JSON file for a rejected candidate. */
+function archivePath(root: string, id: string): string {
+  return path.join(root, CANDIDATES_ARCHIVE_DIR, `${id}${CANDIDATE_EXT}`);
+}
+
+/**
+ * Persist a new candidate record and return it. The id is generated from the
+ * slug plus a short random suffix so multiple compile runs can co-exist.
+ * @param root - Project root directory.
+ * @param draft - The candidate fields to persist.
+ * @returns The full ReviewCandidate (with id + generatedAt populated).
+ */
+export async function writeCandidate(
+  root: string,
+  draft: CandidateDraft,
+): Promise<ReviewCandidate> {
+  const candidate: ReviewCandidate = {
+    id: buildCandidateId(draft.slug),
+    title: draft.title,
+    slug: draft.slug,
+    summary: draft.summary,
+    sources: draft.sources,
+    body: draft.body,
+    generatedAt: new Date().toISOString(),
+  };
+
+  await atomicWrite(candidatePath(root, candidate.id), JSON.stringify(candidate, null, 2));
+  return candidate;
+}
+
+/**
+ * Load a candidate by id and, if missing, emit the standard "not found" CLI
+ * error and set process.exitCode = 1. Returns null when the candidate is
+ * missing so callers can early-return without re-implementing the same
+ * error block in every review subcommand.
+ * @param root - Project root directory.
+ * @param id - Candidate id to look up.
+ */
+export async function loadCandidateOrFail(
+  root: string,
+  id: string,
+): Promise<ReviewCandidate | null> {
+  const candidate = await readCandidate(root, id);
+  if (!candidate) {
+    output.status("!", output.error(`Candidate not found: ${id}`));
+    process.exitCode = 1;
+    return null;
+  }
+  return candidate;
+}
+
+/** Parse a single candidate JSON file. Returns null when the file is missing or malformed. */
+export async function readCandidate(
+  root: string,
+  id: string,
+): Promise<ReviewCandidate | null> {
+  const raw = await safeReadFile(candidatePath(root, id));
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as ReviewCandidate;
+    if (!isValidCandidate(parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** Defensive type-guard so corrupted candidate files don't blow up the CLI. */
+function isValidCandidate(value: unknown): value is ReviewCandidate {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.title === "string" &&
+    typeof candidate.slug === "string" &&
+    typeof candidate.body === "string" &&
+    Array.isArray(candidate.sources)
+  );
+}
+
+/**
+ * List every candidate currently pending review, sorted by generation time.
+ * Skips files that aren't candidate JSON (e.g. the archive subdirectory).
+ * @param root - Project root directory.
+ * @returns All pending review candidates.
+ */
+export async function listCandidates(root: string): Promise<ReviewCandidate[]> {
+  const dir = path.join(root, CANDIDATES_DIR);
+  if (!existsSync(dir)) return [];
+
+  const entries = await readdir(dir, { withFileTypes: true });
+  const candidates: ReviewCandidate[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(CANDIDATE_EXT)) continue;
+    const id = entry.name.slice(0, -CANDIDATE_EXT.length);
+    const candidate = await readCandidate(root, id);
+    if (candidate) candidates.push(candidate);
+  }
+
+  candidates.sort((a, b) => a.generatedAt.localeCompare(b.generatedAt));
+  return candidates;
+}
+
+/** Count pending candidates without parsing each file's body. */
+export async function countCandidates(root: string): Promise<number> {
+  const dir = path.join(root, CANDIDATES_DIR);
+  if (!existsSync(dir)) return 0;
+
+  const entries = await readdir(dir, { withFileTypes: true });
+  return entries.filter((entry) => entry.isFile() && entry.name.endsWith(CANDIDATE_EXT)).length;
+}
+
+/** Remove a pending candidate from disk. Returns false when nothing existed to remove. */
+export async function deleteCandidate(root: string, id: string): Promise<boolean> {
+  const filePath = candidatePath(root, id);
+  if (!existsSync(filePath)) return false;
+  await unlink(filePath);
+  return true;
+}
+
+/**
+ * Move a candidate from the pending area into the archive subdirectory so
+ * rejected proposals stay auditable without touching `wiki/`.
+ * @param root - Project root directory.
+ * @param id - Candidate id to archive.
+ * @returns True when the candidate was found and archived.
+ */
+export async function archiveCandidate(root: string, id: string): Promise<boolean> {
+  const sourcePath = candidatePath(root, id);
+  if (!existsSync(sourcePath)) return false;
+
+  const target = archivePath(root, id);
+  await mkdir(path.dirname(target), { recursive: true });
+  // Copy via writeFile + unlink to support cross-filesystem rename failures.
+  try {
+    await rename(sourcePath, target);
+  } catch {
+    const raw = await safeReadFile(sourcePath);
+    await writeFile(target, raw, "utf-8");
+    await unlink(sourcePath);
+  }
+  return true;
+}

--- a/src/compiler/candidates.ts
+++ b/src/compiler/candidates.ts
@@ -22,7 +22,7 @@ import {
   CANDIDATES_DIR,
   CANDIDATES_ARCHIVE_DIR,
 } from "../utils/constants.js";
-import type { ReviewCandidate } from "../utils/types.js";
+import type { ReviewCandidate, SourceState } from "../utils/types.js";
 
 /** Length (bytes) of the random suffix appended to candidate ids. */
 const ID_SUFFIX_BYTES = 4;
@@ -37,6 +37,12 @@ interface CandidateDraft {
   summary: string;
   sources: string[];
   body: string;
+  /**
+   * Per-source state entries to persist into `.llmwiki/state.json` when this
+   * candidate is approved. Keyed by source filename. Optional so callers that
+   * never need incremental tracking (legacy / tests) can omit it.
+   */
+  sourceStates?: Record<string, SourceState>;
 }
 
 /** Build a deterministic-but-unique id from a slug and a short random suffix. */
@@ -74,6 +80,7 @@ export async function writeCandidate(
     sources: draft.sources,
     body: draft.body,
     generatedAt: new Date().toISOString(),
+    ...(draft.sourceStates ? { sourceStates: draft.sourceStates } : {}),
   };
 
   await atomicWrite(candidatePath(root, candidate.id), JSON.stringify(candidate, null, 2));
@@ -153,13 +160,15 @@ export async function listCandidates(root: string): Promise<ReviewCandidate[]> {
   return candidates;
 }
 
-/** Count pending candidates without parsing each file's body. */
+/**
+ * Count pending candidates using the same validity filter as listCandidates,
+ * so consumers (e.g. `wiki_status.pendingCandidates`) never report counts
+ * that disagree with what `review list` actually shows. Malformed JSON files
+ * are skipped here exactly as they are by listCandidates.
+ */
 export async function countCandidates(root: string): Promise<number> {
-  const dir = path.join(root, CANDIDATES_DIR);
-  if (!existsSync(dir)) return 0;
-
-  const entries = await readdir(dir, { withFileTypes: true });
-  return entries.filter((entry) => entry.isFile() && entry.name.endsWith(CANDIDATE_EXT)).length;
+  const candidates = await listCandidates(root);
+  return candidates.length;
 }
 
 /** Remove a pending candidate from disk. Returns false when nothing existed to remove. */

--- a/src/compiler/candidates.ts
+++ b/src/compiler/candidates.ts
@@ -88,6 +88,17 @@ export async function writeCandidate(
 }
 
 /**
+ * Emit a CLI error, set exit code 1, and return null. Used by candidate load
+ * helpers to avoid duplicating the error-path boilerplate.
+ * @param message - Error message to display.
+ */
+function failWithError(message: string): null {
+  output.status("!", output.error(message));
+  process.exitCode = 1;
+  return null;
+}
+
+/**
  * Load a candidate by id and, if missing, emit the standard "not found" CLI
  * error and set process.exitCode = 1. Returns null when the candidate is
  * missing so callers can early-return without re-implementing the same
@@ -100,10 +111,28 @@ export async function loadCandidateOrFail(
   id: string,
 ): Promise<ReviewCandidate | null> {
   const candidate = await readCandidate(root, id);
+  if (!candidate) return failWithError(`Candidate not found: ${id}`);
+  return candidate;
+}
+
+/**
+ * Re-read a candidate under the lock and abort if it has disappeared.
+ *
+ * This is the authoritative TOCTOU guard: a concurrent approve or reject may
+ * have removed the candidate after the pre-lock fast-fail but before the lock
+ * was acquired. Returning `null` signals the caller to abort without writing
+ * any output artefact.
+ * @param root - Project root directory.
+ * @param id - Candidate id to load.
+ * @returns The candidate if still present, or `null` after setting exit code 1.
+ */
+export async function loadCandidateUnderLockOrFail(
+  root: string,
+  id: string,
+): Promise<ReviewCandidate | null> {
+  const candidate = await readCandidate(root, id);
   if (!candidate) {
-    output.status("!", output.error(`Candidate not found: ${id}`));
-    process.exitCode = 1;
-    return null;
+    return failWithError(`Candidate ${id} was removed by another process during review.`);
   }
   return candidate;
 }

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -8,7 +8,7 @@
  * sources are processed through the LLM pipeline.
  */
 
-import { readFile, readdir } from "fs/promises";
+import { readFile } from "fs/promises";
 import path from "path";
 import { readState, updateSourceState } from "../utils/state.js";
 import {
@@ -16,15 +16,12 @@ import {
   safeReadFile,
   validateWikiPage,
   slugify,
-  buildFrontmatter,
-  parseFrontmatter,
 } from "../utils/markdown.js";
 import { callClaude } from "../utils/llm.js";
 import { acquireLock, releaseLock } from "../utils/lock.js";
 import {
   CONCEPT_EXTRACTION_TOOL,
   buildExtractionPrompt,
-  buildPagePrompt,
   parseConcepts,
 } from "./prompts.js";
 import { detectChanges, hashFile } from "./hasher.js";
@@ -39,8 +36,10 @@ import {
 import { markOrphaned, orphanUnownedFrozenPages } from "./orphan.js";
 import { resolveLinks } from "./resolver.js";
 import { generateIndex } from "./indexgen.js";
-import { addObsidianMeta, generateMOC } from "./obsidian.js";
+import { generateMOC } from "./obsidian.js";
 import { updateEmbeddings } from "../utils/embeddings.js";
+import { writeCandidate } from "./candidates.js";
+import { renderMergedPageContent } from "./page-renderer.js";
 import * as output from "../utils/output.js";
 import {
   COMPILE_CONCURRENCY,
@@ -50,8 +49,10 @@ import {
 } from "../utils/constants.js";
 import pLimit from "p-limit";
 import type {
+  CompileOptions,
   CompileResult,
   ExtractedConcept,
+  ReviewCandidate,
   SourceChange,
   SourceState,
   WikiState,
@@ -67,9 +68,10 @@ function emptyCompileResult(): CompileResult {
  * Acquires .llmwiki/lock, detects changes, compiles new/changed sources,
  * marks orphaned pages, resolves interlinks, and rebuilds the index.
  * @param root - Project root directory.
+ * @param options - Optional pipeline overrides (e.g. --review mode).
  */
-export async function compile(root: string): Promise<void> {
-  await compileAndReport(root);
+export async function compile(root: string, options: CompileOptions = {}): Promise<void> {
+  await compileAndReport(root, options);
 }
 
 /**
@@ -78,9 +80,13 @@ export async function compile(root: string): Promise<void> {
  * non-CLI consumers (the MCP server, programmatic callers) can report
  * meaningful data without scraping terminal output.
  * @param root - Project root directory.
+ * @param options - Optional pipeline overrides (e.g. --review mode).
  * @returns Structured result describing what was compiled.
  */
-export async function compileAndReport(root: string): Promise<CompileResult> {
+export async function compileAndReport(
+  root: string,
+  options: CompileOptions = {},
+): Promise<CompileResult> {
   output.header("llmwiki compile");
 
   const locked = await acquireLock(root);
@@ -93,7 +99,7 @@ export async function compileAndReport(root: string): Promise<CompileResult> {
   }
 
   try {
-    return await runCompilePipeline(root);
+    return await runCompilePipeline(root, options);
   } finally {
     await releaseLock(root);
   }
@@ -119,6 +125,8 @@ function bucketChanges(changes: SourceChange[]): ChangeBuckets {
 interface PageGenerationResult {
   pages: MergedConcept[];
   errors: string[];
+  /** Candidate ids written when running in --review mode. Empty otherwise. */
+  candidates: string[];
 }
 
 /** Phase 2: generate pages for merged concepts in parallel, capturing errors. */
@@ -126,18 +134,21 @@ async function generatePagesPhase(
   root: string,
   extractions: ExtractionResult[],
   frozenSlugs: Set<string>,
+  options: CompileOptions,
 ): Promise<PageGenerationResult> {
   const merged = mergeExtractions(extractions, frozenSlugs);
   const limit = pLimit(COMPILE_CONCURRENCY);
   const errors: string[] = [];
+  const candidates: string[] = [];
   const pages = await Promise.all(
     merged.map((entry) => limit(async () => {
-      const writeError = await generateMergedPage(root, entry);
-      if (writeError) errors.push(writeError);
+      const result = await generateMergedPage(root, entry, options);
+      if (result.error) errors.push(result.error);
+      if (result.candidateId) candidates.push(result.candidateId);
       return entry;
     })),
   );
-  return { pages, errors };
+  return { pages, errors, candidates };
 }
 
 /** Persist source state for every extraction that produced concepts. */
@@ -156,12 +167,17 @@ function summarizeCompile(
   buckets: ChangeBuckets,
   generation: PageGenerationResult,
   extractions: ExtractionResult[],
+  options: CompileOptions,
 ): CompileResult {
   output.header("Compilation complete");
   output.status("✓", output.success(
     `${buckets.toCompile.length} compiled, ${buckets.unchanged.length} skipped, ${buckets.deleted.length} deleted`,
   ));
-  if (buckets.toCompile.length > 0) {
+  if (options.review && generation.candidates.length > 0) {
+    output.status("?", output.info(
+      `${generation.candidates.length} candidate(s) awaiting review — run \`llmwiki review list\``,
+    ));
+  } else if (buckets.toCompile.length > 0) {
     output.status("→", output.dim('Next: llmwiki query "your question here"'));
   }
 
@@ -172,7 +188,7 @@ function summarizeCompile(
     }
   }
 
-  return {
+  const baseResult: CompileResult = {
     compiled: buckets.toCompile.length,
     skipped: buckets.unchanged.length,
     deleted: buckets.deleted.length,
@@ -180,10 +196,17 @@ function summarizeCompile(
     pages: generation.pages.map((entry) => entry.slug),
     errors,
   };
+  if (options.review) {
+    baseResult.candidates = generation.candidates;
+  }
+  return baseResult;
 }
 
 /** Inner pipeline, runs under lock protection. Returns structured CompileResult. */
-async function runCompilePipeline(root: string): Promise<CompileResult> {
+async function runCompilePipeline(
+  root: string,
+  options: CompileOptions,
+): Promise<CompileResult> {
   const state = await readState(root);
   const changes = await detectChanges(root, state);
   augmentWithAffectedSources(changes, findAffectedSources(state, changes));
@@ -195,24 +218,29 @@ async function runCompilePipeline(root: string): Promise<CompileResult> {
   }
 
   printChangesSummary(changes);
-  await markDeletedAsOrphaned(root, buckets.deleted, state);
+  if (!options.review) {
+    await markDeletedAsOrphaned(root, buckets.deleted, state);
+  }
 
   const frozenSlugs = findFrozenSlugs(state, changes);
   reportFrozenSlugs(frozenSlugs);
 
   const extractions = await runExtractionPhases(root, buckets.toCompile, state, changes);
-  await freezeFailedExtractions(root, extractions, frozenSlugs);
-
-  const generation = await generatePagesPhase(root, extractions, frozenSlugs);
-  await persistExtractionStates(root, extractions);
-
-  if (frozenSlugs.size > 0) {
-    await orphanUnownedFrozenPages(root, frozenSlugs);
+  if (!options.review) {
+    await freezeFailedExtractions(root, extractions, frozenSlugs);
   }
-  await persistFrozenSlugs(root, frozenSlugs, extractions);
 
-  await finalizeWiki(root, generation.pages);
-  return summarizeCompile(buckets, generation, extractions);
+  const generation = await generatePagesPhase(root, extractions, frozenSlugs, options);
+
+  if (!options.review) {
+    await persistExtractionStates(root, extractions);
+    if (frozenSlugs.size > 0) {
+      await orphanUnownedFrozenPages(root, frozenSlugs);
+    }
+    await persistFrozenSlugs(root, frozenSlugs, extractions);
+    await finalizeWiki(root, generation.pages);
+  }
+  return summarizeCompile(buckets, generation, extractions, options);
 }
 
 /** Append affected-source changes (logging each addition) to the change list. */
@@ -363,49 +391,50 @@ function mergeExtractions(
   return Array.from(bySlug.values());
 }
 
+/** Outcome of generating a single merged concept page. */
+interface MergedPageOutcome {
+  error?: string;
+  candidateId?: string;
+}
+
 /**
  * Generate a wiki page from merged source content.
  * For shared concepts, the LLM sees content from all contributing sources
- * and frontmatter records every source file.
+ * and frontmatter records every source file. When `options.review` is set,
+ * the rendered page is persisted as a review candidate instead of being
+ * written into `wiki/`.
  */
 async function generateMergedPage(
   root: string,
   entry: MergedConcept,
-): Promise<string | null> {
+  options: CompileOptions,
+): Promise<MergedPageOutcome> {
+  const fullPage = await renderMergedPageContent(root, entry);
+
+  if (options.review) {
+    return await persistReviewCandidate(root, entry, fullPage);
+  }
+
   const pagePath = path.join(root, CONCEPTS_DIR, `${entry.slug}.md`);
-  const existingPage = await safeReadFile(pagePath);
-  const relatedPages = await loadRelatedPages(root, entry.slug);
+  const error = await writePageIfValid(pagePath, fullPage, entry.concept.concept);
+  return { error: error ?? undefined };
+}
 
-  const system = buildPagePrompt(
-    entry.concept.concept,
-    entry.combinedContent,
-    existingPage,
-    relatedPages,
-  );
-
-  const pageBody = await callClaude({
-    system,
-    messages: [
-      { role: "user", content: `Write the wiki page for "${entry.concept.concept}".` },
-    ],
-  });
-
-  const now = new Date().toISOString();
-  const existing = existingPage ? parseFrontmatter(existingPage) : null;
-  const createdAt = (existing?.meta.createdAt && typeof existing.meta.createdAt === "string")
-    ? existing.meta.createdAt
-    : now;
-  const frontmatterFields: Record<string, unknown> = {
+/** Persist a candidate JSON record for later review and report it on stdout. */
+async function persistReviewCandidate(
+  root: string,
+  entry: MergedConcept,
+  fullPage: string,
+): Promise<MergedPageOutcome> {
+  const candidate: ReviewCandidate = await writeCandidate(root, {
     title: entry.concept.concept,
+    slug: entry.slug,
     summary: entry.concept.summary,
     sources: entry.sourceFiles,
-    createdAt,
-    updatedAt: now,
-  };
-  addObsidianMeta(frontmatterFields, entry.concept.concept, entry.concept.tags ?? []);
-  const frontmatter = buildFrontmatter(frontmatterFields);
-  const fullPage = `${frontmatter}\n\n${pageBody}\n`;
-  return await writePageIfValid(pagePath, fullPage, entry.concept.concept);
+    body: fullPage,
+  });
+  output.status("?", output.info(`Candidate ready: ${candidate.id} (${entry.slug})`));
+  return { candidateId: candidate.id };
 }
 
 /**
@@ -428,42 +457,6 @@ async function extractConcepts(
   return parseConcepts(rawOutput);
 }
 
-
-/**
- * Load related wiki pages to provide cross-referencing context.
- * Returns concatenated content of up to 5 existing concept pages.
- * @param root - Project root directory.
- * @param excludeSlug - Slug of the current page to exclude.
- * @returns Concatenated related page contents.
- */
-async function loadRelatedPages(
-  root: string,
-  excludeSlug: string,
-): Promise<string> {
-  const conceptsPath = path.join(root, CONCEPTS_DIR);
-  let files: string[];
-
-  try {
-    files = await readdir(conceptsPath);
-  } catch {
-    return "";
-  }
-
-  const related = files
-    .filter((f) => f.endsWith(".md") && f !== `${excludeSlug}.md`)
-    .slice(0, 5);
-
-  const contents: string[] = [];
-  for (const f of related) {
-    const content = await safeReadFile(path.join(conceptsPath, f));
-    if (!content) continue;
-    const { meta } = parseFrontmatter(content);
-    if (meta.orphaned) continue;
-    contents.push(content);
-  }
-
-  return contents.join("\n\n---\n\n");
-}
 
 /**
  * Validate and atomically write a wiki page, logging the result.

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -12,6 +12,10 @@ import { readFile } from "fs/promises";
 import path from "path";
 import { readState, updateSourceState } from "../utils/state.js";
 import {
+  buildExtractionSourceStates,
+  pickStatesForSources,
+} from "./source-state.js";
+import {
   atomicWrite,
   safeReadFile,
   validateWikiPage,
@@ -57,6 +61,9 @@ import type {
   SourceState,
   WikiState,
 } from "../utils/types.js";
+
+/** Per-source state snapshots keyed by source filename. */
+type SourceStateMap = Record<string, SourceState>;
 
 /** Empty CompileResult used when no pipeline work runs (e.g. lock contention). */
 function emptyCompileResult(): CompileResult {
@@ -137,12 +144,17 @@ async function generatePagesPhase(
   options: CompileOptions,
 ): Promise<PageGenerationResult> {
   const merged = mergeExtractions(extractions, frozenSlugs);
+  // Build the per-source state snapshot once so each candidate can carry the
+  // exact data needed to mark its sources compiled on approval.
+  const sourceStates = options.review
+    ? await buildExtractionSourceStates(root, extractions)
+    : {};
   const limit = pLimit(COMPILE_CONCURRENCY);
   const errors: string[] = [];
   const candidates: string[] = [];
   const pages = await Promise.all(
     merged.map((entry) => limit(async () => {
-      const result = await generateMergedPage(root, entry, options);
+      const result = await generateMergedPage(root, entry, options, sourceStates);
       if (result.error) errors.push(result.error);
       if (result.candidateId) candidates.push(result.candidateId);
       return entry;
@@ -218,9 +230,13 @@ async function runCompilePipeline(
   }
 
   printChangesSummary(changes);
-  if (!options.review) {
-    await markDeletedAsOrphaned(root, buckets.deleted, state);
-  }
+  // Deletion bookkeeping (orphan marking + frozen-slug persistence) runs in
+  // both modes — it tracks deleted sources, not approved pages, so deferring
+  // it to per-approval would leave the wiki in a stale state if no candidate
+  // is ever approved. Source-state persistence for compiled sources, on the
+  // other hand, is review-deferred: those entries land at approve time so
+  // unapproved candidates remain re-detectable on subsequent compiles.
+  await markDeletedAsOrphaned(root, buckets.deleted, state);
 
   const frozenSlugs = findFrozenSlugs(state, changes);
   reportFrozenSlugs(frozenSlugs);
@@ -234,10 +250,12 @@ async function runCompilePipeline(
 
   if (!options.review) {
     await persistExtractionStates(root, extractions);
-    if (frozenSlugs.size > 0) {
-      await orphanUnownedFrozenPages(root, frozenSlugs);
-    }
-    await persistFrozenSlugs(root, frozenSlugs, extractions);
+  }
+  if (frozenSlugs.size > 0) {
+    await orphanUnownedFrozenPages(root, frozenSlugs);
+  }
+  await persistFrozenSlugs(root, frozenSlugs, extractions);
+  if (!options.review) {
     await finalizeWiki(root, generation.pages);
   }
   return summarizeCompile(buckets, generation, extractions, options);
@@ -408,11 +426,12 @@ async function generateMergedPage(
   root: string,
   entry: MergedConcept,
   options: CompileOptions,
+  sourceStates: SourceStateMap,
 ): Promise<MergedPageOutcome> {
   const fullPage = await renderMergedPageContent(root, entry);
 
   if (options.review) {
-    return await persistReviewCandidate(root, entry, fullPage);
+    return await persistReviewCandidate(root, entry, fullPage, sourceStates);
   }
 
   const pagePath = path.join(root, CONCEPTS_DIR, `${entry.slug}.md`);
@@ -425,6 +444,7 @@ async function persistReviewCandidate(
   root: string,
   entry: MergedConcept,
   fullPage: string,
+  sourceStates: SourceStateMap,
 ): Promise<MergedPageOutcome> {
   const candidate: ReviewCandidate = await writeCandidate(root, {
     title: entry.concept.concept,
@@ -432,6 +452,7 @@ async function persistReviewCandidate(
     summary: entry.concept.summary,
     sources: entry.sourceFiles,
     body: fullPage,
+    sourceStates: pickStatesForSources(sourceStates, entry.sourceFiles),
   });
   output.status("?", output.info(`Candidate ready: ${candidate.id} (${entry.slug})`));
   return { candidateId: candidate.id };

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -230,13 +230,16 @@ async function runCompilePipeline(
   }
 
   printChangesSummary(changes);
-  // Deletion bookkeeping (orphan marking + frozen-slug persistence) runs in
-  // both modes — it tracks deleted sources, not approved pages, so deferring
-  // it to per-approval would leave the wiki in a stale state if no candidate
-  // is ever approved. Source-state persistence for compiled sources, on the
-  // other hand, is review-deferred: those entries land at approve time so
-  // unapproved candidates remain re-detectable on subsequent compiles.
-  await markDeletedAsOrphaned(root, buckets.deleted, state);
+  // In review mode the pipeline contract is "write candidates instead of
+  // mutating wiki/". Deletion bookkeeping (orphan marking + frozen-slug
+  // persistence) writes directly into wiki/ and updates state.json, so we
+  // defer it to the next non-review compile pass. Source-state persistence
+  // for compiled sources is also review-deferred — those entries land at
+  // approve time so unapproved candidates remain re-detectable on subsequent
+  // compiles.
+  if (!options.review) {
+    await markDeletedAsOrphaned(root, buckets.deleted, state);
+  }
 
   const frozenSlugs = findFrozenSlugs(state, changes);
   reportFrozenSlugs(frozenSlugs);
@@ -250,12 +253,10 @@ async function runCompilePipeline(
 
   if (!options.review) {
     await persistExtractionStates(root, extractions);
-  }
-  if (frozenSlugs.size > 0) {
-    await orphanUnownedFrozenPages(root, frozenSlugs);
-  }
-  await persistFrozenSlugs(root, frozenSlugs, extractions);
-  if (!options.review) {
+    if (frozenSlugs.size > 0) {
+      await orphanUnownedFrozenPages(root, frozenSlugs);
+    }
+    await persistFrozenSlugs(root, frozenSlugs, extractions);
     await finalizeWiki(root, generation.pages);
   }
   return summarizeCompile(buckets, generation, extractions, options);

--- a/src/compiler/page-renderer.ts
+++ b/src/compiler/page-renderer.ts
@@ -1,0 +1,117 @@
+/**
+ * Wiki page rendering for the llmwiki compile pipeline.
+ *
+ * Encapsulates the single-page generation step: gather related pages, call
+ * the LLM, build frontmatter, and produce the final markdown blob. Splitting
+ * this away from the orchestrator (`compiler/index.ts`) keeps the orchestrator
+ * focused on phase sequencing and lets the review-candidate code path reuse
+ * the exact same renderer used for direct writes.
+ */
+
+import { readdir } from "fs/promises";
+import path from "path";
+import {
+  buildFrontmatter,
+  parseFrontmatter,
+  safeReadFile,
+} from "../utils/markdown.js";
+import { callClaude } from "../utils/llm.js";
+import { buildPagePrompt } from "./prompts.js";
+import { addObsidianMeta } from "./obsidian.js";
+import { CONCEPTS_DIR } from "../utils/constants.js";
+import type { ExtractedConcept } from "../utils/types.js";
+
+/** Maximum number of existing concept pages to include as cross-reference context. */
+const RELATED_PAGE_CONTEXT_LIMIT = 5;
+
+/** A merged-concept input from the orchestrator (multiple sources merged into one). */
+interface RenderableConcept {
+  slug: string;
+  concept: ExtractedConcept;
+  sourceFiles: string[];
+  combinedContent: string;
+}
+
+/**
+ * Render a wiki page (frontmatter + body) for a merged concept by calling
+ * the LLM with cross-referencing context from existing concept pages.
+ * @param root - Project root directory.
+ * @param entry - The merged concept to render.
+ * @returns Full markdown content (frontmatter + body, trailing newline).
+ */
+export async function renderMergedPageContent(
+  root: string,
+  entry: RenderableConcept,
+): Promise<string> {
+  const pagePath = path.join(root, CONCEPTS_DIR, `${entry.slug}.md`);
+  const existingPage = await safeReadFile(pagePath);
+  const relatedPages = await loadRelatedPages(root, entry.slug);
+
+  const system = buildPagePrompt(
+    entry.concept.concept,
+    entry.combinedContent,
+    existingPage,
+    relatedPages,
+  );
+
+  const pageBody = await callClaude({
+    system,
+    messages: [
+      { role: "user", content: `Write the wiki page for "${entry.concept.concept}".` },
+    ],
+  });
+
+  const frontmatter = buildMergedFrontmatter(entry, existingPage);
+  return `${frontmatter}\n\n${pageBody}\n`;
+}
+
+/** Construct the frontmatter block for a merged concept, preserving createdAt. */
+function buildMergedFrontmatter(entry: RenderableConcept, existingPage: string): string {
+  const now = new Date().toISOString();
+  const existing = existingPage ? parseFrontmatter(existingPage) : null;
+  const createdAt = (existing?.meta.createdAt && typeof existing.meta.createdAt === "string")
+    ? existing.meta.createdAt
+    : now;
+  const frontmatterFields: Record<string, unknown> = {
+    title: entry.concept.concept,
+    summary: entry.concept.summary,
+    sources: entry.sourceFiles,
+    createdAt,
+    updatedAt: now,
+  };
+  addObsidianMeta(frontmatterFields, entry.concept.concept, entry.concept.tags ?? []);
+  return buildFrontmatter(frontmatterFields);
+}
+
+/**
+ * Load related wiki pages to provide cross-referencing context.
+ * Returns concatenated content of up to RELATED_PAGE_CONTEXT_LIMIT pages.
+ * @param root - Project root directory.
+ * @param excludeSlug - Slug of the current page to exclude.
+ * @returns Concatenated related page contents (empty when concepts dir is missing).
+ */
+async function loadRelatedPages(root: string, excludeSlug: string): Promise<string> {
+  const conceptsPath = path.join(root, CONCEPTS_DIR);
+  let files: string[];
+
+  try {
+    files = await readdir(conceptsPath);
+  } catch {
+    return "";
+  }
+
+  const related = files
+    .filter((f) => f.endsWith(".md") && f !== `${excludeSlug}.md`)
+    .slice(0, RELATED_PAGE_CONTEXT_LIMIT);
+
+  const contents: string[] = [];
+  for (const f of related) {
+    const content = await safeReadFile(path.join(conceptsPath, f));
+    if (!content) continue;
+    const { meta } = parseFrontmatter(content);
+    if (meta.orphaned) continue;
+    contents.push(content);
+  }
+
+  return contents.join("\n\n---\n\n");
+}

--- a/src/compiler/source-state.ts
+++ b/src/compiler/source-state.ts
@@ -1,0 +1,86 @@
+/**
+ * Source-state snapshot helpers shared between the live compile path and the
+ * review-candidate path.
+ *
+ * The compile pipeline normally persists a `SourceState` entry for every
+ * extracted source so subsequent compiles can skip unchanged inputs. When
+ * compile runs in `--review` mode, page writes are deferred — but the same
+ * per-source state still needs to land on approval, otherwise approved
+ * sources stay marked as "new/changed" forever and reproduce duplicate
+ * candidates on every compile.
+ *
+ * This module produces a `Record<sourceFile, SourceState>` snapshot from the
+ * extraction results so it can ride along inside each `ReviewCandidate` and
+ * be flushed to `.llmwiki/state.json` at approval time.
+ */
+
+import path from "path";
+import { hashFile } from "./hasher.js";
+import { slugify } from "../utils/markdown.js";
+import { SOURCES_DIR } from "../utils/constants.js";
+import type { ExtractionResult } from "./deps.js";
+import type { SourceState } from "../utils/types.js";
+
+/**
+ * Compute a per-source state snapshot keyed by source filename.
+ *
+ * Hashes every contributing source once so each candidate carries the
+ * incremental-state payload required to mark its sources compiled on
+ * approval. Sources with no extracted concepts are skipped — we only mark
+ * sources compiled when extraction succeeded, mirroring the live path's
+ * behaviour.
+ *
+ * @param root - Project root directory.
+ * @param extractions - Extraction results from the compile pipeline.
+ * @returns Map of source filename → SourceState ready for state.json.
+ */
+export async function buildExtractionSourceStates(
+  root: string,
+  extractions: ExtractionResult[],
+): Promise<Record<string, SourceState>> {
+  const snapshot: Record<string, SourceState> = {};
+  const compiledAt = new Date().toISOString();
+
+  for (const result of extractions) {
+    if (result.concepts.length === 0) continue;
+    snapshot[result.sourceFile] = await buildEntry(root, result, compiledAt);
+  }
+
+  return snapshot;
+}
+
+/** Build a single SourceState entry for one extraction result. */
+async function buildEntry(
+  root: string,
+  result: ExtractionResult,
+  compiledAt: string,
+): Promise<SourceState> {
+  const filePath = path.join(root, SOURCES_DIR, result.sourceFile);
+  const hash = await hashFile(filePath);
+  return {
+    hash,
+    concepts: result.concepts.map((concept) => slugify(concept.concept)),
+    compiledAt,
+  };
+}
+
+/**
+ * Filter a global source-state snapshot down to entries relevant to a
+ * specific candidate. A candidate carries only the source-state entries
+ * for sources that actually contributed to it, so on approval we can
+ * persist a minimal, accurate slice into state.json.
+ *
+ * @param allStates - Global per-source snapshot from buildExtractionSourceStates.
+ * @param sourceFiles - Source filenames that contributed to the candidate.
+ */
+export function pickStatesForSources(
+  allStates: Record<string, SourceState>,
+  sourceFiles: string[],
+): Record<string, SourceState> {
+  const picked: Record<string, SourceState> = {};
+  for (const file of sourceFiles) {
+    const entry = allStates[file];
+    if (entry) picked[file] = entry;
+  }
+  return picked;
+}

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -17,6 +17,7 @@ import { generateAnswer, selectPages } from "../commands/query.js";
 import { lint } from "../linter/index.js";
 import { collectPageSummaries, scanWikiPages } from "../compiler/indexgen.js";
 import { detectChanges } from "../compiler/hasher.js";
+import { countCandidates } from "../compiler/candidates.js";
 import { readState } from "../utils/state.js";
 import { safeReadFile, parseFrontmatter } from "../utils/markdown.js";
 import { findRelevantPages } from "../utils/embeddings.js";
@@ -232,6 +233,7 @@ async function collectStatus(root: string): Promise<WikiStatus> {
   const state = await readState(root);
   const changes = await detectChanges(root, state);
   const orphans = await findOrphanedSlugs(root);
+  const pendingCandidates = await countCandidates(root);
   const compileTimes = Object.values(state.sources).map((s) => s.compiledAt);
   const lastCompile = compileTimes.length > 0
     ? compileTimes.sort().slice(-1)[0]
@@ -242,6 +244,7 @@ async function collectStatus(root: string): Promise<WikiStatus> {
     sources: Object.keys(state.sources).length,
     lastCompiledAt: lastCompile,
     orphanedPages: orphans,
+    pendingCandidates,
     pendingChanges: changes
       .filter((c) => c.status !== "unchanged")
       .map((c) => ({ file: c.file, status: c.status })),
@@ -253,6 +256,8 @@ interface WikiStatus {
   sources: number;
   lastCompiledAt: string | null;
   orphanedPages: string[];
+  /** Number of compile candidates awaiting human review. */
+  pendingCandidates: number;
   pendingChanges: Array<{ file: string; status: string }>;
 }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -45,6 +45,12 @@ export const INDEX_FILE = "wiki/index.md";
 export const MOC_FILE = "wiki/MOC.md";
 export const EMBEDDINGS_FILE = ".llmwiki/embeddings.json";
 
+/** Pending review candidates awaiting approval/rejection. */
+export const CANDIDATES_DIR = ".llmwiki/candidates";
+
+/** Rejected review candidates archived for audit (not deleted). */
+export const CANDIDATES_ARCHIVE_DIR = ".llmwiki/candidates/archive";
+
 /** Number of most similar pages to return from embedding-based pre-filter. */
 export const EMBEDDING_TOP_K = 15;
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -92,6 +92,15 @@ export interface ReviewCandidate {
   body: string;
   /** ISO timestamp recorded when the candidate was generated. */
   generatedAt: string;
+  /**
+   * Per-source incremental-state snapshots captured at compile time.
+   *
+   * Approving the candidate persists these into `.llmwiki/state.json` so the
+   * source files are marked compiled and won't be reprocessed on the next
+   * `compile` run. Without this, approved candidates would silently
+   * regenerate on every subsequent compile.
+   */
+  sourceStates?: Record<string, SourceState>;
 }
 
 /** Structured result returned by the query pipeline. */

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -60,6 +60,38 @@ export interface CompileResult {
   concepts: string[];
   pages: string[];
   errors: string[];
+  /** Candidate IDs created when the pipeline runs in --review mode. */
+  candidates?: string[];
+}
+
+/** Optional behaviour controls for the compile pipeline. */
+export interface CompileOptions {
+  /**
+   * Write generated pages as candidates under .llmwiki/candidates/ instead
+   * of mutating wiki/. Reviewers approve/reject via `llmwiki review`.
+   */
+  review?: boolean;
+}
+
+/**
+ * A pending wiki page change awaiting human review. Persisted as JSON under
+ * .llmwiki/candidates/<id>.json when compile is run with --review.
+ */
+export interface ReviewCandidate {
+  /** Stable identifier used by the review CLI commands. */
+  id: string;
+  /** Human-readable concept title. */
+  title: string;
+  /** Filename slug that the page would be written to. */
+  slug: string;
+  /** Short summary copied from the LLM extraction. */
+  summary: string;
+  /** Source filenames that contributed to this candidate. */
+  sources: string[];
+  /** Full page content (frontmatter + body) ready to be written verbatim. */
+  body: string;
+  /** ISO timestamp recorded when the candidate was generated. */
+  generatedAt: string;
 }
 
 /** Structured result returned by the query pipeline. */

--- a/test/fixtures/temp-root.ts
+++ b/test/fixtures/temp-root.ts
@@ -1,11 +1,16 @@
 /**
  * Shared test helper for creating temporary llmwiki project roots.
  * Used by tests that need a realistic filesystem layout (wiki/concepts, wiki/queries).
+ *
+ * Also exports `useTempRoot`, a composable that manages the full chdir lifecycle
+ * (create → chdir in beforeEach, restore → rm in afterEach) so individual test
+ * files don't duplicate this boilerplate.
  */
 
-import { mkdir } from "fs/promises";
+import { mkdir, rm } from "fs/promises";
 import path from "path";
 import os from "os";
+import { beforeEach, afterEach, vi } from "vitest";
 
 /**
  * Create a temp directory simulating an llmwiki project root.
@@ -21,4 +26,46 @@ export async function makeTempRoot(prefix: string): Promise<string> {
   await mkdir(path.join(root, "wiki/concepts"), { recursive: true });
   await mkdir(path.join(root, "wiki/queries"), { recursive: true });
   return root;
+}
+
+/**
+ * State object populated by `useTempRoot`. Exposed as a mutable reference
+ * so test files can read `ctx.dir` without calling a function.
+ */
+export interface TempRootCtx {
+  /** Absolute path of the current test's temporary project root. */
+  dir: string;
+}
+
+/**
+ * Composable that registers beforeEach/afterEach hooks managing a temporary
+ * project root. The current process directory is changed into the temp root
+ * for each test and restored afterwards.
+ *
+ * Call at the top level of a describe block (or test file). Access the
+ * current temp path via the returned context object's `dir` property.
+ *
+ * @param extraDirs - Additional sub-directories to create inside the root.
+ * @returns Mutable context with the current `dir` set by each beforeEach.
+ */
+export function useTempRoot(extraDirs: string[] = []): TempRootCtx {
+  const ctx: TempRootCtx = { dir: "" };
+  let originalCwd = "";
+
+  beforeEach(async () => {
+    ctx.dir = await makeTempRoot("test");
+    for (const dir of extraDirs) {
+      await mkdir(path.join(ctx.dir, dir), { recursive: true });
+    }
+    originalCwd = process.cwd();
+    process.chdir(ctx.dir);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(ctx.dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  return ctx;
 }

--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -189,6 +189,37 @@ describe("wiki_status tool", () => {
     }));
     expect(afterFiles).toEqual(beforeFiles);
   });
+
+  it("reports pendingCandidates equal to the number of valid candidate files", async () => {
+    const candidatesDir = path.join(root, ".llmwiki", "candidates");
+    await mkdir(candidatesDir, { recursive: true });
+    const validCandidates = [
+      { id: "alpha-aaaaaaaa", slug: "alpha", title: "Alpha" },
+      { id: "beta-bbbbbbbb", slug: "beta", title: "Beta" },
+    ];
+    for (const seed of validCandidates) {
+      await writeFile(
+        path.join(candidatesDir, `${seed.id}.json`),
+        JSON.stringify({
+          id: seed.id,
+          title: seed.title,
+          slug: seed.slug,
+          summary: "Summary",
+          sources: ["source.md"],
+          body: "body",
+          generatedAt: new Date().toISOString(),
+        }),
+        "utf-8",
+      );
+    }
+    // A malformed JSON file should NOT inflate pendingCandidates.
+    await writeFile(path.join(candidatesDir, "broken.json"), "not json", "utf-8");
+
+    const server = buildServer();
+    const result = await callTool(server, "wiki_status", {});
+    const status = result.structuredContent?.result as { pendingCandidates: number };
+    expect(status.pendingCandidates).toBe(validCandidates.length);
+  });
 });
 
 describe("error handling", () => {

--- a/test/review-integration.test.ts
+++ b/test/review-integration.test.ts
@@ -1,0 +1,270 @@
+/**
+ * CLI-level integration tests for the `llmwiki review` subcommand family.
+ *
+ * All tests spawn real subprocesses via execFile so they exercise the full
+ * CLI surface (Commander routing, exit codes, stdout/stderr) without mocking
+ * internal modules. Candidate JSON files are written manually to control state
+ * so no LLM call is needed for any test in this file.
+ *
+ * Tests that would require a real LLM call (compile --review with valid creds)
+ * are marked it.skip and explained inline.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import path from "path";
+import { mkdir, rm, writeFile, readdir, access } from "fs/promises";
+import { tmpdir } from "os";
+import type { ReviewCandidate } from "../src/utils/types.js";
+
+const exec = promisify(execFile);
+const CLI = path.resolve("dist/cli.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a disposable temp directory with a sources/ sub-folder. */
+async function makeTempWorkspace(suffix: string): Promise<string> {
+  const cwd = path.join(tmpdir(), `llmwiki-review-test-${suffix}-${Date.now()}`);
+  await mkdir(path.join(cwd, "sources"), { recursive: true });
+  return cwd;
+}
+
+async function cleanupDir(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true });
+}
+
+/** Write a minimal, valid ReviewCandidate JSON under .llmwiki/candidates/. */
+async function writeCandidateFixture(
+  cwd: string,
+  overrides: Partial<ReviewCandidate> = {},
+): Promise<ReviewCandidate> {
+  const candidate: ReviewCandidate = {
+    id: overrides.id ?? "test-slug-aabbccdd",
+    title: overrides.title ?? "Test Concept",
+    slug: overrides.slug ?? "test-slug",
+    summary: overrides.summary ?? "A test concept summary.",
+    sources: overrides.sources ?? ["source-a.md"],
+    body: overrides.body ?? buildValidPageBody(
+      overrides.title ?? "Test Concept",
+      overrides.summary ?? "A test concept summary.",
+    ),
+    generatedAt: overrides.generatedAt ?? new Date().toISOString(),
+  };
+
+  const candidatesDir = path.join(cwd, ".llmwiki", "candidates");
+  await mkdir(candidatesDir, { recursive: true });
+  const filePath = path.join(candidatesDir, `${candidate.id}.json`);
+  await writeFile(filePath, JSON.stringify(candidate, null, 2), "utf-8");
+  return candidate;
+}
+
+/** Build minimal YAML-frontmatter page body that passes validateWikiPage. */
+function buildValidPageBody(title: string, summary: string): string {
+  const now = new Date().toISOString();
+  return [
+    "---",
+    `title: "${title}"`,
+    `summary: "${summary}"`,
+    `sources: []`,
+    `createdAt: "${now}"`,
+    `updatedAt: "${now}"`,
+    "---",
+    "",
+    `# ${title}`,
+    "",
+    summary,
+  ].join("\n");
+}
+
+/** Run a CLI subcommand in cwd and return stdout+stderr regardless of exit. */
+async function runCLI(
+  args: string[],
+  cwd: string,
+  envOverrides: NodeJS.ProcessEnv = {},
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  try {
+    const { stdout, stderr } = await exec("node", [CLI, ...args], {
+      cwd,
+      env: { ...process.env, ...envOverrides },
+    });
+    return { stdout, stderr, code: 0 };
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; stderr?: string; code?: number };
+    return { stdout: e.stdout ?? "", stderr: e.stderr ?? "", code: e.code ?? 1 };
+  }
+}
+
+/**
+ * Assert that a review subcommand exits non-zero and prints "not found" when
+ * given an id that does not correspond to any candidate file.
+ */
+async function assertMissingIdFails(subcommand: string, suffix: string): Promise<void> {
+  const cwd = await makeTempWorkspace(suffix);
+  try {
+    const result = await runCLI(["review", subcommand, "does-not-exist-00000000"], cwd);
+    expect(result.code).not.toBe(0);
+    expect(result.stdout).toContain("not found");
+  } finally {
+    await cleanupDir(cwd);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Build once before all tests
+// ---------------------------------------------------------------------------
+
+describe("review integration tests", () => {
+  beforeAll(async () => {
+    await exec("npx", ["tsup"], { cwd: path.resolve(".") });
+  }, 30_000);
+
+  // -------------------------------------------------------------------------
+  // compile --review without credentials
+  // -------------------------------------------------------------------------
+
+  it("compile --review fails with credential error when no API key set", async () => {
+    const cwd = await makeTempWorkspace("compile-review-no-key");
+    try {
+      const result = await runCLI(["compile", "--review"], cwd, {
+        ANTHROPIC_API_KEY: "",
+        ANTHROPIC_AUTH_TOKEN: "",
+      });
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain("Error:");
+    } finally {
+      await cleanupDir(cwd);
+    }
+  }, 30_000);
+
+  // -------------------------------------------------------------------------
+  // review list — no candidates
+  // -------------------------------------------------------------------------
+
+  it("review list on a fresh wiki exits 0 and reports no candidates", async () => {
+    const cwd = await makeTempWorkspace("review-list-empty");
+    try {
+      const result = await runCLI(["review", "list"], cwd);
+      expect(result.code).toBe(0);
+      expect(result.stdout.toLowerCase()).toContain("no pending");
+    } finally {
+      await cleanupDir(cwd);
+    }
+  }, 30_000);
+
+  // -------------------------------------------------------------------------
+  // review show — missing id
+  // -------------------------------------------------------------------------
+
+  it("review show with missing id exits non-zero with actionable error", async () => {
+    await assertMissingIdFails("show", "review-show-missing");
+  }, 30_000);
+
+  // -------------------------------------------------------------------------
+  // review approve — missing id
+  // -------------------------------------------------------------------------
+
+  it("review approve with missing id exits non-zero with actionable error", async () => {
+    await assertMissingIdFails("approve", "review-approve-missing");
+  }, 30_000);
+
+  // -------------------------------------------------------------------------
+  // review reject — missing id
+  // -------------------------------------------------------------------------
+
+  it("review reject with missing id exits non-zero with actionable error", async () => {
+    await assertMissingIdFails("reject", "review-reject-missing");
+  }, 30_000);
+
+  // -------------------------------------------------------------------------
+  // End-to-end: list → show → reject
+  // -------------------------------------------------------------------------
+
+  it("review list shows a manually seeded candidate", async () => {
+    const cwd = await makeTempWorkspace("review-list-seed");
+    try {
+      const candidate = await writeCandidateFixture(cwd);
+      const result = await runCLI(["review", "list"], cwd);
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain(candidate.id);
+    } finally {
+      await cleanupDir(cwd);
+    }
+  }, 30_000);
+
+  it("review show prints title and summary for a seeded candidate", async () => {
+    const cwd = await makeTempWorkspace("review-show-seed");
+    try {
+      const candidate = await writeCandidateFixture(cwd, {
+        title: "Semantic Indexing",
+        summary: "How semantic indexes are built.",
+      });
+      const result = await runCLI(["review", "show", candidate.id], cwd);
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain("Semantic Indexing");
+      expect(result.stdout).toContain("How semantic indexes are built.");
+    } finally {
+      await cleanupDir(cwd);
+    }
+  }, 30_000);
+
+  it("review reject moves candidate to archive and removes it from list", async () => {
+    const cwd = await makeTempWorkspace("review-reject-e2e");
+    try {
+      const candidate = await writeCandidateFixture(cwd);
+
+      const rejectResult = await runCLI(["review", "reject", candidate.id], cwd);
+      expect(rejectResult.code).toBe(0);
+
+      // Candidate no longer appears in list
+      const listResult = await runCLI(["review", "list"], cwd);
+      expect(listResult.stdout).not.toContain(candidate.id);
+      expect(listResult.stdout.toLowerCase()).toContain("no pending");
+
+      // Archived file exists
+      const archivePath = path.join(
+        cwd,
+        ".llmwiki",
+        "candidates",
+        "archive",
+        `${candidate.id}.json`,
+      );
+      await expect(access(archivePath)).resolves.toBeUndefined();
+    } finally {
+      await cleanupDir(cwd);
+    }
+  }, 30_000);
+
+  // -------------------------------------------------------------------------
+  // End-to-end: approve → wiki page written
+  // -------------------------------------------------------------------------
+
+  it("review approve writes the wiki page and clears the candidate", async () => {
+    const cwd = await makeTempWorkspace("review-approve-e2e");
+    try {
+      const candidate = await writeCandidateFixture(cwd, {
+        slug: "test-slug",
+        title: "Test Concept",
+      });
+
+      const approveResult = await runCLI(["review", "approve", candidate.id], cwd);
+      // Exit code 0 — embeddings warning is tolerated by design in approve
+      expect(approveResult.code).toBe(0);
+
+      // Wiki page written
+      const pagePath = path.join(cwd, "wiki", "concepts", `${candidate.slug}.md`);
+      await expect(access(pagePath)).resolves.toBeUndefined();
+
+      // Candidate file removed from pending area
+      const pendingFiles = await readdir(path.join(cwd, ".llmwiki", "candidates")).catch(
+        () => [] as string[],
+      );
+      const jsonFiles = pendingFiles.filter((f) => f.endsWith(".json"));
+      expect(jsonFiles).not.toContain(`${candidate.id}.json`);
+    } finally {
+      await cleanupDir(cwd);
+    }
+  }, 30_000);
+});

--- a/test/review-integration.test.ts
+++ b/test/review-integration.test.ts
@@ -122,6 +122,21 @@ describe("review integration tests", () => {
   }, 30_000);
 
   // -------------------------------------------------------------------------
+  // compile --help advertises the --review flag
+  // -------------------------------------------------------------------------
+
+  it("compile --help documents the --review flag for discoverability", async () => {
+    const cwd = await makeTempWorkspace("compile-help-review-flag");
+    try {
+      const result = await runCLI(["compile", "--help"], cwd);
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain("--review");
+    } finally {
+      await cleanupDir(cwd);
+    }
+  }, 30_000);
+
+  // -------------------------------------------------------------------------
   // compile --review without credentials
   // -------------------------------------------------------------------------
 

--- a/test/review-lock.test.ts
+++ b/test/review-lock.test.ts
@@ -7,15 +7,22 @@
  * asserting the expected call sequence. A sequential two-approval test also
  * confirms that when two candidates share a source, exactly one persists the
  * source state (the second approval, when no sibling remains).
+ *
+ * TOCTOU regression: the last two describe blocks simulate a candidate
+ * disappearing between the pre-lock fast-fail read and the under-lock re-read.
+ * They confirm the commands abort cleanly (exit code 1) and produce no output
+ * artefacts (no wiki page, no archive file).
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { readFile, realpath } from "fs/promises";
+import { readFile, realpath, unlink } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
 import { writeCandidate } from "../src/compiler/candidates.js";
 import {
   CANDIDATES_DIR,
+  CANDIDATES_ARCHIVE_DIR,
+  CONCEPTS_DIR,
   STATE_FILE,
 } from "../src/utils/constants.js";
 import { useTempRoot } from "./fixtures/temp-root.js";
@@ -219,6 +226,64 @@ describe("sequential approvals — source-state persistence under lock", () => {
     const stateAfterSecond = await readStateFile(root.dir);
     expect(stateAfterSecond?.sources[SHARED_SOURCE]).toBeDefined();
     expect(stateAfterSecond?.sources[SHARED_SOURCE].hash).toBe("abc123");
+  });
+});
+
+/**
+ * Stub acquireLock so that it deletes the given candidate file before
+ * returning true, simulating a concurrent process that removed the candidate
+ * between the pre-lock fast-fail read and the lock acquisition.
+ */
+async function stubLockWithCandidateRemoval(
+  root: string,
+  candidateId: string,
+): Promise<void> {
+  const lockMod = await import("../src/utils/lock.js");
+  vi.spyOn(lockMod, "acquireLock").mockImplementation(async () => {
+    const candidateFile = path.join(root, CANDIDATES_DIR, `${candidateId}.json`);
+    await unlink(candidateFile);
+    return true;
+  });
+  vi.spyOn(lockMod, "releaseLock").mockResolvedValue(undefined);
+}
+
+describe("approve TOCTOU — candidate removed between pre-lock check and under-lock read", () => {
+  it("aborts with exit code 1 and does not write a wiki page", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const candidate = await writeSampleCandidate(root.dir, "Epsilon", "epsilon");
+    await stubLockWithCandidateRemoval(root.dir, candidate.id);
+
+    const { default: reviewApproveCommand } = await import(
+      "../src/commands/review-approve.js"
+    );
+    await reviewApproveCommand(candidate.id);
+
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0;
+
+    const wikiPage = path.join(root.dir, CONCEPTS_DIR, `${candidate.slug}.md`);
+    expect(existsSync(wikiPage)).toBe(false);
+  });
+});
+
+describe("reject TOCTOU — candidate removed between pre-lock check and under-lock read", () => {
+  it("aborts with exit code 1 and does not write an archive file", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const candidate = await writeSampleCandidate(root.dir, "Zeta", "zeta");
+    await stubLockWithCandidateRemoval(root.dir, candidate.id);
+
+    const { default: reviewRejectCommand } = await import(
+      "../src/commands/review-reject.js"
+    );
+    await reviewRejectCommand(candidate.id);
+
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0;
+
+    const archiveFile = path.join(root.dir, CANDIDATES_ARCHIVE_DIR, `${candidate.id}.json`);
+    expect(existsSync(archiveFile)).toBe(false);
   });
 });
 

--- a/test/review-lock.test.ts
+++ b/test/review-lock.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests that reviewApproveCommand and reviewRejectCommand acquire and release
+ * the `.llmwiki/lock` around their mutating operations.
+ *
+ * True concurrency is non-deterministic in a single process, so these tests
+ * verify lock discipline by mocking `acquireLock` / `releaseLock` and
+ * asserting the expected call sequence. A sequential two-approval test also
+ * confirms that when two candidates share a source, exactly one persists the
+ * source state (the second approval, when no sibling remains).
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { readFile, realpath } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import { writeCandidate } from "../src/compiler/candidates.js";
+import {
+  CANDIDATES_DIR,
+  STATE_FILE,
+} from "../src/utils/constants.js";
+import { useTempRoot } from "./fixtures/temp-root.js";
+import type { ReviewCandidate, WikiState } from "../src/utils/types.js";
+
+const SHARED_SOURCE = "shared-source.md";
+
+/** Minimal valid page body referencing SHARED_SOURCE. */
+function buildPageBody(title: string): string {
+  return [
+    "---",
+    `title: ${title}`,
+    `summary: "Summary for ${title}"`,
+    "sources:",
+    `  - "${SHARED_SOURCE}"`,
+    'createdAt: "2026-01-01T00:00:00.000Z"',
+    'updatedAt: "2026-01-01T00:00:00.000Z"',
+    "tags: []",
+    "aliases: []",
+    "---",
+    "",
+    `Body for ${title}.`,
+    "",
+  ].join("\n");
+}
+
+/** Write a candidate referencing SHARED_SOURCE. */
+async function writeSampleCandidate(
+  root: string,
+  title: string,
+  slug: string,
+  sourceStates?: ReviewCandidate["sourceStates"],
+): Promise<ReviewCandidate> {
+  return writeCandidate(root, {
+    title,
+    slug,
+    summary: `${title} summary`,
+    sources: [SHARED_SOURCE],
+    body: buildPageBody(title),
+    ...(sourceStates ? { sourceStates } : {}),
+  });
+}
+
+/**
+ * Stub acquireLock to return `granted` and releaseLock to resolve immediately.
+ * Returns the spies so callers can assert call counts.
+ */
+async function stubLock(granted: boolean): Promise<{
+  acquireSpy: ReturnType<typeof vi.spyOn>;
+  releaseSpy: ReturnType<typeof vi.spyOn>;
+}> {
+  const lockMod = await import("../src/utils/lock.js");
+  const acquireSpy = vi.spyOn(lockMod, "acquireLock").mockResolvedValue(granted);
+  const releaseSpy = vi.spyOn(lockMod, "releaseLock").mockResolvedValue(undefined);
+  return { acquireSpy, releaseSpy };
+}
+
+/**
+ * Assert that the candidate file still exists in the pending area — confirming
+ * no mutations ran when the lock was unavailable.
+ */
+function assertCandidatePending(root: string, candidateId: string): void {
+  const candidateFile = path.join(root, CANDIDATES_DIR, `${candidateId}.json`);
+  expect(existsSync(candidateFile)).toBe(true);
+}
+
+/**
+ * Assert that acquireLock and releaseLock were each called exactly once with
+ * the expected root path. Used to verify lock discipline for approve/reject.
+ */
+function assertLockUsed(
+  acquireSpy: ReturnType<typeof vi.spyOn>,
+  releaseSpy: ReturnType<typeof vi.spyOn>,
+  root: string,
+): void {
+  expect(acquireSpy).toHaveBeenCalledTimes(1);
+  expect(acquireSpy).toHaveBeenCalledWith(root);
+  expect(releaseSpy).toHaveBeenCalledTimes(1);
+  expect(releaseSpy).toHaveBeenCalledWith(root);
+}
+
+const root = useTempRoot(["sources"]);
+
+/**
+ * Resolved real path of the current temp dir.
+ *
+ * On macOS, /var/folders is a symlink to /private/var/folders.
+ * process.cwd() returns the real path after chdir, so we normalise for
+ * assertions about what path was passed to acquireLock/releaseLock.
+ */
+let rootReal: string;
+
+beforeEach(async () => {
+  rootReal = await realpath(root.dir);
+  // useTempRoot already handles reset via afterEach
+});
+
+// vi.resetModules is needed here because we spy on the lock module via dynamic
+// import. Without it, the mock leaks across tests in this file.
+// useTempRoot's afterEach calls vi.restoreAllMocks; we add resetModules on top.
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe("review approve — lock discipline", () => {
+  it("acquires and releases the lock exactly once per approval", async () => {
+    const { acquireSpy, releaseSpy } = await stubLock(true);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const { default: reviewApproveCommand } = await import(
+      "../src/commands/review-approve.js"
+    );
+    const candidate = await writeSampleCandidate(root.dir, "Alpha", "alpha");
+
+    await reviewApproveCommand(candidate.id);
+
+    assertLockUsed(acquireSpy, releaseSpy, rootReal);
+  });
+
+  it("sets exit code 1 and skips writes when lock is unavailable", async () => {
+    await stubLock(false);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const { default: reviewApproveCommand } = await import(
+      "../src/commands/review-approve.js"
+    );
+    const candidate = await writeSampleCandidate(root.dir, "Beta", "beta");
+
+    await reviewApproveCommand(candidate.id);
+
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0;
+    assertCandidatePending(root.dir, candidate.id);
+  });
+});
+
+describe("review reject — lock discipline", () => {
+  it("acquires and releases the lock exactly once per rejection", async () => {
+    const { acquireSpy, releaseSpy } = await stubLock(true);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const { default: reviewRejectCommand } = await import(
+      "../src/commands/review-reject.js"
+    );
+    const candidate = await writeSampleCandidate(root.dir, "Gamma", "gamma");
+
+    await reviewRejectCommand(candidate.id);
+
+    assertLockUsed(acquireSpy, releaseSpy, rootReal);
+  });
+
+  it("sets exit code 1 and leaves candidate pending when lock is unavailable", async () => {
+    await stubLock(false);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const { default: reviewRejectCommand } = await import(
+      "../src/commands/review-reject.js"
+    );
+    const candidate = await writeSampleCandidate(root.dir, "Delta", "delta");
+
+    await reviewRejectCommand(candidate.id);
+
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0;
+    assertCandidatePending(root.dir, candidate.id);
+  });
+});
+
+describe("sequential approvals — source-state persistence under lock", () => {
+  /**
+   * Two candidates from the same source approved in sequence (simulating what
+   * concurrent approvals would serialize to under lock). The first approval
+   * must NOT persist source state while the sibling is still pending. The
+   * second approval must persist it.
+   */
+  it("persists source state only after the last sibling candidate is approved", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const { default: reviewApproveCommand } = await import(
+      "../src/commands/review-approve.js"
+    );
+
+    const sourceStates = {
+      [SHARED_SOURCE]: {
+        hash: "abc123",
+        concepts: ["alpha", "beta"],
+        compiledAt: "2026-01-01T00:00:00.000Z",
+      },
+    };
+
+    const alpha = await writeSampleCandidate(root.dir, "Alpha", "alpha", sourceStates);
+    const beta = await writeSampleCandidate(root.dir, "Beta", "beta", sourceStates);
+
+    // First approval: sibling beta is still pending → source state NOT written.
+    await reviewApproveCommand(alpha.id);
+    const stateAfterFirst = await readStateFile(root.dir);
+    expect(stateAfterFirst?.sources[SHARED_SOURCE]).toBeUndefined();
+
+    // Second approval: no remaining sibling → source state IS written.
+    await reviewApproveCommand(beta.id);
+    const stateAfterSecond = await readStateFile(root.dir);
+    expect(stateAfterSecond?.sources[SHARED_SOURCE]).toBeDefined();
+    expect(stateAfterSecond?.sources[SHARED_SOURCE].hash).toBe("abc123");
+  });
+});
+
+/** Read state.json, returning undefined if the file does not exist. */
+async function readStateFile(root: string): Promise<WikiState | undefined> {
+  const raw = await readFile(path.join(root, STATE_FILE), "utf-8").catch(() => "");
+  return raw ? (JSON.parse(raw) as WikiState) : undefined;
+}

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -105,6 +105,22 @@ describe("candidates module", () => {
     expect(await countCandidates(tmpDir)).toBe(2);
   });
 
+  it("countCandidates and listCandidates agree even with malformed JSON files", async () => {
+    await writeCandidate(tmpDir, sampleDraft("good"));
+    // Drop a syntactically-broken candidate file alongside the valid one.
+    const candidatesDir = path.join(tmpDir, CANDIDATES_DIR);
+    await writeFile(
+      path.join(candidatesDir, "broken-candidate.json"),
+      "{ this is not valid json",
+      "utf-8",
+    );
+
+    const listed = await listCandidates(tmpDir);
+    const counted = await countCandidates(tmpDir);
+    expect(counted).toBe(listed.length);
+    expect(counted).toBe(1);
+  });
+
   it("returns null when reading a missing candidate", async () => {
     expect(await readCandidate(tmpDir, "no-such-id")).toBeNull();
   });
@@ -226,5 +242,45 @@ describe("compile --review pipeline integration", () => {
 
     const candidateFiles = await readdir(path.join(tmpDir, CANDIDATES_DIR));
     expect(candidateFiles.filter((f) => f.endsWith(".json"))).toHaveLength(1);
+  });
+
+  /**
+   * End-to-end incremental-state regression test for Finding 1.
+   *
+   * Prior to the fix, `compile --review` skipped state.json writes entirely.
+   * That left every approved source still flagged "new" in change detection,
+   * so the next compile would regenerate the same candidate over and over.
+   * Approving a candidate must persist its source-state snapshot so the
+   * source is treated as "unchanged" on subsequent compiles.
+   */
+  it("does not regenerate a candidate for a source that was approved", async () => {
+    await writeFile(
+      path.join(tmpDir, "sources", "topic.md"),
+      "# Topic\nA brief article about a single topic.",
+    );
+
+    const llm = await import("../src/utils/llm.js");
+    vi.spyOn(llm, "callClaude").mockImplementation(async ({ tools }) => {
+      if (tools && tools.length > 0) {
+        return JSON.stringify({
+          concepts: [
+            { concept: "Topic", summary: "A topic.", is_new: true, tags: [] },
+          ],
+        });
+      }
+      return VALID_BODY;
+    });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const first = await compileAndReport(tmpDir, { review: true });
+    expect(first.candidates).toHaveLength(1);
+
+    const candidateId = first.candidates![0];
+    await reviewApproveCommand(candidateId);
+
+    const second = await compileAndReport(tmpDir, { review: true });
+    expect(second.candidates ?? []).toHaveLength(0);
+    expect(second.compiled).toBe(0);
+    expect(second.skipped).toBeGreaterThanOrEqual(1);
   });
 });

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests for the candidate review queue: candidate persistence, approve/reject
+ * CLI actions, and the compile pipeline's --review opt-in. The compile
+ * integration test stubs the LLM provider so no network calls are made.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, mkdir, readdir, readFile, writeFile, rm } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import os from "os";
+import {
+  archiveCandidate,
+  countCandidates,
+  deleteCandidate,
+  listCandidates,
+  readCandidate,
+  writeCandidate,
+} from "../src/compiler/candidates.js";
+import reviewApproveCommand from "../src/commands/review-approve.js";
+import reviewRejectCommand from "../src/commands/review-reject.js";
+import reviewListCommand from "../src/commands/review-list.js";
+import reviewShowCommand from "../src/commands/review-show.js";
+import { compileAndReport } from "../src/compiler/index.js";
+import {
+  CANDIDATES_ARCHIVE_DIR,
+  CANDIDATES_DIR,
+  CONCEPTS_DIR,
+} from "../src/utils/constants.js";
+
+const VALID_BODY = [
+  "---",
+  "title: Sample Concept",
+  'summary: "A sample summary"',
+  "sources:",
+  '  - "source.md"',
+  'createdAt: "2026-01-01T00:00:00.000Z"',
+  'updatedAt: "2026-01-01T00:00:00.000Z"',
+  "tags: []",
+  "aliases: []",
+  "---",
+  "",
+  "Body content for the sample concept page.",
+  "",
+].join("\n");
+
+let tmpDir: string;
+let originalCwd: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(path.join(os.tmpdir(), "review-test-"));
+  await mkdir(path.join(tmpDir, "wiki/concepts"), { recursive: true });
+  await mkdir(path.join(tmpDir, "wiki/queries"), { recursive: true });
+  await mkdir(path.join(tmpDir, "sources"), { recursive: true });
+  originalCwd = process.cwd();
+  process.chdir(tmpDir);
+});
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await rm(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function sampleDraft(slug = "sample-concept") {
+  return {
+    title: "Sample Concept",
+    slug,
+    summary: "A sample summary",
+    sources: ["source.md"],
+    body: VALID_BODY,
+  };
+}
+
+describe("candidates module", () => {
+  it("writes a candidate JSON file under .llmwiki/candidates/", async () => {
+    const candidate = await writeCandidate(tmpDir, sampleDraft());
+    expect(candidate.id).toMatch(/^sample-concept-[0-9a-f]+$/);
+
+    const filePath = path.join(tmpDir, CANDIDATES_DIR, `${candidate.id}.json`);
+    expect(existsSync(filePath)).toBe(true);
+  });
+
+  it("reads back a written candidate verbatim", async () => {
+    const candidate = await writeCandidate(tmpDir, sampleDraft());
+    const loaded = await readCandidate(tmpDir, candidate.id);
+    expect(loaded).toEqual(candidate);
+  });
+
+  it("lists pending candidates sorted by generation time", async () => {
+    const first = await writeCandidate(tmpDir, sampleDraft("alpha"));
+    // Sleep-free ordering: rewrite generatedAt explicitly so the test never races.
+    const filePath = path.join(tmpDir, CANDIDATES_DIR, `${first.id}.json`);
+    const earlier = { ...first, generatedAt: "2025-01-01T00:00:00.000Z" };
+    await writeFile(filePath, JSON.stringify(earlier, null, 2));
+
+    const second = await writeCandidate(tmpDir, sampleDraft("beta"));
+    const all = await listCandidates(tmpDir);
+    expect(all.map((c) => c.id)).toEqual([first.id, second.id]);
+  });
+
+  it("counts candidates without parsing each file body", async () => {
+    await writeCandidate(tmpDir, sampleDraft("alpha"));
+    await writeCandidate(tmpDir, sampleDraft("beta"));
+    expect(await countCandidates(tmpDir)).toBe(2);
+  });
+
+  it("returns null when reading a missing candidate", async () => {
+    expect(await readCandidate(tmpDir, "no-such-id")).toBeNull();
+  });
+
+  it("deletes a candidate and reports whether it existed", async () => {
+    const candidate = await writeCandidate(tmpDir, sampleDraft());
+    expect(await deleteCandidate(tmpDir, candidate.id)).toBe(true);
+    expect(existsSync(path.join(tmpDir, CANDIDATES_DIR, `${candidate.id}.json`))).toBe(false);
+    expect(await deleteCandidate(tmpDir, candidate.id)).toBe(false);
+  });
+
+  it("archives a rejected candidate without removing the record", async () => {
+    const candidate = await writeCandidate(tmpDir, sampleDraft());
+    expect(await archiveCandidate(tmpDir, candidate.id)).toBe(true);
+
+    const pending = path.join(tmpDir, CANDIDATES_DIR, `${candidate.id}.json`);
+    const archived = path.join(tmpDir, CANDIDATES_ARCHIVE_DIR, `${candidate.id}.json`);
+    expect(existsSync(pending)).toBe(false);
+    expect(existsSync(archived)).toBe(true);
+  });
+});
+
+describe("review approve command", () => {
+  it("writes the candidate body into wiki/concepts and clears the candidate", async () => {
+    const candidate = await writeCandidate(tmpDir, sampleDraft());
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await reviewApproveCommand(candidate.id);
+
+    const pagePath = path.join(tmpDir, CONCEPTS_DIR, "sample-concept.md");
+    expect(existsSync(pagePath)).toBe(true);
+    const content = await readFile(pagePath, "utf-8");
+    expect(content).toBe(VALID_BODY);
+
+    const candidateFile = path.join(tmpDir, CANDIDATES_DIR, `${candidate.id}.json`);
+    expect(existsSync(candidateFile)).toBe(false);
+  });
+
+  it("rejects approval when the candidate body is invalid", async () => {
+    const draft = { ...sampleDraft("broken"), body: "no frontmatter here" };
+    const candidate = await writeCandidate(tmpDir, draft);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await reviewApproveCommand(candidate.id);
+
+    expect(process.exitCode).toBe(1);
+    expect(existsSync(path.join(tmpDir, CONCEPTS_DIR, "broken.md"))).toBe(false);
+    process.exitCode = 0;
+    errorSpy.mockRestore();
+  });
+});
+
+describe("review reject command", () => {
+  it("archives the candidate without touching wiki/concepts", async () => {
+    const candidate = await writeCandidate(tmpDir, sampleDraft());
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await reviewRejectCommand(candidate.id);
+
+    expect(existsSync(path.join(tmpDir, CONCEPTS_DIR, "sample-concept.md"))).toBe(false);
+    const archivePath = path.join(tmpDir, CANDIDATES_ARCHIVE_DIR, `${candidate.id}.json`);
+    expect(existsSync(archivePath)).toBe(true);
+  });
+
+  it("sets exit code 1 when the candidate is missing", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    await reviewRejectCommand("missing-id-x");
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0;
+  });
+});
+
+describe("review list and show commands", () => {
+  it("list reports a quiet message when no candidates exist", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await reviewListCommand();
+    const allOutput = logSpy.mock.calls.map((args) => args.join(" ")).join("\n");
+    expect(allOutput).toContain("No pending candidates.");
+  });
+
+  it("show prints the candidate id, slug, and body", async () => {
+    const candidate = await writeCandidate(tmpDir, sampleDraft());
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await reviewShowCommand(candidate.id);
+    const allOutput = logSpy.mock.calls.map((args) => args.join(" ")).join("\n");
+    expect(allOutput).toContain(candidate.id);
+    expect(allOutput).toContain("sample-concept");
+    expect(allOutput).toContain("Body content for the sample concept page.");
+  });
+});
+
+describe("compile --review pipeline integration", () => {
+  it("creates candidates and leaves wiki/ untouched", async () => {
+    await writeFile(
+      path.join(tmpDir, "sources", "topic.md"),
+      "# Topic\nA brief article about a single topic.",
+    );
+
+    const llm = await import("../src/utils/llm.js");
+    const callSpy = vi.spyOn(llm, "callClaude").mockImplementation(async ({ tools }) => {
+      if (tools && tools.length > 0) {
+        return JSON.stringify({
+          concepts: [
+            { concept: "Topic", summary: "A topic.", is_new: true, tags: ["intro"] },
+          ],
+        });
+      }
+      return "## Topic\n\nThe page body for the topic.";
+    });
+
+    const result = await compileAndReport(tmpDir, { review: true });
+    expect(callSpy).toHaveBeenCalled();
+    expect(result.candidates ?? []).toHaveLength(1);
+
+    // Pages on disk: only the candidate, never the wiki page.
+    const conceptsDir = path.join(tmpDir, CONCEPTS_DIR);
+    expect(existsSync(path.join(conceptsDir, "topic.md"))).toBe(false);
+
+    const candidateFiles = await readdir(path.join(tmpDir, CANDIDATES_DIR));
+    expect(candidateFiles.filter((f) => f.endsWith(".json"))).toHaveLength(1);
+  });
+});

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -26,7 +26,9 @@ import {
   CANDIDATES_ARCHIVE_DIR,
   CANDIDATES_DIR,
   CONCEPTS_DIR,
+  STATE_FILE,
 } from "../src/utils/constants.js";
+import type { WikiState } from "../src/utils/types.js";
 
 const VALID_BODY = [
   "---",
@@ -283,4 +285,132 @@ describe("compile --review pipeline integration", () => {
     expect(second.compiled).toBe(0);
     expect(second.skipped).toBeGreaterThanOrEqual(1);
   });
+
+  /**
+   * Regression test for the multi-candidate-per-source bug.
+   *
+   * When a single source yields multiple concepts (and therefore multiple
+   * candidates), approving the first candidate must NOT mark the source as
+   * fully compiled — otherwise the remaining pending candidates can never
+   * be regenerated, because the next compile sees the source as unchanged.
+   * Source-state is only persisted when the LAST candidate from that source
+   * is approved.
+   */
+  it("defers source-state persistence until every candidate from a source is approved", async () => {
+    await writeFile(
+      path.join(tmpDir, "sources", "topic.md"),
+      "# Topic\nA brief article covering two related concepts.",
+    );
+    await stubMultiConceptLLM();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const first = await compileAndReport(tmpDir, { review: true });
+    expect(first.candidates).toHaveLength(2);
+
+    const [firstId, secondId] = first.candidates!;
+    await reviewApproveCommand(firstId);
+    expect(await readSourceState(tmpDir, "topic.md")).toBeUndefined();
+
+    await reviewApproveCommand(secondId);
+    expect(await readSourceState(tmpDir, "topic.md")).toBeDefined();
+
+    const followup = await compileAndReport(tmpDir, { review: true });
+    expect(followup.candidates ?? []).toHaveLength(0);
+    expect(followup.compiled).toBe(0);
+  });
+
+  /**
+   * Regression test for Finding 2: `compile --review` must NOT mutate
+   * `wiki/concepts/*.md` even when sources are deleted. Orphan-marking is
+   * deferred to the next non-review compile pass.
+   */
+  it("does not mark wiki pages orphaned when a source is deleted in review mode", async () => {
+    await seedExistingPage(tmpDir, "topic", ["topic"]);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    // Source absent from sources/ but present in state.json → detected as deleted.
+    const result = await compileAndReport(tmpDir, { review: true });
+    expect(result.deleted).toBe(1);
+
+    const pageContent = await readFile(
+      path.join(tmpDir, CONCEPTS_DIR, "topic.md"),
+      "utf-8",
+    );
+    expect(pageContent).not.toContain("orphaned: true");
+  });
 });
+
+/** Read a single source's persisted state entry, or undefined if absent. */
+async function readSourceState(
+  root: string,
+  sourceFile: string,
+): Promise<WikiState["sources"][string] | undefined> {
+  const raw = await readFile(path.join(root, STATE_FILE), "utf-8").catch(() => "");
+  if (!raw) return undefined;
+  const state = JSON.parse(raw) as WikiState;
+  return state.sources[sourceFile];
+}
+
+/** Stub the LLM so a single source extracts to TWO concepts (one body each). */
+async function stubMultiConceptLLM(): Promise<void> {
+  const llm = await import("../src/utils/llm.js");
+  let bodyCallCount = 0;
+  vi.spyOn(llm, "callClaude").mockImplementation(async ({ tools }) => {
+    if (tools && tools.length > 0) {
+      return JSON.stringify({
+        concepts: [
+          { concept: "Alpha", summary: "First concept.", is_new: true, tags: [] },
+          { concept: "Beta", summary: "Second concept.", is_new: true, tags: [] },
+        ],
+      });
+    }
+    bodyCallCount += 1;
+    const title = bodyCallCount === 1 ? "Alpha" : "Beta";
+    const summary = bodyCallCount === 1 ? "First concept." : "Second concept.";
+    return buildValidPageBody(title, summary);
+  });
+}
+
+/** Compose a frontmatter+body page string that passes validateWikiPage. */
+function buildValidPageBody(title: string, summary: string): string {
+  return [
+    "---",
+    `title: ${title}`,
+    `summary: "${summary}"`,
+    "sources:",
+    '  - "topic.md"',
+    'createdAt: "2026-01-01T00:00:00.000Z"',
+    'updatedAt: "2026-01-01T00:00:00.000Z"',
+    "tags: []",
+    "aliases: []",
+    "---",
+    "",
+    `Body for ${title}.`,
+    "",
+  ].join("\n");
+}
+
+/** Pre-seed state.json + a wiki page for a source that will then be "deleted". */
+async function seedExistingPage(
+  root: string,
+  slug: string,
+  conceptSlugs: string[],
+): Promise<void> {
+  const state: WikiState = {
+    version: 1,
+    indexHash: "",
+    sources: {
+      "topic.md": {
+        hash: "stale-hash",
+        concepts: conceptSlugs,
+        compiledAt: "2026-01-01T00:00:00.000Z",
+      },
+    },
+  };
+  await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+  await writeFile(path.join(root, STATE_FILE), JSON.stringify(state, null, 2));
+  await writeFile(
+    path.join(root, CONCEPTS_DIR, `${slug}.md`),
+    buildValidPageBody(slug, "seeded"),
+  );
+}

--- a/test/review.test.ts
+++ b/test/review.test.ts
@@ -4,11 +4,10 @@
  * integration test stubs the LLM provider so no network calls are made.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtemp, mkdir, readdir, readFile, writeFile, rm } from "fs/promises";
+import { describe, it, expect, vi } from "vitest";
+import { mkdir, writeFile, readdir, readFile } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
-import os from "os";
 import {
   archiveCandidate,
   countCandidates,
@@ -28,6 +27,7 @@ import {
   CONCEPTS_DIR,
   STATE_FILE,
 } from "../src/utils/constants.js";
+import { useTempRoot } from "./fixtures/temp-root.js";
 import type { WikiState } from "../src/utils/types.js";
 
 const VALID_BODY = [
@@ -46,23 +46,7 @@ const VALID_BODY = [
   "",
 ].join("\n");
 
-let tmpDir: string;
-let originalCwd: string;
-
-beforeEach(async () => {
-  tmpDir = await mkdtemp(path.join(os.tmpdir(), "review-test-"));
-  await mkdir(path.join(tmpDir, "wiki/concepts"), { recursive: true });
-  await mkdir(path.join(tmpDir, "wiki/queries"), { recursive: true });
-  await mkdir(path.join(tmpDir, "sources"), { recursive: true });
-  originalCwd = process.cwd();
-  process.chdir(tmpDir);
-});
-
-afterEach(async () => {
-  process.chdir(originalCwd);
-  await rm(tmpDir, { recursive: true, force: true });
-  vi.restoreAllMocks();
-});
+const root = useTempRoot(["sources"]);
 
 function sampleDraft(slug = "sample-concept") {
   return {
@@ -76,70 +60,70 @@ function sampleDraft(slug = "sample-concept") {
 
 describe("candidates module", () => {
   it("writes a candidate JSON file under .llmwiki/candidates/", async () => {
-    const candidate = await writeCandidate(tmpDir, sampleDraft());
+    const candidate = await writeCandidate(root.dir, sampleDraft());
     expect(candidate.id).toMatch(/^sample-concept-[0-9a-f]+$/);
 
-    const filePath = path.join(tmpDir, CANDIDATES_DIR, `${candidate.id}.json`);
+    const filePath = path.join(root.dir, CANDIDATES_DIR, `${candidate.id}.json`);
     expect(existsSync(filePath)).toBe(true);
   });
 
   it("reads back a written candidate verbatim", async () => {
-    const candidate = await writeCandidate(tmpDir, sampleDraft());
-    const loaded = await readCandidate(tmpDir, candidate.id);
+    const candidate = await writeCandidate(root.dir, sampleDraft());
+    const loaded = await readCandidate(root.dir, candidate.id);
     expect(loaded).toEqual(candidate);
   });
 
   it("lists pending candidates sorted by generation time", async () => {
-    const first = await writeCandidate(tmpDir, sampleDraft("alpha"));
+    const first = await writeCandidate(root.dir, sampleDraft("alpha"));
     // Sleep-free ordering: rewrite generatedAt explicitly so the test never races.
-    const filePath = path.join(tmpDir, CANDIDATES_DIR, `${first.id}.json`);
+    const filePath = path.join(root.dir, CANDIDATES_DIR, `${first.id}.json`);
     const earlier = { ...first, generatedAt: "2025-01-01T00:00:00.000Z" };
     await writeFile(filePath, JSON.stringify(earlier, null, 2));
 
-    const second = await writeCandidate(tmpDir, sampleDraft("beta"));
-    const all = await listCandidates(tmpDir);
+    const second = await writeCandidate(root.dir, sampleDraft("beta"));
+    const all = await listCandidates(root.dir);
     expect(all.map((c) => c.id)).toEqual([first.id, second.id]);
   });
 
   it("counts candidates without parsing each file body", async () => {
-    await writeCandidate(tmpDir, sampleDraft("alpha"));
-    await writeCandidate(tmpDir, sampleDraft("beta"));
-    expect(await countCandidates(tmpDir)).toBe(2);
+    await writeCandidate(root.dir, sampleDraft("alpha"));
+    await writeCandidate(root.dir, sampleDraft("beta"));
+    expect(await countCandidates(root.dir)).toBe(2);
   });
 
   it("countCandidates and listCandidates agree even with malformed JSON files", async () => {
-    await writeCandidate(tmpDir, sampleDraft("good"));
+    await writeCandidate(root.dir, sampleDraft("good"));
     // Drop a syntactically-broken candidate file alongside the valid one.
-    const candidatesDir = path.join(tmpDir, CANDIDATES_DIR);
+    const candidatesDir = path.join(root.dir, CANDIDATES_DIR);
     await writeFile(
       path.join(candidatesDir, "broken-candidate.json"),
       "{ this is not valid json",
       "utf-8",
     );
 
-    const listed = await listCandidates(tmpDir);
-    const counted = await countCandidates(tmpDir);
+    const listed = await listCandidates(root.dir);
+    const counted = await countCandidates(root.dir);
     expect(counted).toBe(listed.length);
     expect(counted).toBe(1);
   });
 
   it("returns null when reading a missing candidate", async () => {
-    expect(await readCandidate(tmpDir, "no-such-id")).toBeNull();
+    expect(await readCandidate(root.dir, "no-such-id")).toBeNull();
   });
 
   it("deletes a candidate and reports whether it existed", async () => {
-    const candidate = await writeCandidate(tmpDir, sampleDraft());
-    expect(await deleteCandidate(tmpDir, candidate.id)).toBe(true);
-    expect(existsSync(path.join(tmpDir, CANDIDATES_DIR, `${candidate.id}.json`))).toBe(false);
-    expect(await deleteCandidate(tmpDir, candidate.id)).toBe(false);
+    const candidate = await writeCandidate(root.dir, sampleDraft());
+    expect(await deleteCandidate(root.dir, candidate.id)).toBe(true);
+    expect(existsSync(path.join(root.dir, CANDIDATES_DIR, `${candidate.id}.json`))).toBe(false);
+    expect(await deleteCandidate(root.dir, candidate.id)).toBe(false);
   });
 
   it("archives a rejected candidate without removing the record", async () => {
-    const candidate = await writeCandidate(tmpDir, sampleDraft());
-    expect(await archiveCandidate(tmpDir, candidate.id)).toBe(true);
+    const candidate = await writeCandidate(root.dir, sampleDraft());
+    expect(await archiveCandidate(root.dir, candidate.id)).toBe(true);
 
-    const pending = path.join(tmpDir, CANDIDATES_DIR, `${candidate.id}.json`);
-    const archived = path.join(tmpDir, CANDIDATES_ARCHIVE_DIR, `${candidate.id}.json`);
+    const pending = path.join(root.dir, CANDIDATES_DIR, `${candidate.id}.json`);
+    const archived = path.join(root.dir, CANDIDATES_ARCHIVE_DIR, `${candidate.id}.json`);
     expect(existsSync(pending)).toBe(false);
     expect(existsSync(archived)).toBe(true);
   });
@@ -147,30 +131,30 @@ describe("candidates module", () => {
 
 describe("review approve command", () => {
   it("writes the candidate body into wiki/concepts and clears the candidate", async () => {
-    const candidate = await writeCandidate(tmpDir, sampleDraft());
+    const candidate = await writeCandidate(root.dir, sampleDraft());
     vi.spyOn(console, "log").mockImplementation(() => {});
 
     await reviewApproveCommand(candidate.id);
 
-    const pagePath = path.join(tmpDir, CONCEPTS_DIR, "sample-concept.md");
+    const pagePath = path.join(root.dir, CONCEPTS_DIR, "sample-concept.md");
     expect(existsSync(pagePath)).toBe(true);
     const content = await readFile(pagePath, "utf-8");
     expect(content).toBe(VALID_BODY);
 
-    const candidateFile = path.join(tmpDir, CANDIDATES_DIR, `${candidate.id}.json`);
+    const candidateFile = path.join(root.dir, CANDIDATES_DIR, `${candidate.id}.json`);
     expect(existsSync(candidateFile)).toBe(false);
   });
 
   it("rejects approval when the candidate body is invalid", async () => {
     const draft = { ...sampleDraft("broken"), body: "no frontmatter here" };
-    const candidate = await writeCandidate(tmpDir, draft);
+    const candidate = await writeCandidate(root.dir, draft);
     vi.spyOn(console, "log").mockImplementation(() => {});
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     await reviewApproveCommand(candidate.id);
 
     expect(process.exitCode).toBe(1);
-    expect(existsSync(path.join(tmpDir, CONCEPTS_DIR, "broken.md"))).toBe(false);
+    expect(existsSync(path.join(root.dir, CONCEPTS_DIR, "broken.md"))).toBe(false);
     process.exitCode = 0;
     errorSpy.mockRestore();
   });
@@ -178,13 +162,13 @@ describe("review approve command", () => {
 
 describe("review reject command", () => {
   it("archives the candidate without touching wiki/concepts", async () => {
-    const candidate = await writeCandidate(tmpDir, sampleDraft());
+    const candidate = await writeCandidate(root.dir, sampleDraft());
     vi.spyOn(console, "log").mockImplementation(() => {});
 
     await reviewRejectCommand(candidate.id);
 
-    expect(existsSync(path.join(tmpDir, CONCEPTS_DIR, "sample-concept.md"))).toBe(false);
-    const archivePath = path.join(tmpDir, CANDIDATES_ARCHIVE_DIR, `${candidate.id}.json`);
+    expect(existsSync(path.join(root.dir, CONCEPTS_DIR, "sample-concept.md"))).toBe(false);
+    const archivePath = path.join(root.dir, CANDIDATES_ARCHIVE_DIR, `${candidate.id}.json`);
     expect(existsSync(archivePath)).toBe(true);
   });
 
@@ -205,7 +189,7 @@ describe("review list and show commands", () => {
   });
 
   it("show prints the candidate id, slug, and body", async () => {
-    const candidate = await writeCandidate(tmpDir, sampleDraft());
+    const candidate = await writeCandidate(root.dir, sampleDraft());
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     await reviewShowCommand(candidate.id);
     const allOutput = logSpy.mock.calls.map((args) => args.join(" ")).join("\n");
@@ -218,7 +202,7 @@ describe("review list and show commands", () => {
 describe("compile --review pipeline integration", () => {
   it("creates candidates and leaves wiki/ untouched", async () => {
     await writeFile(
-      path.join(tmpDir, "sources", "topic.md"),
+      path.join(root.dir, "sources", "topic.md"),
       "# Topic\nA brief article about a single topic.",
     );
 
@@ -234,15 +218,15 @@ describe("compile --review pipeline integration", () => {
       return "## Topic\n\nThe page body for the topic.";
     });
 
-    const result = await compileAndReport(tmpDir, { review: true });
+    const result = await compileAndReport(root.dir, { review: true });
     expect(callSpy).toHaveBeenCalled();
     expect(result.candidates ?? []).toHaveLength(1);
 
     // Pages on disk: only the candidate, never the wiki page.
-    const conceptsDir = path.join(tmpDir, CONCEPTS_DIR);
+    const conceptsDir = path.join(root.dir, CONCEPTS_DIR);
     expect(existsSync(path.join(conceptsDir, "topic.md"))).toBe(false);
 
-    const candidateFiles = await readdir(path.join(tmpDir, CANDIDATES_DIR));
+    const candidateFiles = await readdir(path.join(root.dir, CANDIDATES_DIR));
     expect(candidateFiles.filter((f) => f.endsWith(".json"))).toHaveLength(1);
   });
 
@@ -257,7 +241,7 @@ describe("compile --review pipeline integration", () => {
    */
   it("does not regenerate a candidate for a source that was approved", async () => {
     await writeFile(
-      path.join(tmpDir, "sources", "topic.md"),
+      path.join(root.dir, "sources", "topic.md"),
       "# Topic\nA brief article about a single topic.",
     );
 
@@ -274,13 +258,13 @@ describe("compile --review pipeline integration", () => {
     });
     vi.spyOn(console, "log").mockImplementation(() => {});
 
-    const first = await compileAndReport(tmpDir, { review: true });
+    const first = await compileAndReport(root.dir, { review: true });
     expect(first.candidates).toHaveLength(1);
 
     const candidateId = first.candidates![0];
     await reviewApproveCommand(candidateId);
 
-    const second = await compileAndReport(tmpDir, { review: true });
+    const second = await compileAndReport(root.dir, { review: true });
     expect(second.candidates ?? []).toHaveLength(0);
     expect(second.compiled).toBe(0);
     expect(second.skipped).toBeGreaterThanOrEqual(1);
@@ -298,23 +282,23 @@ describe("compile --review pipeline integration", () => {
    */
   it("defers source-state persistence until every candidate from a source is approved", async () => {
     await writeFile(
-      path.join(tmpDir, "sources", "topic.md"),
+      path.join(root.dir, "sources", "topic.md"),
       "# Topic\nA brief article covering two related concepts.",
     );
     await stubMultiConceptLLM();
     vi.spyOn(console, "log").mockImplementation(() => {});
 
-    const first = await compileAndReport(tmpDir, { review: true });
+    const first = await compileAndReport(root.dir, { review: true });
     expect(first.candidates).toHaveLength(2);
 
     const [firstId, secondId] = first.candidates!;
     await reviewApproveCommand(firstId);
-    expect(await readSourceState(tmpDir, "topic.md")).toBeUndefined();
+    expect(await readSourceState(root.dir, "topic.md")).toBeUndefined();
 
     await reviewApproveCommand(secondId);
-    expect(await readSourceState(tmpDir, "topic.md")).toBeDefined();
+    expect(await readSourceState(root.dir, "topic.md")).toBeDefined();
 
-    const followup = await compileAndReport(tmpDir, { review: true });
+    const followup = await compileAndReport(root.dir, { review: true });
     expect(followup.candidates ?? []).toHaveLength(0);
     expect(followup.compiled).toBe(0);
   });
@@ -325,15 +309,15 @@ describe("compile --review pipeline integration", () => {
    * deferred to the next non-review compile pass.
    */
   it("does not mark wiki pages orphaned when a source is deleted in review mode", async () => {
-    await seedExistingPage(tmpDir, "topic", ["topic"]);
+    await seedExistingPage(root.dir, "topic", ["topic"]);
     vi.spyOn(console, "log").mockImplementation(() => {});
 
     // Source absent from sources/ but present in state.json → detected as deleted.
-    const result = await compileAndReport(tmpDir, { review: true });
+    const result = await compileAndReport(root.dir, { review: true });
     expect(result.deleted).toBe(1);
 
     const pageContent = await readFile(
-      path.join(tmpDir, CONCEPTS_DIR, "topic.md"),
+      path.join(root.dir, CONCEPTS_DIR, "topic.md"),
       "utf-8",
     );
     expect(pageContent).not.toContain("orphaned: true");


### PR DESCRIPTION
Implements a review queue so compile output can be inspected before pages land in `wiki/`. Opt-in via `llmwiki compile --review` — default behavior is unchanged.

## Surface

| Command | Behavior |
|---|---|
| `llmwiki compile --review` | Writes candidates to `.llmwiki/candidates/` instead of `wiki/`. Defers orphan-marking and frozen-slug persistence until next non-review compile (advertised in help text). |
| `llmwiki review list` | Shows pending candidates. |
| `llmwiki review show <id>` | Prints title, summary, body, sources. |
| `llmwiki review approve <id>` | Writes the page into `wiki/` and refreshes index/MOC/embeddings. Persists source state only when no sibling candidates remain for that source. |
| `llmwiki review reject <id>` | Archives the candidate to `.llmwiki/candidates/archive/` without touching `wiki/`. |

MCP `wiki_status` exposes `pendingCandidates` so agents can detect work in the queue.

## Concurrency

`approve` and `reject` acquire `.llmwiki/lock` (the same lock `compile` uses) and re-read the candidate under lock to close the TOCTOU window between pre-check and mutation. Lock-busy returns exit code 1 rather than degrading.

## Test plan

- [x] `npm test` — 258 tests pass (37 new across the feature)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `npx fallow` 0 above threshold
- [x] CLI integration tests cover help, error paths, seed→list/show/reject(archive)/approve(write+clear) round trips
- [x] MCP `wiki_status.pendingCandidates` test
- [x] Multi-candidate-per-source regression: approving one does not falsely complete the source
- [x] Review-mode regression: `compile --review` does not orphan-mark deleted sources
- [x] Concurrency regression: candidate disappearing between pre-check and lock acquisition aborts cleanly without writing

## Known limitations

Subprocess-level happy-path `compile --review` is covered programmatically rather than via the CLI integration suite — `callClaude` cannot be stubbed across a child-process boundary without fake-provider infrastructure that doesn't yet exist. Tracked as a separate concern; programmatic coverage in `test/review.test.ts` exercises the full pipeline.

Closes the candidate-review-queue item from the next-feature roadmap.