### PR TITLE
Build dist once via vitest globalSetup

### DIFF
--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect } from "vitest";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import path from "path";
@@ -48,9 +48,6 @@ async function createCompileWorkspace(
 }
 
 describe("CLI smoke tests", () => {
-  beforeAll(async () => {
-    await exec("npx", ["tsup"], { cwd: path.resolve(".") });
-  }, 30_000);
   it("prints help and exits 0", async () => {
     const { stdout } = await exec("node", [CLI, "--help"]);
     expect(stdout).toContain("llmwiki");

--- a/test/confidence-metadata-integration.test.ts
+++ b/test/confidence-metadata-integration.test.ts
@@ -12,7 +12,7 @@
  *     sources/                  ← empty dir so broken-citation rule finds nothing
  */
 
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect } from "vitest";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import path from "path";
@@ -89,9 +89,7 @@ function assertNoConfidenceFindings(stdout: string): void {
 // ---------------------------------------------------------------------------
 
 describe("confidence metadata — CLI lint integration", () => {
-  beforeAll(async () => {
-    await execFileAsync("npx", ["tsup"], { cwd: path.resolve(".") });
-  }, 60_000);
+  // dist/cli.js is built once via vitest globalSetup (test/global-setup.ts)
 
   // -------------------------------------------------------------------------
   // low-confidence rule

--- a/test/global-setup.ts
+++ b/test/global-setup.ts
@@ -1,0 +1,19 @@
+/**
+ * Vitest globalSetup: build dist/ once before any test file loads.
+ *
+ * Several test files spawn `node dist/cli.js` to exercise the CLI surface.
+ * Without a shared setup, each file's own beforeAll would call `npx tsup`,
+ * and vitest's parallel-by-default test workers would race on dist/cli.js
+ * (tsup's `clean: true` wipes the file mid-write). Building once globally
+ * eliminates the race and saves ~1s per integration test file.
+ */
+
+import { execFile } from "child_process";
+import { promisify } from "util";
+import path from "path";
+
+const exec = promisify(execFile);
+
+export async function setup(): Promise<void> {
+  await exec("npx", ["tsup"], { cwd: path.resolve(".") });
+}

--- a/test/review-integration.test.ts
+++ b/test/review-integration.test.ts
@@ -10,7 +10,7 @@
  * are marked it.skip and explained inline.
  */
 
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect } from "vitest";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import path from "path";
@@ -113,14 +113,10 @@ async function assertMissingIdFails(subcommand: string, suffix: string): Promise
 }
 
 // ---------------------------------------------------------------------------
-// Build once before all tests
+// dist/cli.js is built once via vitest globalSetup (see test/global-setup.ts)
 // ---------------------------------------------------------------------------
 
 describe("review integration tests", () => {
-  beforeAll(async () => {
-    await exec("npx", ["tsup"], { cwd: path.resolve(".") });
-  }, 30_000);
-
   // -------------------------------------------------------------------------
   // compile --help advertises the --review flag
   // -------------------------------------------------------------------------

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,5 +7,9 @@ export default defineConfig({
     // Worktrees share the parent's working directory tree, so without this
     // exclude vitest discovers and runs every feature branch's tests.
     exclude: ["**/node_modules/**", "**/dist/**", ".claude/**"],
+    // Build dist/ once globally so parallel test workers don't race on
+    // tsup's clean+write cycle (multiple beforeAll(npx tsup) calls were
+    // wiping dist/cli.js mid-test).
+    globalSetup: "./test/global-setup.ts",
   },
 });


### PR DESCRIPTION
Fixes the intermittent test race that flaked CI on PRs #19 and #20 and that broke npm publish's prepublishOnly hook.

## The bug

Three test files (`cli.test.ts`, `review-integration.test.ts`, `confidence-metadata-integration.test.ts`) each had a `beforeAll` that called `npx tsup`. Vitest runs test files in parallel workers, so multiple tsup processes were racing on `dist/cli.js`. `tsup.config.ts` has `clean: true`, which wipes the file before writing, opening a window where another worker's subprocess test would read `dist/cli.js` and get `MODULE_NOT_FOUND`.

The race was intermittent under CI load and deterministic during `npm publish` (`prepublishOnly` runs full test suite with parallel workers, hit the race every time).

## The fix

Move the build to vitest's `globalSetup` (new file `test/global-setup.ts`) so `dist/` is built exactly once before any test file loads. Remove the per-file `beforeAll` calls (and unused `beforeAll` imports).

## Test plan
- [x] `rm -rf dist && npm test` — 291 tests pass cleanly (proves globalSetup builds dist before any test runs)
- [x] No flake in 3 consecutive local runs
- [x] CI passes