### PR TITLE
Ignore .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ localdocs/
 .fallow/
 .worktrees/
 .sisyphus/
+.claude/


### PR DESCRIPTION
Holds local Claude Code state (worktrees, settings) that varies per contributor and shouldn't be in the repo.