### PR TITLE
Add confidence, contradiction, and provenance-state metadata

### DIFF
--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -37,6 +37,7 @@ import {
   type ExtractionResult,
 } from "./deps.js";
 import { markOrphaned, orphanUnownedFrozenPages } from "./orphan.js";
+import { addProvenanceMeta, reportContradictionWarnings } from "./provenance.js";
 import { resolveLinks } from "./resolver.js";
 import { generateIndex } from "./indexgen.js";
 import { addObsidianMeta, generateMOC } from "./obsidian.js";
@@ -403,6 +404,8 @@ async function generateMergedPage(
     updatedAt: now,
   };
   addObsidianMeta(frontmatterFields, entry.concept.concept, entry.concept.tags ?? []);
+  addProvenanceMeta(frontmatterFields, entry.concept);
+  reportContradictionWarnings(entry.concept.concept, entry.concept);
   const frontmatter = buildFrontmatter(frontmatterFields);
   const fullPage = `${frontmatter}\n\n${pageBody}\n`;
   return await writePageIfValid(pagePath, fullPage, entry.concept.concept);

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -328,10 +328,60 @@ interface MergedConcept {
 }
 
 /**
+ * Reconcile metadata from a later-extracted concept into an existing merged entry.
+ * Called when multiple sources contribute the same slug — produces the most
+ * pessimistic aggregate view of confidence, provenance, and contradictions.
+ *
+ * Rules:
+ * - confidence: min (most pessimistic value wins)
+ * - provenanceState: always 'merged' once two sources are involved
+ * - contradictedBy: union by slug (deduplicating on slug identity)
+ * - inferredParagraphs: max (any source claiming inference wins)
+ */
+export function reconcileConceptMetadata(
+  existing: ExtractedConcept,
+  incoming: ExtractedConcept,
+): ExtractedConcept {
+  const reconciled = { ...existing };
+
+  // Minimum confidence — the weaker source's score governs the whole page.
+  if (typeof incoming.confidence === "number") {
+    reconciled.confidence = typeof existing.confidence === "number"
+      ? Math.min(existing.confidence, incoming.confidence)
+      : incoming.confidence;
+  }
+
+  // Merged state is the canonical answer when multiple sources contribute.
+  reconciled.provenanceState = "merged";
+
+  // Union contradictedBy entries, deduplicating by slug.
+  const refs = [...(existing.contradictedBy ?? [])];
+  const seenSlugs = new Set(refs.map((r) => r.slug));
+  for (const ref of incoming.contradictedBy ?? []) {
+    if (!seenSlugs.has(ref.slug)) {
+      refs.push(ref);
+      seenSlugs.add(ref.slug);
+    }
+  }
+  reconciled.contradictedBy = refs.length > 0 ? refs : undefined;
+
+  // Max inferredParagraphs — any source flagging inference raises the count.
+  if (typeof incoming.inferredParagraphs === "number") {
+    reconciled.inferredParagraphs = typeof existing.inferredParagraphs === "number"
+      ? Math.max(existing.inferredParagraphs, incoming.inferredParagraphs)
+      : incoming.inferredParagraphs;
+  }
+
+  return reconciled;
+}
+
+/**
  * Merge extractions so each concept slug maps to ALL contributing sources.
  * When sources A and B both extract concept X, the LLM receives combined
  * content from both sources, producing a single page that reflects all
  * contributing material rather than just the last source processed.
+ * Metadata is reconciled across all contributing concepts via
+ * reconcileConceptMetadata so contradictions from later sources are not lost.
  */
 function mergeExtractions(
   extractions: ExtractionResult[],
@@ -348,6 +398,7 @@ function mergeExtractions(
 
       const existing = bySlug.get(slug);
       if (existing) {
+        existing.concept = reconcileConceptMetadata(existing.concept, concept);
         existing.sourceFiles.push(result.sourceFile);
         existing.combinedContent += `\n\n--- SOURCE: ${result.sourceFile} ---\n\n${result.sourceContent}`;
       } else {

--- a/src/compiler/prompts.ts
+++ b/src/compiler/prompts.ts
@@ -5,7 +5,19 @@
  * and a parser for the structured tool output.
  */
 
-import type { ExtractedConcept } from "../utils/types.js";
+import type {
+  ContradictionRef,
+  ExtractedConcept,
+  ProvenanceState,
+} from "../utils/types.js";
+
+/** Allowed provenance state strings emitted by the LLM tool schema. */
+const PROVENANCE_STATE_VALUES: ProvenanceState[] = [
+  "extracted",
+  "merged",
+  "inferred",
+  "ambiguous",
+];
 
 /**
  * Anthropic Tool definition for extracting knowledge concepts from a source.
@@ -40,6 +52,34 @@ export const CONCEPT_EXTRACTION_TOOL = {
               description:
                 "2-4 categorical tags for organizing this concept (e.g., 'machine-learning', 'optimization')",
             },
+            confidence: {
+              type: "number",
+              description:
+                "Confidence in this concept on a 0..1 scale (1 = directly stated, 0 = highly speculative).",
+            },
+            provenance_state: {
+              type: "string",
+              enum: PROVENANCE_STATE_VALUES,
+              description:
+                "How this concept was produced: 'extracted' (direct from source), 'merged' (synthesised across sources), 'inferred' (model deduction), or 'ambiguous' (sources disagree).",
+            },
+            contradicted_by: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  slug: { type: "string", description: "Slug of the contradicting concept." },
+                  reason: { type: "string", description: "Brief reason for the contradiction." },
+                },
+                required: ["slug"],
+              },
+              description: "Slugs of other concepts whose evidence contradicts this one.",
+            },
+            inferred_paragraphs: {
+              type: "integer",
+              description:
+                "Estimated number of paragraphs in the page that will be inferred rather than directly cited.",
+            },
           },
           required: ["concept", "summary", "is_new"],
         },
@@ -70,6 +110,17 @@ export function buildExtractionPrompt(
     "Each concept should be a standalone topic that someone might look up.",
     "Focus on key ideas, techniques, patterns, or entities — not trivial details.",
     "Use the extract_concepts tool to return your findings.",
+    "",
+    "For every concept, emit provenance metadata so downstream tools can reason",
+    "about reliability:",
+    "  - confidence: 0..1 — how certain you are the source supports this concept.",
+    "  - provenance_state: 'extracted' if directly stated, 'merged' if synthesised",
+    "    from multiple parts of the source, 'inferred' if reasoned from context,",
+    "    or 'ambiguous' if the source is contradictory or unclear.",
+    "  - contradicted_by: slugs of other concepts (in this batch or the index)",
+    "    whose evidence conflicts with this one.",
+    "  - inferred_paragraphs: estimated number of paragraphs in the resulting",
+    "    page that will be inferred rather than directly citable.",
     indexSection,
     "\n\n--- SOURCE DOCUMENT ---\n\n",
     sourceContent,
@@ -111,11 +162,73 @@ export function buildPagePrompt(
     "Format: ^[filename.md] for single-source, ^[source-a.md, source-b.md] for multi-source.",
     "Place citations only at the end of prose paragraphs — not on headings, list items, or code blocks.",
     "Source filenames are visible as `--- SOURCE: filename.md ---` headers in the content below.",
+    "",
+    "If a paragraph is your inference rather than a direct extraction, leave it",
+    "uncited — downstream lint rules will count uncited paragraphs as 'inferred'",
+    "to compute the page's provenance metadata.",
     existingSection,
     relatedSection,
     "\n\n--- SOURCE MATERIAL ---\n\n",
     sourceContent,
   ].join("\n");
+}
+
+/** Raw concept shape as it arrives from the tool JSON. */
+interface RawConcept {
+  concept: unknown;
+  summary: unknown;
+  is_new: unknown;
+  tags?: unknown;
+  confidence?: unknown;
+  provenance_state?: unknown;
+  contradicted_by?: unknown;
+  inferred_paragraphs?: unknown;
+}
+
+/** True if the raw concept has the required string/boolean fields. */
+function isValidRawConcept(c: RawConcept): boolean {
+  return (
+    typeof c.concept === "string" &&
+    typeof c.summary === "string" &&
+    typeof c.is_new === "boolean" &&
+    (c.tags === undefined || Array.isArray(c.tags))
+  );
+}
+
+/** Coerce raw contradiction entries from the tool into typed refs. */
+function coerceContradictedBy(raw: unknown): ContradictionRef[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const refs: ContradictionRef[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const obj = entry as { slug?: unknown; reason?: unknown };
+    if (typeof obj.slug !== "string" || obj.slug.trim().length === 0) continue;
+    const ref: ContradictionRef = { slug: obj.slug.trim() };
+    if (typeof obj.reason === "string") ref.reason = obj.reason;
+    refs.push(ref);
+  }
+  return refs.length > 0 ? refs : undefined;
+}
+
+/** Map a validated raw concept into an ExtractedConcept. */
+function mapRawConcept(c: RawConcept): ExtractedConcept {
+  const provenance = typeof c.provenance_state === "string" &&
+    PROVENANCE_STATE_VALUES.includes(c.provenance_state as ProvenanceState)
+    ? (c.provenance_state as ProvenanceState)
+    : undefined;
+  return {
+    concept: c.concept as string,
+    summary: c.summary as string,
+    is_new: c.is_new as boolean,
+    tags: Array.isArray(c.tags) ? (c.tags as string[]) : undefined,
+    confidence: typeof c.confidence === "number" ? c.confidence : undefined,
+    provenanceState: provenance,
+    contradictedBy: coerceContradictedBy(c.contradicted_by),
+    inferredParagraphs: typeof c.inferred_paragraphs === "number" &&
+      Number.isInteger(c.inferred_paragraphs) && c.inferred_paragraphs >= 0
+      ? c.inferred_paragraphs
+      : undefined,
+  };
 }
 
 /**
@@ -126,21 +239,8 @@ export function buildPagePrompt(
 export function parseConcepts(toolOutput: string): ExtractedConcept[] {
   try {
     const parsed = JSON.parse(toolOutput);
-    const concepts: ExtractedConcept[] = parsed.concepts ?? [];
-    return concepts
-      .filter(
-        (c) =>
-          typeof c.concept === "string" &&
-          typeof c.summary === "string" &&
-          typeof c.is_new === "boolean" &&
-          (c.tags === undefined || Array.isArray(c.tags)),
-      )
-      .map((c) => ({
-        concept: c.concept,
-        summary: c.summary,
-        is_new: c.is_new,
-        tags: Array.isArray(c.tags) ? c.tags : undefined,
-      }));
+    const concepts: RawConcept[] = parsed.concepts ?? [];
+    return concepts.filter(isValidRawConcept).map(mapRawConcept);
   } catch {
     return [];
   }

--- a/src/compiler/provenance.ts
+++ b/src/compiler/provenance.ts
@@ -1,0 +1,55 @@
+/**
+ * Helpers for surfacing provenance metadata during compilation.
+ *
+ * Keeps the compile orchestrator small by isolating the logic that copies
+ * confidence/contradiction signals from extracted concepts onto wiki page
+ * frontmatter and emits compile-time warnings when contradictions are
+ * reported.
+ */
+
+import * as output from "../utils/output.js";
+import type { ExtractedConcept } from "../utils/types.js";
+
+/**
+ * Copy provenance metadata fields from an extracted concept onto the
+ * frontmatter record, omitting fields the LLM did not provide so existing
+ * pages without these fields stay clean.
+ * @param fields - Mutable frontmatter record being assembled for a page.
+ * @param concept - Source concept whose provenance metadata to apply.
+ */
+export function addProvenanceMeta(
+  fields: Record<string, unknown>,
+  concept: ExtractedConcept,
+): void {
+  if (typeof concept.confidence === "number") {
+    fields.confidence = concept.confidence;
+  }
+  if (concept.provenanceState) {
+    fields.provenanceState = concept.provenanceState;
+  }
+  if (concept.contradictedBy && concept.contradictedBy.length > 0) {
+    fields.contradictedBy = concept.contradictedBy;
+  }
+  if (typeof concept.inferredParagraphs === "number") {
+    fields.inferredParagraphs = concept.inferredParagraphs;
+  }
+}
+
+/**
+ * Print a compile-time warning when a concept reports contradictions with
+ * other pages. Returns silently when there is nothing to report.
+ * @param conceptTitle - Human-readable title of the concept being compiled.
+ * @param concept - The extracted concept whose contradictions to surface.
+ */
+export function reportContradictionWarnings(
+  conceptTitle: string,
+  concept: ExtractedConcept,
+): void {
+  const refs = concept.contradictedBy;
+  if (!refs || refs.length === 0) return;
+  const slugs = refs.map((r) => r.slug).join(", ");
+  output.status(
+    "!",
+    output.warn(`Contradiction reported on "${conceptTitle}" — conflicts with: ${slugs}`),
+  );
+}

--- a/src/linter/index.ts
+++ b/src/linter/index.ts
@@ -14,6 +14,9 @@ import {
   checkDuplicateConcepts,
   checkEmptyPages,
   checkBrokenCitations,
+  checkLowConfidencePages,
+  checkContradictedPages,
+  checkInferredWithoutCitations,
 } from "./rules.js";
 
 /** All lint rules to execute during a lint pass. */
@@ -24,6 +27,9 @@ const ALL_RULES: LintRule[] = [
   checkDuplicateConcepts,
   checkEmptyPages,
   checkBrokenCitations,
+  checkLowConfidencePages,
+  checkContradictedPages,
+  checkInferredWithoutCitations,
 ];
 
 /**

--- a/src/linter/rules.ts
+++ b/src/linter/rules.ts
@@ -10,8 +10,14 @@
 import { readdir, readFile } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
-import { parseFrontmatter, slugify } from "../utils/markdown.js";
-import { CONCEPTS_DIR, QUERIES_DIR, SOURCES_DIR } from "../utils/constants.js";
+import { parseFrontmatter, parseProvenanceMetadata, slugify } from "../utils/markdown.js";
+import {
+  CONCEPTS_DIR,
+  LOW_CONFIDENCE_THRESHOLD,
+  MAX_INFERRED_PARAGRAPHS_WITHOUT_CITATIONS,
+  QUERIES_DIR,
+  SOURCES_DIR,
+} from "../utils/constants.js";
 import type { LintResult } from "./types.js";
 
 /** Minimum body length (in characters) for a page to be considered non-empty. */
@@ -214,6 +220,97 @@ export async function checkEmptyPages(root: string): Promise<LintResult[]> {
   }
 
   return results;
+}
+
+/**
+ * Flag pages whose frontmatter declares confidence below the threshold.
+ * Pages without a confidence field are silently skipped to preserve
+ * backward-compatibility with pre-existing wikis.
+ */
+export async function checkLowConfidencePages(root: string): Promise<LintResult[]> {
+  const pages = await collectAllPages(root);
+  const results: LintResult[] = [];
+
+  for (const page of pages) {
+    const { meta } = parseFrontmatter(page.content);
+    const { confidence } = parseProvenanceMetadata(meta);
+    if (confidence === undefined || confidence >= LOW_CONFIDENCE_THRESHOLD) continue;
+    results.push({
+      rule: "low-confidence",
+      severity: "warning",
+      file: page.filePath,
+      message: `Page confidence ${confidence.toFixed(2)} is below ${LOW_CONFIDENCE_THRESHOLD}`,
+    });
+  }
+
+  return results;
+}
+
+/** Flag pages whose frontmatter records contradictions with other pages. */
+export async function checkContradictedPages(root: string): Promise<LintResult[]> {
+  const pages = await collectAllPages(root);
+  const results: LintResult[] = [];
+
+  for (const page of pages) {
+    const { meta } = parseFrontmatter(page.content);
+    const { contradictedBy } = parseProvenanceMetadata(meta);
+    if (!contradictedBy || contradictedBy.length === 0) continue;
+    const slugs = contradictedBy.map((r) => r.slug).join(", ");
+    results.push({
+      rule: "contradicted-page",
+      severity: "warning",
+      file: page.filePath,
+      message: `Page contradicts: ${slugs}`,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Flag pages with too many inferred paragraphs unsupported by direct citations.
+ * Uses the metadata-reported count when present and falls back to counting
+ * uncited prose paragraphs in the body.
+ */
+export async function checkInferredWithoutCitations(root: string): Promise<LintResult[]> {
+  const pages = await collectAllPages(root);
+  const results: LintResult[] = [];
+
+  for (const page of pages) {
+    const { meta, body } = parseFrontmatter(page.content);
+    const provenance = parseProvenanceMetadata(meta);
+    const inferred = provenance.inferredParagraphs ?? countUncitedProseParagraphs(body);
+    if (inferred <= MAX_INFERRED_PARAGRAPHS_WITHOUT_CITATIONS) continue;
+    results.push({
+      rule: "excess-inferred-paragraphs",
+      severity: "warning",
+      file: page.filePath,
+      message: `Page has ${inferred} inferred paragraphs without citations (max ${MAX_INFERRED_PARAGRAPHS_WITHOUT_CITATIONS})`,
+    });
+  }
+
+  return results;
+}
+
+/** Match a paragraph that looks like prose (not a heading, list, or code block). */
+const PROSE_PARAGRAPH_LEAD = /^[A-Za-z]/;
+
+/** Count prose paragraphs in a body that lack a ^[citation] marker. */
+function countUncitedProseParagraphs(body: string): number {
+  const paragraphs = body.split(/\n\s*\n/);
+  let count = 0;
+  for (const block of paragraphs) {
+    const trimmed = block.trim();
+    if (trimmed.length === 0) continue;
+    if (!PROSE_PARAGRAPH_LEAD.test(trimmed)) continue;
+    if (CITATION_PATTERN.test(trimmed)) {
+      CITATION_PATTERN.lastIndex = 0;
+      continue;
+    }
+    CITATION_PATTERN.lastIndex = 0;
+    count += 1;
+  }
+  return count;
 }
 
 /** Find ^[filename.md] citations referencing source files that don't exist. */

--- a/src/linter/rules.ts
+++ b/src/linter/rules.ts
@@ -313,7 +313,21 @@ function countUncitedProseParagraphs(body: string): number {
   return count;
 }
 
-/** Find ^[filename.md] citations referencing source files that don't exist. */
+/**
+ * Expand a captured citation string into individual source filenames.
+ * A multi-source citation like "a.md, b.md" is split on commas so each
+ * filename can be checked independently. Single-source citations are
+ * returned as a one-element array unchanged.
+ */
+function splitCitationFilenames(captured: string): string[] {
+  return captured.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+/** Find ^[filename.md] citations referencing source files that don't exist.
+ * Handles both single-source ^[file.md] and multi-source ^[a.md, b.md] forms.
+ * Each filename in a multi-source citation is checked independently — only the
+ * missing ones are reported, not the entire captured text as one filename.
+ */
 export async function checkBrokenCitations(root: string): Promise<LintResult[]> {
   const pages = await collectAllPages(root);
   const sourcesDir = path.join(root, SOURCES_DIR);
@@ -321,15 +335,17 @@ export async function checkBrokenCitations(root: string): Promise<LintResult[]> 
 
   for (const page of pages) {
     for (const { captured, line } of findMatchesInContent(page.content, CITATION_PATTERN)) {
-      const citedPath = path.join(sourcesDir, captured);
-      if (!existsSync(citedPath)) {
-        results.push({
-          rule: "broken-citation",
-          severity: "error",
-          file: page.filePath,
-          message: `Broken citation ^[${captured}] — source file not found`,
-          line,
-        });
+      for (const filename of splitCitationFilenames(captured)) {
+        const citedPath = path.join(sourcesDir, filename);
+        if (!existsSync(citedPath)) {
+          results.push({
+            rule: "broken-citation",
+            severity: "error",
+            file: page.filePath,
+            message: `Broken citation ^[${filename}] — source file not found`,
+            line,
+          });
+        }
       }
     }
   }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -48,6 +48,10 @@ export const EMBEDDINGS_FILE = ".llmwiki/embeddings.json";
 /** Number of most similar pages to return from embedding-based pre-filter. */
 export const EMBEDDING_TOP_K = 15;
 
+/** Provenance metadata thresholds used by lint rules. */
+export const LOW_CONFIDENCE_THRESHOLD = 0.5;
+export const MAX_INFERRED_PARAGRAPHS_WITHOUT_CITATIONS = 2;
+
 /** Embedding model to use per provider. */
 export const EMBEDDING_MODELS: Record<string, string> = {
   anthropic: "voyage-3-lite",

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -7,6 +7,23 @@
 import { writeFile, rename, readFile, mkdir } from "fs/promises";
 import path from "path";
 import yaml from "js-yaml";
+import type { ContradictionRef, ProvenanceState } from "./types.js";
+
+/** The set of valid provenance state strings, used to reject unknown values. */
+const VALID_PROVENANCE_STATES: ReadonlySet<ProvenanceState> = new Set([
+  "extracted",
+  "merged",
+  "inferred",
+  "ambiguous",
+]);
+
+/** Provenance metadata parsed from a page's frontmatter. */
+interface ProvenanceMetadata {
+  confidence?: number;
+  provenanceState?: ProvenanceState;
+  contradictedBy?: ContradictionRef[];
+  inferredParagraphs?: number;
+}
 
 /** Convert a human-readable concept title to a filename slug. */
 export function slugify(title: string): string {
@@ -86,6 +103,70 @@ export async function safeReadFile(filePath: string): Promise<string> {
   } catch {
     return "";
   }
+}
+
+/** Parse a numeric confidence value, clamping to 0..1 and rejecting non-numbers. */
+function parseConfidence(raw: unknown): number | undefined {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return undefined;
+  if (raw < 0) return 0;
+  if (raw > 1) return 1;
+  return raw;
+}
+
+/** Parse a provenance state string, returning undefined for unknown values. */
+function parseProvenanceState(raw: unknown): ProvenanceState | undefined {
+  if (typeof raw !== "string") return undefined;
+  return VALID_PROVENANCE_STATES.has(raw as ProvenanceState)
+    ? (raw as ProvenanceState)
+    : undefined;
+}
+
+/** Coerce a single contradiction entry to a ContradictionRef, or null if invalid. */
+function coerceContradictionEntry(entry: unknown): ContradictionRef | null {
+  if (typeof entry === "string" && entry.trim().length > 0) {
+    return { slug: entry.trim() };
+  }
+  if (entry && typeof entry === "object" && "slug" in entry) {
+    const obj = entry as { slug: unknown; reason?: unknown };
+    if (typeof obj.slug !== "string" || obj.slug.trim().length === 0) return null;
+    const ref: ContradictionRef = { slug: obj.slug.trim() };
+    if (typeof obj.reason === "string") ref.reason = obj.reason;
+    return ref;
+  }
+  return null;
+}
+
+/** Parse a contradictedBy array, accepting strings or objects with slug. */
+function parseContradictedBy(raw: unknown): ContradictionRef[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const refs = raw
+    .map(coerceContradictionEntry)
+    .filter((ref): ref is ContradictionRef => ref !== null);
+  return refs.length > 0 ? refs : undefined;
+}
+
+/** Parse the inferred paragraph count, requiring a non-negative integer. */
+function parseInferredParagraphs(raw: unknown): number | undefined {
+  if (typeof raw !== "number" || !Number.isInteger(raw) || raw < 0) return undefined;
+  return raw;
+}
+
+/**
+ * Extract provenance metadata fields from a parsed frontmatter record.
+ * Defensively handles missing or malformed values so existing pages without
+ * the new fields continue to parse correctly.
+ * @param meta - Raw frontmatter object as returned by parseFrontmatter.
+ * @returns Typed provenance metadata with only the fields that were present.
+ */
+export function parseProvenanceMetadata(
+  meta: Record<string, unknown>,
+): ProvenanceMetadata {
+  return {
+    confidence: parseConfidence(meta.confidence),
+    provenanceState: parseProvenanceState(meta.provenanceState),
+    contradictedBy: parseContradictedBy(meta.contradictedBy),
+    inferredParagraphs: parseInferredParagraphs(meta.inferredParagraphs),
+  };
 }
 
 /**

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -3,12 +3,41 @@
  * All shared interfaces live here to keep the module boundary clean.
  */
 
+/**
+ * Lifecycle state of a concept or page's provenance.
+ * - `extracted`: drawn directly from a source document.
+ * - `merged`: synthesised from multiple sources during compilation.
+ * - `inferred`: produced by the model from context, not directly cited.
+ * - `ambiguous`: sources disagree or evidence is conflicting.
+ */
+export type ProvenanceState = "extracted" | "merged" | "inferred" | "ambiguous";
+
+/**
+ * Reference to another concept that contradicts the current one.
+ * The slug points to the contradicting wiki page.
+ */
+export interface ContradictionRef {
+  slug: string;
+  reason?: string;
+}
+
 /** A single concept extracted from a source by the LLM. */
 export interface ExtractedConcept {
   concept: string;
   summary: string;
   is_new: boolean;
   tags?: string[];
+  /** Numeric confidence in 0..1 — how certain the model is in this concept. */
+  confidence?: number;
+  /** Lifecycle state describing how this concept was produced. */
+  provenanceState?: ProvenanceState;
+  /** Slugs of concepts whose evidence contradicts this one. */
+  contradictedBy?: ContradictionRef[];
+  /**
+   * Number of paragraphs the model considers inferred (not directly extracted).
+   * Used by the inferred-without-citations lint rule.
+   */
+  inferredParagraphs?: number;
 }
 
 /** Per-source entry in .llmwiki/state.json. */
@@ -43,6 +72,14 @@ interface WikiFrontmatter {
   aliases?: string[];
   createdAt: string;
   updatedAt: string;
+  /** Numeric confidence in 0..1 — overall confidence in the page's claims. */
+  confidence?: number;
+  /** Lifecycle state describing how the page's content was produced. */
+  provenanceState?: ProvenanceState;
+  /** Slugs of pages whose evidence contradicts this one. */
+  contradictedBy?: ContradictionRef[];
+  /** Number of inferred paragraphs in the page body without direct citations. */
+  inferredParagraphs?: number;
 }
 
 /** Summary entry used in index.md generation. */

--- a/test/compile-provenance.test.ts
+++ b/test/compile-provenance.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Compile-path tests for provenance metadata (confidence, contradictions,
+ * and provenanceState) flowing end-to-end through compileAndReport().
+ *
+ * These tests verify that metadata the LLM returns during concept extraction
+ * is faithfully written into the wiki page frontmatter and that contradiction
+ * warnings are emitted at compile time.
+ *
+ * Strategy: stub the AnthropicProvider so no real API calls are made.
+ *   - toolCall() returns extraction JSON with the desired provenance fields.
+ *   - complete() returns a minimal wiki-page body.
+ * The compiled output is then read back and parsed to assert on frontmatter.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdir, rm, writeFile, readFile } from "fs/promises";
+import path from "path";
+import os from "os";
+import { compileAndReport } from "../src/compiler/index.js";
+import { parseFrontmatter, parseProvenanceMetadata } from "../src/utils/markdown.js";
+import { AnthropicProvider } from "../src/providers/anthropic.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal project root with one source file. */
+async function makeProjectRoot(suffix: string): Promise<string> {
+  const root = path.join(os.tmpdir(), `llmwiki-compile-prov-${suffix}-${Date.now()}`);
+  await mkdir(path.join(root, "sources"), { recursive: true });
+  await mkdir(path.join(root, "wiki", "concepts"), { recursive: true });
+  await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+  await writeFile(
+    path.join(root, "sources", "sample.md"),
+    "# Sample\n\nSome source content about a topic.",
+    "utf-8",
+  );
+  return root;
+}
+
+/** Extraction tool JSON that instructs the compiler to produce provenance metadata. */
+function buildExtractionResponse(): string {
+  return JSON.stringify({
+    concepts: [
+      {
+        concept: "Sample Topic",
+        summary: "A topic with stubbed provenance metadata.",
+        is_new: true,
+        confidence: 0.3,
+        provenance_state: "inferred",
+        contradicted_by: [{ slug: "other", reason: "conflicting evidence" }],
+        inferred_paragraphs: 2,
+      },
+    ],
+  });
+}
+
+/** Minimal wiki page body returned by the page-generation stub. */
+const STUB_PAGE_BODY = "The sample topic is described here. ^[sample.md]";
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe("compile-path provenance metadata", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    process.env.LLMWIKI_PROVIDER = "anthropic";
+    process.env.ANTHROPIC_API_KEY = "test-key";
+    tmpDir = await makeProjectRoot("meta");
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    delete process.env.LLMWIKI_PROVIDER;
+    delete process.env.ANTHROPIC_API_KEY;
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes confidence, provenanceState, and contradictedBy into frontmatter", async () => {
+    vi.spyOn(AnthropicProvider.prototype, "toolCall").mockResolvedValue(
+      buildExtractionResponse(),
+    );
+    vi.spyOn(AnthropicProvider.prototype, "complete").mockResolvedValue(STUB_PAGE_BODY);
+
+    await compileAndReport(tmpDir);
+
+    const pagePath = path.join(tmpDir, "wiki", "concepts", "sample-topic.md");
+    const content = await readFile(pagePath, "utf-8");
+    const { meta } = parseFrontmatter(content);
+    const provenance = parseProvenanceMetadata(meta);
+
+    expect(provenance.confidence).toBe(0.3);
+    expect(provenance.provenanceState).toBe("inferred");
+    expect(provenance.contradictedBy).toEqual([
+      { slug: "other", reason: "conflicting evidence" },
+    ]);
+    expect(provenance.inferredParagraphs).toBe(2);
+  });
+
+  it("emits a contradiction warning to console during compilation", async () => {
+    vi.spyOn(AnthropicProvider.prototype, "toolCall").mockResolvedValue(
+      buildExtractionResponse(),
+    );
+    vi.spyOn(AnthropicProvider.prototype, "complete").mockResolvedValue(STUB_PAGE_BODY);
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await compileAndReport(tmpDir);
+
+    // reportContradictionWarnings calls output.status("!", output.warn(...))
+    // which maps to console.log("! <yellow>Contradiction reported on...<reset>")
+    const warningLines = logSpy.mock.calls
+      .map(([line]) => (typeof line === "string" ? line : ""))
+      .filter((line) => line.includes("Contradiction reported on"));
+
+    expect(warningLines).toHaveLength(1);
+    expect(warningLines[0]).toContain("Sample Topic");
+    expect(warningLines[0]).toContain("other");
+  });
+});

--- a/test/confidence-metadata-integration.test.ts
+++ b/test/confidence-metadata-integration.test.ts
@@ -1,0 +1,230 @@
+/**
+ * CLI-level integration tests for the confidence and contradiction metadata
+ * lint rules introduced in the feature/confidence-metadata branch.
+ *
+ * Each test spins up a temporary directory that mimics a real wiki layout,
+ * invokes `dist/cli.js lint` via execFile, and asserts on stdout/stderr and
+ * exit code. No LLM calls are made — the lint command is purely static.
+ *
+ * Directory layout used by every fixture:
+ *   <tmp>/
+ *     wiki/concepts/<page>.md   ← the wiki page under test
+ *     sources/                  ← empty dir so broken-citation rule finds nothing
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import path from "path";
+import { mkdir, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+
+const execFileAsync = promisify(execFile);
+const BUILT_CLI = path.resolve("dist/cli.js");
+
+// ---------------------------------------------------------------------------
+// Fixture and runner helpers
+// ---------------------------------------------------------------------------
+
+/** Build YAML frontmatter lines shared by every fixture page. */
+function sharedFrontmatterLines(): string[] {
+  return ["sources: []", "createdAt: 2024-01-01", "updatedAt: 2024-01-01"];
+}
+
+/**
+ * Assemble page markdown from a frontmatter key-value map and a body sentence.
+ * Keeps test declarations short and avoids repeated boilerplate arrays.
+ */
+function buildPageContent(extraFields: Record<string, string>, body: string): string {
+  const header = [
+    "---",
+    ...sharedFrontmatterLines(),
+    ...Object.entries(extraFields).map(([k, v]) => `${k}: ${v}`),
+    "---",
+    "",
+  ];
+  return [...header, body].join("\n");
+}
+
+/**
+ * Create a minimal wiki fixture in a temp directory containing one concept page.
+ * Returns the absolute path to the project root.
+ */
+async function createWikiFixture(suffix: string, pageContent: string): Promise<string> {
+  const root = path.join(tmpdir(), `llmwiki-ci-conf-${suffix}-${Date.now()}`);
+  await mkdir(path.join(root, "wiki", "concepts"), { recursive: true });
+  await mkdir(path.join(root, "sources"), { recursive: true });
+  await writeFile(path.join(root, "wiki", "concepts", `${suffix}.md`), pageContent, "utf-8");
+  return root;
+}
+
+/** Run `llmwiki lint` in the given project root, always resolving (never rejecting). */
+async function runLint(root: string): Promise<{ stdout: string; code: number }> {
+  try {
+    const { stdout } = await execFileAsync("node", [BUILT_CLI, "lint"], { cwd: root });
+    return { stdout, code: 0 };
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; code?: number };
+    return { stdout: e.stdout ?? "", code: e.code ?? 1 };
+  }
+}
+
+/** Remove a temp directory, ignoring errors on double-cleanup. */
+async function removeFixture(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true });
+}
+
+/**
+ * Assert that none of the confidence-metadata rule messages appear in output.
+ * Used by both the "clean metadata" and "no metadata at all" tests.
+ */
+function assertNoConfidenceFindings(stdout: string): void {
+  expect(stdout).not.toContain("below 0.5");
+  expect(stdout).not.toContain("contradicts");
+  expect(stdout).not.toContain("inferred paragraphs");
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("confidence metadata — CLI lint integration", () => {
+  beforeAll(async () => {
+    await execFileAsync("npx", ["tsup"], { cwd: path.resolve(".") });
+  }, 60_000);
+
+  // -------------------------------------------------------------------------
+  // low-confidence rule
+  // -------------------------------------------------------------------------
+
+  it("reports low-confidence finding when confidence is 0.2", async () => {
+    const content = buildPageContent(
+      { title: "Fragile Concept", summary: "Low confidence page.", confidence: "0.2" },
+      "This page has very low confidence and should trigger the lint warning.",
+    );
+    const root = await createWikiFixture("low-conf", content);
+    try {
+      const { stdout } = await runLint(root);
+      // The lint output prints the message text — assert on the key substrings.
+      expect(stdout).toContain("0.20");
+      expect(stdout).toContain("below 0.5");
+    } finally {
+      await removeFixture(root);
+    }
+  }, 30_000);
+
+  // -------------------------------------------------------------------------
+  // contradicted-page rule
+  // -------------------------------------------------------------------------
+
+  it("reports contradiction finding when contradictedBy is set", async () => {
+    // YAML list values need a literal multiline string, so we bypass buildPageContent.
+    const content = [
+      "---",
+      ...sharedFrontmatterLines(),
+      "title: Contradicted Concept",
+      "summary: This concept contradicts another.",
+      "contradictedBy:",
+      "  - slug: other-page",
+      "---",
+      "",
+      "This page is contradicted by other-page.",
+    ].join("\n");
+    const root = await createWikiFixture("contradiction", content);
+    try {
+      const { stdout } = await runLint(root);
+      expect(stdout).toContain("other-page");
+      expect(stdout).toContain("contradicts");
+    } finally {
+      await removeFixture(root);
+    }
+  }, 30_000);
+
+  // -------------------------------------------------------------------------
+  // excess-inferred-paragraphs rule
+  // -------------------------------------------------------------------------
+
+  it("reports excess-inferred-paragraphs when inferredParagraphs > 2 with no citations", async () => {
+    const content = buildPageContent(
+      { title: "Inferred Concept", summary: "Mostly inferred.", inferredParagraphs: "5" },
+      "This page declares five inferred paragraphs, exceeding the maximum of two.",
+    );
+    const root = await createWikiFixture("inferred", content);
+    try {
+      const { stdout } = await runLint(root);
+      // Assert on the message count and threshold text.
+      expect(stdout).toContain("5 inferred paragraphs");
+      expect(stdout).toContain("max 2");
+    } finally {
+      await removeFixture(root);
+    }
+  }, 30_000);
+
+  // -------------------------------------------------------------------------
+  // All-clean fixture — no new-rule findings
+  // -------------------------------------------------------------------------
+
+  it("reports no confidence-related findings for a page with good metadata", async () => {
+    const content = buildPageContent(
+      { title: "Clean Concept", summary: "Well-formed page.", confidence: "0.9", provenanceState: "extracted" },
+      "This page meets all quality criteria and should trigger no confidence warnings.",
+    );
+    const root = await createWikiFixture("clean", content);
+    try {
+      const { stdout } = await runLint(root);
+      assertNoConfidenceFindings(stdout);
+    } finally {
+      await removeFixture(root);
+    }
+  }, 30_000);
+
+  // -------------------------------------------------------------------------
+  // Backward compatibility — no confidence metadata at all
+  // -------------------------------------------------------------------------
+
+  it("does not surface new rule findings when pages have no confidence metadata", async () => {
+    const content = buildPageContent(
+      { title: "Legacy Concept", summary: "Older page without provenance fields." },
+      "This is an existing page created before confidence metadata was introduced.",
+    );
+    const root = await createWikiFixture("legacy", content);
+    try {
+      const { stdout } = await runLint(root);
+      // Pages without confidence fields must not trigger any of the new rules.
+      assertNoConfidenceFindings(stdout);
+    } finally {
+      await removeFixture(root);
+    }
+  }, 30_000);
+
+  // -------------------------------------------------------------------------
+  // All-flags fixture — all three new rules fire simultaneously
+  // -------------------------------------------------------------------------
+
+  it("surfaces all three new rule messages when a page violates all constraints", async () => {
+    // Use raw YAML array syntax for contradictedBy alongside other scalar fields.
+    const content = [
+      "---",
+      ...sharedFrontmatterLines(),
+      "title: All Flags Concept",
+      "summary: Triggers every new rule.",
+      "confidence: 0.1",
+      "inferredParagraphs: 4",
+      "contradictedBy:",
+      "  - slug: rival-page",
+      "---",
+      "",
+      "This page deliberately violates all three new lint rules.",
+    ].join("\n");
+    const root = await createWikiFixture("all-flags", content);
+    try {
+      const { stdout } = await runLint(root);
+      // Each new rule emits a distinct message substring — assert on all three.
+      expect(stdout).toContain("below 0.5");
+      expect(stdout).toContain("contradicts");
+      expect(stdout).toContain("inferred paragraphs");
+    } finally {
+      await removeFixture(root);
+    }
+  }, 30_000);
+});

--- a/test/confidence-metadata.test.ts
+++ b/test/confidence-metadata.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for confidence/contradiction/provenance metadata.
+ *
+ * Covers parsing of the new optional frontmatter fields, frontmatter
+ * round-trip with the new metadata, the provenance-aware lint rules, and
+ * backward-compatibility with pages that omit the new fields.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { rm } from "fs/promises";
+import {
+  buildFrontmatter,
+  parseFrontmatter,
+  parseProvenanceMetadata,
+} from "../src/utils/markdown.js";
+import {
+  checkLowConfidencePages,
+  checkContradictedPages,
+  checkInferredWithoutCitations,
+} from "../src/linter/rules.js";
+import { parseConcepts } from "../src/compiler/prompts.js";
+import { makeLintTempRoot } from "./fixtures/lint-temp-root.js";
+
+let tmpDir: string;
+let writeConcept: (slug: string, content: string) => Promise<void>;
+
+beforeEach(async () => {
+  const fx = await makeLintTempRoot("provenance-test");
+  tmpDir = fx.root;
+  writeConcept = fx.writeConceptPage;
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("parseProvenanceMetadata", () => {
+  it("returns empty object for frontmatter without provenance fields", () => {
+    const result = parseProvenanceMetadata({ title: "Test" });
+    expect(result.confidence).toBeUndefined();
+    expect(result.provenanceState).toBeUndefined();
+    expect(result.contradictedBy).toBeUndefined();
+    expect(result.inferredParagraphs).toBeUndefined();
+  });
+
+  it("parses confidence as a number in [0, 1]", () => {
+    expect(parseProvenanceMetadata({ confidence: 0.7 }).confidence).toBe(0.7);
+    expect(parseProvenanceMetadata({ confidence: -1 }).confidence).toBe(0);
+    expect(parseProvenanceMetadata({ confidence: 5 }).confidence).toBe(1);
+    expect(parseProvenanceMetadata({ confidence: "high" }).confidence).toBeUndefined();
+  });
+
+  it("accepts only known provenanceState values", () => {
+    expect(parseProvenanceMetadata({ provenanceState: "extracted" }).provenanceState).toBe(
+      "extracted",
+    );
+    expect(parseProvenanceMetadata({ provenanceState: "merged" }).provenanceState).toBe("merged");
+    expect(parseProvenanceMetadata({ provenanceState: "bogus" }).provenanceState).toBeUndefined();
+  });
+
+  it("parses contradictedBy from string list and object list", () => {
+    const fromStrings = parseProvenanceMetadata({ contradictedBy: ["other-slug"] });
+    expect(fromStrings.contradictedBy).toEqual([{ slug: "other-slug" }]);
+
+    const fromObjects = parseProvenanceMetadata({
+      contradictedBy: [{ slug: "x", reason: "conflicting numbers" }],
+    });
+    expect(fromObjects.contradictedBy).toEqual([
+      { slug: "x", reason: "conflicting numbers" },
+    ]);
+  });
+
+  it("rejects invalid inferredParagraphs values", () => {
+    expect(parseProvenanceMetadata({ inferredParagraphs: 3 }).inferredParagraphs).toBe(3);
+    expect(parseProvenanceMetadata({ inferredParagraphs: -1 }).inferredParagraphs).toBeUndefined();
+    expect(parseProvenanceMetadata({ inferredParagraphs: 1.5 }).inferredParagraphs).toBeUndefined();
+  });
+});
+
+describe("frontmatter round-trip with provenance", () => {
+  it("preserves provenance fields through buildFrontmatter and parseFrontmatter", () => {
+    const fields = {
+      title: "Test",
+      confidence: 0.42,
+      provenanceState: "inferred",
+      contradictedBy: [{ slug: "rival-page", reason: "different number" }],
+      inferredParagraphs: 4,
+    };
+    const built = buildFrontmatter(fields);
+    const { meta } = parseFrontmatter(`${built}\n\nBody.`);
+    const provenance = parseProvenanceMetadata(meta);
+    expect(provenance.confidence).toBe(0.42);
+    expect(provenance.provenanceState).toBe("inferred");
+    expect(provenance.contradictedBy).toEqual([
+      { slug: "rival-page", reason: "different number" },
+    ]);
+    expect(provenance.inferredParagraphs).toBe(4);
+  });
+});
+
+describe("parseConcepts handles new optional fields", () => {
+  it("passes through provenance fields from tool output", () => {
+    const raw = JSON.stringify({
+      concepts: [
+        {
+          concept: "Demo",
+          summary: "A demo concept",
+          is_new: true,
+          confidence: 0.3,
+          provenance_state: "inferred",
+          contradicted_by: [{ slug: "rival" }],
+          inferred_paragraphs: 2,
+        },
+      ],
+    });
+    const [concept] = parseConcepts(raw);
+    expect(concept.confidence).toBe(0.3);
+    expect(concept.provenanceState).toBe("inferred");
+    expect(concept.contradictedBy).toEqual([{ slug: "rival" }]);
+    expect(concept.inferredParagraphs).toBe(2);
+  });
+
+  it("still parses concepts with no provenance fields", () => {
+    const raw = JSON.stringify({
+      concepts: [{ concept: "Plain", summary: "no extras", is_new: false }],
+    });
+    const [concept] = parseConcepts(raw);
+    expect(concept.confidence).toBeUndefined();
+    expect(concept.provenanceState).toBeUndefined();
+    expect(concept.contradictedBy).toBeUndefined();
+  });
+});
+
+describe("checkLowConfidencePages", () => {
+  it("flags pages whose confidence is below the threshold", async () => {
+    await writeConcept(
+      "shaky",
+      "---\ntitle: Shaky\nconfidence: 0.2\n---\nBody.",
+    );
+    const results = await checkLowConfidencePages(tmpDir);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe("low-confidence");
+    expect(results[0].severity).toBe("warning");
+  });
+
+  it("ignores pages without a confidence field", async () => {
+    await writeConcept("plain", "---\ntitle: Plain\n---\nBody.");
+    const results = await checkLowConfidencePages(tmpDir);
+    expect(results).toHaveLength(0);
+  });
+
+  it("ignores pages above the threshold", async () => {
+    await writeConcept("solid", "---\ntitle: Solid\nconfidence: 0.9\n---\nBody.");
+    const results = await checkLowConfidencePages(tmpDir);
+    expect(results).toHaveLength(0);
+  });
+});
+
+describe("checkContradictedPages", () => {
+  it("flags pages with contradictedBy entries", async () => {
+    const fm = "---\ntitle: Conflicted\ncontradictedBy:\n  - slug: rival\n    reason: disagrees\n---\n";
+    await writeConcept("conflicted", `${fm}Body.`);
+    const results = await checkContradictedPages(tmpDir);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe("contradicted-page");
+    expect(results[0].message).toContain("rival");
+  });
+
+  it("ignores pages without contradictedBy", async () => {
+    await writeConcept("clean", "---\ntitle: Clean\n---\nBody.");
+    const results = await checkContradictedPages(tmpDir);
+    expect(results).toHaveLength(0);
+  });
+});
+
+describe("checkInferredWithoutCitations", () => {
+  it("flags pages whose metadata reports too many inferred paragraphs", async () => {
+    await writeConcept(
+      "infer",
+      "---\ntitle: Infer\ninferredParagraphs: 5\n---\nA cited paragraph. ^[src.md]",
+    );
+    const results = await checkInferredWithoutCitations(tmpDir);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe("excess-inferred-paragraphs");
+  });
+
+  it("falls back to counting uncited prose paragraphs when metadata is absent", async () => {
+    const body = [
+      "First uncited prose paragraph here.",
+      "Second uncited prose paragraph here.",
+      "Third uncited prose paragraph here.",
+    ].join("\n\n");
+    await writeConcept("nocitations", `---\ntitle: NoCites\n---\n${body}`);
+    const results = await checkInferredWithoutCitations(tmpDir);
+    expect(results).toHaveLength(1);
+  });
+
+  it("does not flag pages whose paragraphs are all cited", async () => {
+    const body = "A well-cited paragraph. ^[src.md]\n\nAnother cited one. ^[src.md]";
+    await writeConcept("good", `---\ntitle: Good\n---\n${body}`);
+    const results = await checkInferredWithoutCitations(tmpDir);
+    expect(results).toHaveLength(0);
+  });
+});

--- a/test/confidence-metadata.test.ts
+++ b/test/confidence-metadata.test.ts
@@ -19,6 +19,7 @@ import {
   checkInferredWithoutCitations,
 } from "../src/linter/rules.js";
 import { parseConcepts } from "../src/compiler/prompts.js";
+import { reconcileConceptMetadata } from "../src/compiler/index.js";
 import { makeLintTempRoot } from "./fixtures/lint-temp-root.js";
 
 let tmpDir: string;
@@ -200,5 +201,58 @@ describe("checkInferredWithoutCitations", () => {
     await writeConcept("good", `---\ntitle: Good\n---\n${body}`);
     const results = await checkInferredWithoutCitations(tmpDir);
     expect(results).toHaveLength(0);
+  });
+});
+
+describe("reconcileConceptMetadata", () => {
+  it("takes the minimum confidence across two concepts", () => {
+    const first = { concept: "X", summary: "s", is_new: true, confidence: 0.8 };
+    const second = { concept: "X", summary: "s", is_new: false, confidence: 0.3 };
+    const result = reconcileConceptMetadata(first, second);
+    expect(result.confidence).toBe(0.3);
+  });
+
+  it("sets provenanceState to 'merged' regardless of input states", () => {
+    const first = { concept: "X", summary: "s", is_new: true, provenanceState: "extracted" as const };
+    const second = { concept: "X", summary: "s", is_new: false, provenanceState: "inferred" as const };
+    const result = reconcileConceptMetadata(first, second);
+    expect(result.provenanceState).toBe("merged");
+  });
+
+  it("unions contradictedBy entries, deduplicating by slug", () => {
+    const first = {
+      concept: "X", summary: "s", is_new: true,
+      contradictedBy: [{ slug: "a", reason: "r1" }, { slug: "b" }],
+    };
+    const second = {
+      concept: "X", summary: "s", is_new: false,
+      contradictedBy: [{ slug: "b", reason: "dup" }, { slug: "c" }],
+    };
+    const result = reconcileConceptMetadata(first, second);
+    const slugs = result.contradictedBy?.map((r) => r.slug);
+    expect(slugs).toEqual(["a", "b", "c"]);
+    expect(result.contradictedBy).toHaveLength(3);
+  });
+
+  it("takes the maximum inferredParagraphs across two concepts", () => {
+    const first = { concept: "X", summary: "s", is_new: true, inferredParagraphs: 1 };
+    const second = { concept: "X", summary: "s", is_new: false, inferredParagraphs: 4 };
+    const result = reconcileConceptMetadata(first, second);
+    expect(result.inferredParagraphs).toBe(4);
+  });
+
+  it("inherits incoming confidence when existing has none", () => {
+    const first = { concept: "X", summary: "s", is_new: true };
+    const second = { concept: "X", summary: "s", is_new: false, confidence: 0.5 };
+    const result = reconcileConceptMetadata(first, second);
+    expect(result.confidence).toBe(0.5);
+  });
+
+  it("preserves concept title and summary from the first entry", () => {
+    const first = { concept: "X", summary: "First summary", is_new: true };
+    const second = { concept: "X", summary: "Second summary", is_new: false };
+    const result = reconcileConceptMetadata(first, second);
+    expect(result.concept).toBe("X");
+    expect(result.summary).toBe("First summary");
   });
 });

--- a/test/fixtures/lint-temp-root.ts
+++ b/test/fixtures/lint-temp-root.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared test helper for creating a temporary llmwiki layout used by
+ * lint-rule tests. Sets up wiki/concepts, wiki/queries, and sources/
+ * directories under a unique temp root.
+ */
+
+import { mkdtemp, mkdir, writeFile } from "fs/promises";
+import path from "path";
+import os from "os";
+
+/** Common shape returned by makeLintTempRoot — root path and writers. */
+export interface LintTempRoot {
+  root: string;
+  writeConceptPage: (slug: string, content: string) => Promise<void>;
+  writeQueryPage: (slug: string, content: string) => Promise<void>;
+  writeSourceFile: (name: string, content: string) => Promise<void>;
+}
+
+/**
+ * Create a temp directory with the standard wiki/sources layout that lint
+ * rules expect. Each call returns a fresh isolated path along with helpers
+ * for writing concept pages, query pages, and source files.
+ * @param prefix - Short label appended to the temp directory name.
+ */
+export async function makeLintTempRoot(prefix: string): Promise<LintTempRoot> {
+  const root = await mkdtemp(path.join(os.tmpdir(), `${prefix}-`));
+  await mkdir(path.join(root, "wiki", "concepts"), { recursive: true });
+  await mkdir(path.join(root, "wiki", "queries"), { recursive: true });
+  await mkdir(path.join(root, "sources"), { recursive: true });
+  return {
+    root,
+    writeConceptPage: (slug, content) =>
+      writeFile(path.join(root, "wiki", "concepts", `${slug}.md`), content),
+    writeQueryPage: (slug, content) =>
+      writeFile(path.join(root, "wiki", "queries", `${slug}.md`), content),
+    writeSourceFile: (name, content) =>
+      writeFile(path.join(root, "sources", name), content),
+  };
+}

--- a/test/lint.test.ts
+++ b/test/lint.test.ts
@@ -5,9 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, mkdir, writeFile, rm } from "fs/promises";
-import path from "path";
-import os from "os";
+import { rm } from "fs/promises";
 import {
   checkBrokenWikilinks,
   checkOrphanedPages,
@@ -17,34 +15,24 @@ import {
   checkBrokenCitations,
 } from "../src/linter/rules.js";
 import { lint } from "../src/linter/index.js";
+import { makeLintTempRoot } from "./fixtures/lint-temp-root.js";
 
 let tmpDir: string;
+let writeConcept: (slug: string, content: string) => Promise<void>;
+let writeQuery: (slug: string, content: string) => Promise<void>;
+let writeSource: (name: string, content: string) => Promise<void>;
 
 beforeEach(async () => {
-  tmpDir = await mkdtemp(path.join(os.tmpdir(), "lint-test-"));
-  await mkdir(path.join(tmpDir, "wiki", "concepts"), { recursive: true });
-  await mkdir(path.join(tmpDir, "wiki", "queries"), { recursive: true });
-  await mkdir(path.join(tmpDir, "sources"), { recursive: true });
+  const fx = await makeLintTempRoot("lint-test");
+  tmpDir = fx.root;
+  writeConcept = fx.writeConceptPage;
+  writeQuery = fx.writeQueryPage;
+  writeSource = fx.writeSourceFile;
 });
 
 afterEach(async () => {
   await rm(tmpDir, { recursive: true, force: true });
 });
-
-/** Helper to write a wiki page to the concepts directory. */
-async function writeConcept(slug: string, content: string): Promise<void> {
-  await writeFile(path.join(tmpDir, "wiki", "concepts", `${slug}.md`), content);
-}
-
-/** Helper to write a wiki page to the queries directory. */
-async function writeQuery(slug: string, content: string): Promise<void> {
-  await writeFile(path.join(tmpDir, "wiki", "queries", `${slug}.md`), content);
-}
-
-/** Helper to write a source file. */
-async function writeSource(name: string, content: string): Promise<void> {
-  await writeFile(path.join(tmpDir, "sources", name), content);
-}
 
 describe("checkBrokenWikilinks", () => {
   it("returns no results when all wikilinks are valid", async () => {

--- a/test/lint.test.ts
+++ b/test/lint.test.ts
@@ -194,6 +194,36 @@ describe("checkBrokenCitations", () => {
     expect(results).toHaveLength(1);
     expect(results[0].line).toBe(5);
   });
+
+  it("accepts a multi-source citation where both files exist", async () => {
+    await writeSource("a.md", "Source A.");
+    await writeSource("b.md", "Source B.");
+    await writeConcept("multi", "---\ntitle: Multi\n---\nDrawn from both sources. ^[a.md, b.md]");
+
+    const results = await checkBrokenCitations(tmpDir);
+    expect(results).toHaveLength(0);
+  });
+
+  it("reports only the missing file in a multi-source citation", async () => {
+    await writeSource("a.md", "Source A.");
+    await writeConcept("partial", "---\ntitle: Partial\n---\nPartially cited. ^[a.md, missing.md]");
+
+    const results = await checkBrokenCitations(tmpDir);
+    expect(results).toHaveLength(1);
+    expect(results[0].message).toContain("missing.md");
+    expect(results[0].message).not.toContain("a.md");
+  });
+
+  it("does not treat the whole comma-joined text as one filename", async () => {
+    await writeSource("a.md", "Source A.");
+    await writeSource("b.md", "Source B.");
+    // If the rule naively checked "a.md, b.md" as one filename it would fail.
+    await writeConcept("joint", "---\ntitle: Joint\n---\nJoint citation. ^[a.md, b.md]");
+
+    const results = await checkBrokenCitations(tmpDir);
+    // Neither "a.md" nor "b.md" is missing, so there should be no findings.
+    expect(results.some((r) => r.message.includes("a.md, b.md"))).toBe(false);
+  });
 });
 
 describe("lint orchestrator", () => {


### PR DESCRIPTION
Adds richer epistemic metadata to compiled pages so the wiki can express how confident an extracted concept is, where its provenance comes from, and which other pages contradict it. Builds toward later trust/review features without changing existing surface.

## New frontmatter fields (all optional)

| Field | Type | Meaning |
|---|---|---|
| `confidence` | number 0–1 | LLM-reported confidence in the synthesized page |
| `provenanceState` | `extracted` \| `merged` \| `inferred` \| `ambiguous` | How the page came to be |
| `contradictedBy` | `{ slug }[]` | Other wiki pages that contradict this one |
| `inferredParagraphs` | number | Count of paragraphs the LLM marked as inferred (vs cited) |

Existing pages without these fields continue to parse and render unchanged.

## New lint rules

- `low-confidence` — flags pages with `confidence` below the threshold
- `contradicted-page` — flags pages with non-empty `contradictedBy`
- `excess-inferred-paragraphs` — flags pages with too many inferred paragraphs without citations

## Compile-time behavior

- Concept extraction prompt asks for the new fields; `parseConcepts` passes them through
- When multiple sources merge into one slug, metadata is reconciled: `min` confidence, `provenanceState = 'merged'`, union of `contradictedBy` (deduped by slug), `max` inferredParagraphs
- Compile output emits a warning when a page declares contradictions

## Citation parsing fix

The new prompt instructs the model to emit multi-source citations like `^[a.md, b.md]`. The existing `checkBrokenCitations` linter previously treated the entire comma-joined string as one filename and would have falsely flagged valid multi-source citations. Now splits on commas and validates each filename independently.

## Test plan

- [x] `npm test` — 291 tests pass (~33 new for this feature plus review-queue's 36 from the merge)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `npx fallow` 0 above threshold
- [x] Compile-path tests exercise the full pipeline with stubbed LLM and assert metadata lands in frontmatter + contradiction warning fires
- [x] Multi-source citation lint test (single, multi, half-missing all behave correctly)
- [x] Backward-compat tests verify pages without metadata continue to work
- [x] All three new lint rules covered end-to-end via the CLI

## Known limitations

The compile-path tests exercise direct compile, not `compile --review`. Because the page renderer is shared between both paths (post-PR-#18 refactor), this is not a correctness hole — just a missing extra test.

Closes the confidence-and-contradiction-metadata item from the next-feature roadmap.