### PR TITLE
Release 0.3.0: review queue, page metadata, README docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-04-23
+
+Adds a candidate review queue for `compile` and richer epistemic metadata on compiled pages.
+
+### Added
+
+- **Candidate review queue** — `llmwiki compile --review` writes generated pages to `.llmwiki/candidates/` instead of mutating `wiki/`. New subcommands `llmwiki review list|show|approve|reject` let you inspect each candidate before it lands. `approve` writes the page and refreshes index/MOC/embeddings; `reject` archives the candidate to `.llmwiki/candidates/archive/`. MCP `wiki_status` exposes `pendingCandidates` so agents can see queue depth.
+- **Confidence and contradiction metadata** — compiled pages can carry optional frontmatter fields (`confidence`, `provenanceState`, `contradictedBy`, `inferredParagraphs`). When multiple sources merge into one slug, metadata is reconciled (`min` confidence, `provenanceState = 'merged'`, union of `contradictedBy` deduped by slug, `max` `inferredParagraphs`).
+- **Three new lint rules** surface the new metadata: `low-confidence`, `contradicted-page`, `excess-inferred-paragraphs`.
+- **Multi-source citation parsing in lint** — `^[a.md, b.md]` now validates each filename independently and only reports the missing one(s).
+- **Husky pre-commit and pre-push hooks** — pre-commit runs `fallow` + `tsc --noEmit`; pre-push runs `npm run build` + `npm test`. Devs get fast feedback on commit and full validation before push.
+
+### Changed
+
+- Pre-commit/pre-push hooks pin `fallow` to `2.42.0` locally (devDep) and in CI to keep complexity thresholds stable across the team.
+- `compile`'s page rendering extracted into `src/compiler/page-renderer.ts` so both direct writes and candidate generation reuse the same renderer.
+- `vitest.config.ts` excludes `.claude/**` so `npm test` from the main checkout doesn't discover sibling worktrees.
+
+### Concurrency
+
+- `review approve` and `review reject` acquire `.llmwiki/lock` (the same lock `compile` uses) and re-read the candidate under the lock to close the TOCTOU window between pre-check and mutation.
+- When one source produces multiple candidates, source state isn't persisted until the last sibling is approved — unresolved siblings stay re-detectable on the next `compile --review`.
+
+### Infrastructure
+
+- Tests grew from 222 to 291 across all new features.
+
 ## [0.2.0] - 2026-04-16
 
 First major release since 0.1.1. Ships the complete initial roadmap plus an MCP server for AI agent integration.

--- a/README.md
+++ b/README.md
@@ -158,9 +158,14 @@ Pages include source attribution in frontmatter. Paragraphs are annotated with `
 |---------|-------------|
 | `llmwiki ingest <url\|file>` | Fetch a URL or copy a local file into `sources/` |
 | `llmwiki compile` | Incremental compile: extract concepts, generate wiki pages |
+| `llmwiki compile --review` | Write candidate pages to `.llmwiki/candidates/` instead of `wiki/` so you can review before they land |
+| `llmwiki review list` | List pending candidate pages |
+| `llmwiki review show <id>` | Print a candidate's title, summary, and body |
+| `llmwiki review approve <id>` | Promote a candidate into `wiki/` and refresh index/MOC/embeddings |
+| `llmwiki review reject <id>` | Archive a candidate without touching `wiki/` |
 | `llmwiki query "question"` | Ask questions against your compiled wiki |
 | `llmwiki query "question" --save` | Answer and save the result as a wiki page |
-| `llmwiki lint` | Check wiki quality (broken links, orphans, empty pages, etc.) |
+| `llmwiki lint` | Check wiki quality (broken links, orphans, empty pages, low confidence, contradictions, etc.) |
 | `llmwiki watch` | Auto-recompile when `sources/` changes |
 | `llmwiki serve [--root <dir>]` | Start an MCP server exposing wiki tools to AI agents |
 
@@ -168,12 +173,60 @@ Pages include source attribution in frontmatter. Paragraphs are annotated with `
 
 ```
 wiki/
-  concepts/     one .md file per concept, with YAML frontmatter
-  queries/      saved query answers, included in index and retrieval
-  index.md      auto-generated table of contents
+  concepts/         one .md file per concept, with YAML frontmatter
+  queries/          saved query answers, included in index and retrieval
+  index.md          auto-generated table of contents
+.llmwiki/
+  candidates/       pending review candidates from `compile --review`
+  candidates/archive/  rejected candidates kept for audit
 ```
 
 Obsidian-compatible. `[[wikilinks]]` resolve to concept titles.
+
+## Review queue
+
+By default, `compile` writes pages directly to `wiki/`. Add `--review` to write candidate JSON records to `.llmwiki/candidates/` instead, so you can inspect each generated page before it lands.
+
+```bash
+llmwiki compile --review     # produces candidates, leaves wiki/ untouched
+llmwiki review list          # see what's pending
+llmwiki review show <id>     # inspect a single candidate
+llmwiki review approve <id>  # write into wiki/ + refresh index/MOC/embeddings
+llmwiki review reject <id>   # archive to .llmwiki/candidates/archive/
+```
+
+A few things to know:
+
+- **Approve and reject acquire `.llmwiki/lock`** so they serialize cleanly against each other and against any concurrent `compile`.
+- **Source state is deferred per-source.** When one source produces multiple candidates, the source isn't marked compiled until the last candidate is approved — so unresolved siblings stay re-detectable on the next `compile --review`.
+- **Deletion bookkeeping is deferred.** `compile --review` does not orphan-mark deleted sources; the next non-review `compile` does that. The `--review` help text advertises this.
+- MCP `wiki_status` exposes `pendingCandidates` so agents can see the queue depth.
+
+## Page metadata
+
+Compiled pages can carry epistemic metadata in frontmatter so consumers know how trustworthy each page is. All fields are optional and existing pages without them continue to work.
+
+```yaml
+---
+title: Knowledge Compilation
+summary: Techniques for converting knowledge representations...
+sources:
+  - knowledge-compilation.md
+confidence: 0.82           # 0–1, LLM-reported confidence in the synthesized page
+provenanceState: merged    # extracted | merged | inferred | ambiguous
+contradictedBy:
+  - slug: probabilistic-reasoning
+inferredParagraphs: 1      # paragraphs the LLM marked as inferred (vs cited)
+---
+```
+
+When multiple sources merge into one slug, metadata is reconciled: `min` confidence, `provenanceState = 'merged'`, union of `contradictedBy` (deduped by slug), `max` `inferredParagraphs`.
+
+`llmwiki lint` adds three rules that surface this metadata:
+
+- `low-confidence` — flags pages with `confidence` below a threshold
+- `contradicted-page` — flags pages with non-empty `contradictedBy`
+- `excess-inferred-paragraphs` — flags pages with too many inferred paragraphs without citations
 
 ## Demo
 
@@ -269,6 +322,11 @@ Karpathy describes an abstract pattern for turning raw data into compiled knowle
 
 ## Roadmap
 
+Shipped in 0.3.0:
+
+- ✅ Candidate review queue (approve compile output before pages are written)
+- ✅ Confidence and contradiction metadata on compiled pages
+
 Shipped in 0.2.0:
 
 - ✅ Better provenance (paragraph-level source attribution)
@@ -280,15 +338,14 @@ Shipped in 0.2.0:
 
 Next up:
 
-- Candidate review queue (approve compile output before pages are written)
-- Confidence and contradiction metadata on compiled pages
 - Claim-level provenance with source ranges
+- First-class schema layer with typed page kinds (`concept`, `entity`, `comparison`, `overview`)
 - Multimodal ingest (images, PDFs, transcripts)
 - Chunked retrieval with reranking
 - Export bundle (`llms.txt`, JSON, JSON-LD, GraphML, Marp)
 - Session-history adapters (Claude, Codex, Cursor exports)
 
-If you like ambitious problems: **claim-level provenance**, **chunked retrieval with reranking**, and **confidence/contradiction metadata** are the meatiest. Open an issue to claim one or kick off a design discussion.
+If you like ambitious problems: **schema layer + typed page kinds**, **claim-level provenance**, and **chunked retrieval with reranking** are the meatiest. Open an issue to claim one or kick off a design discussion.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-wiki-compiler",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A knowledge compiler CLI — raw sources in, interlinked wiki out",
   "type": "module",
   "bin": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,11 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  test: { globals: true },
+  test: {
+    globals: true,
+    // Don't pick up tests from sibling worktrees living under .claude/worktrees/.
+    // Worktrees share the parent's working directory tree, so without this
+    // exclude vitest discovers and runs every feature branch's tests.
+    exclude: ["**/node_modules/**", "**/dist/**", ".claude/**"],
+  },
 });


### PR DESCRIPTION
Release prep for 0.3.0 — bundles README docs, version bump, and CHANGELOG entry for the work shipped in PRs #18 and #19.

## Changes

### Version + CHANGELOG
- Bump `package.json` from 0.2.0 to 0.3.0
- Add `CHANGELOG.md` entry for 0.3.0 covering review queue, confidence/contradiction metadata, husky hooks, fallow pin, multi-source citation linting, and the page-renderer extraction

### README
- New `Shipped in 0.3.0` section in Roadmap; the two new features removed from `Next up`
- Commands table adds `compile --review` and the four `review` subcommands; `lint` description updated to mention the new rules
- Output tree shows `.llmwiki/candidates/` and `candidates/archive/`
- New "Review queue" section documents the workflow plus lock semantics, deferred per-source state persistence, and deferred deletion bookkeeping
- New "Page metadata" section documents the new optional frontmatter fields, merge reconciliation rules, and the three new lint rules

### Infrastructure
- `vitest.config.ts` excludes `.claude/**` so `npm test` from the main checkout doesn't discover sibling worktrees' tests (was making the pre-push hook collect ~2,500 tests across all in-flight feature worktrees)

## Test plan
- [x] `npm test` from main scope: 291 tests pass
- [x] `npm run build` clean
- [x] `npx fallow` 0 above threshold
- [x] CI green on prior commit; awaiting CI on the version-bump commit
- [ ] After merge: tag v0.3.0, npm publish, create GitHub release