### PR TITLE
Make OpenAI/Ollama request timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ export OLLAMA_HOST=http://ollama_host:11434/v1
 export OLLAMA_EMBEDDINGS_HOST=http://ollama_host:11435/v1
 ```
 
+### Request timeouts
+
+The OpenAI SDK defaults to a 10-minute per-request timeout, which can cut off long compile-time completions on slower local models. Override per provider:
+
+- `LLMWIKI_REQUEST_TIMEOUT_MS` — provider-agnostic timeout in milliseconds. Applies to both the `openai` and `ollama` backends.
+- `OLLAMA_TIMEOUT_MS` — Ollama-specific override. Wins over `LLMWIKI_REQUEST_TIMEOUT_MS` when both are set.
+
+Defaults: 10 minutes for `openai`, 30 minutes for `ollama` (local models commonly need more).
+
 ## Why not just RAG?
 
 RAG retrieves chunks at query time. Every question re-discovers the same relationships from scratch. Nothing accumulates.

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -5,14 +5,31 @@
  * Overrides only the constructor to set baseURL and disable API key auth.
  */
 
-import { OpenAIProvider } from "./openai.js";
-import { EMBEDDING_MODELS } from "../utils/constants.js";
+import { OpenAIProvider, readTimeoutEnv } from "./openai.js";
+import { EMBEDDING_MODELS, OLLAMA_DEFAULT_TIMEOUT_MS } from "../utils/constants.js";
 
 /** Construction options for an Ollama-compatible provider. */
 interface OllamaProviderOptions {
   baseURL: string;
   embeddingsBaseURL?: string;
   embeddingModel?: string;
+  /**
+   * Per-request timeout in milliseconds. Defaults to 30 minutes for Ollama
+   * because local models on modest hardware can take much longer than the
+   * cloud-OpenAI default of 10. Override with OLLAMA_TIMEOUT_MS or the
+   * provider-agnostic LLMWIKI_REQUEST_TIMEOUT_MS env var.
+   */
+  timeoutMs?: number;
+}
+
+/** Resolve the Ollama timeout: explicit option → OLLAMA_TIMEOUT_MS → LLMWIKI_REQUEST_TIMEOUT_MS → default. */
+function resolveOllamaTimeoutMs(explicit?: number): number {
+  return (
+    explicit ??
+    readTimeoutEnv("OLLAMA_TIMEOUT_MS") ??
+    readTimeoutEnv("LLMWIKI_REQUEST_TIMEOUT_MS") ??
+    OLLAMA_DEFAULT_TIMEOUT_MS
+  );
 }
 
 /** Ollama-backed LLM provider using the OpenAI-compatible endpoint. */
@@ -23,6 +40,7 @@ export class OllamaProvider extends OpenAIProvider {
       apiKey: "ollama",
       embeddingsBaseURL: options.embeddingsBaseURL,
       embeddingModel: options.embeddingModel,
+      timeoutMs: resolveOllamaTimeoutMs(options.timeoutMs),
     });
   }
 

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -26,7 +26,9 @@ interface OpenAIProviderOptions {
 
 /**
  * Read an integer-millisecond timeout from an env var. Returns undefined when
- * the env var is unset or non-numeric so the caller can fall back to a default.
+ * the env var is unset, empty, non-numeric, zero, or negative — so the caller
+ * silently falls back to the next source in its resolution chain (env-var
+ * typos like `OLLAMA_TIMEOUT_MS=30m` are not surfaced to the user).
  */
 export function readTimeoutEnv(name: string): number | undefined {
   const raw = process.env[name]?.trim();

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -7,7 +7,7 @@
 
 import OpenAI from "openai";
 import type { LLMProvider, LLMMessage, LLMTool } from "../utils/provider.js";
-import { EMBEDDING_MODELS } from "../utils/constants.js";
+import { EMBEDDING_MODELS, OPENAI_DEFAULT_TIMEOUT_MS } from "../utils/constants.js";
 
 /** Construction options for an OpenAI-compatible provider. */
 interface OpenAIProviderOptions {
@@ -15,6 +15,29 @@ interface OpenAIProviderOptions {
   apiKey?: string;
   embeddingsBaseURL?: string;
   embeddingModel?: string;
+  /**
+   * Per-request timeout in milliseconds. Defaults to 10 minutes for cloud
+   * OpenAI (matches the SDK default). Long compile-time completions on
+   * slower local models can exceed this — see {@link OllamaProvider} which
+   * raises the default and reads LLMWIKI_REQUEST_TIMEOUT_MS / OLLAMA_TIMEOUT_MS.
+   */
+  timeoutMs?: number;
+}
+
+/**
+ * Read an integer-millisecond timeout from an env var. Returns undefined when
+ * the env var is unset or non-numeric so the caller can fall back to a default.
+ */
+export function readTimeoutEnv(name: string): number | undefined {
+  const raw = process.env[name]?.trim();
+  if (!raw) return undefined;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+/** Resolve the OpenAI client timeout from LLMWIKI_REQUEST_TIMEOUT_MS, if set. */
+function resolveOpenAITimeoutMs(): number | undefined {
+  return readTimeoutEnv("LLMWIKI_REQUEST_TIMEOUT_MS");
 }
 
 /** Translate an Anthropic-style LLMTool to an OpenAI ChatCompletionTool. */
@@ -44,12 +67,14 @@ export class OpenAIProvider implements LLMProvider {
     // The OpenAI SDK validates OPENAI_API_KEY at construction time.
     // Pass the key explicitly so the provider controls when validation happens.
     const resolvedKey = options.apiKey ?? process.env.OPENAI_API_KEY ?? "";
+    const timeout = options.timeoutMs ?? resolveOpenAITimeoutMs() ?? OPENAI_DEFAULT_TIMEOUT_MS;
     this.client = new OpenAI({
       apiKey: resolvedKey,
       baseURL: options.baseURL ?? null,
+      timeout,
     });
     this.embeddingsClient = options.embeddingsBaseURL
-      ? new OpenAI({ apiKey: resolvedKey, baseURL: options.embeddingsBaseURL })
+      ? new OpenAI({ apiKey: resolvedKey, baseURL: options.embeddingsBaseURL, timeout })
       : this.client;
   }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -34,6 +34,20 @@ export const PROVIDER_MODELS: Record<string, string> = {
 /** Default Ollama API base URL. */
 export const OLLAMA_DEFAULT_HOST = "http://localhost:11434/v1";
 
+/**
+ * Default request timeout for cloud OpenAI-compatible providers (10 minutes).
+ * Matches the OpenAI SDK's own default; called out here so it's explicit.
+ */
+export const OPENAI_DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+
+/**
+ * Default request timeout for Ollama (30 minutes). Local models on modest
+ * hardware can take well over the cloud-provider default for a single
+ * compile-time completion. Configurable via LLMWIKI_REQUEST_TIMEOUT_MS or
+ * OLLAMA_TIMEOUT_MS env vars.
+ */
+export const OLLAMA_DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
+
 /** Directory names relative to the project root. */
 export const SOURCES_DIR = "sources";
 export const CONCEPTS_DIR = "wiki/concepts";

--- a/test/provider-timeout.test.ts
+++ b/test/provider-timeout.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for OpenAI/Ollama provider request timeout configuration.
+ *
+ * Issue #11: the OpenAI SDK defaults to a 10-minute request timeout, which
+ * cuts off long Ollama compile-time completions on slower local hardware.
+ * The provider now reads OLLAMA_TIMEOUT_MS / LLMWIKI_REQUEST_TIMEOUT_MS env
+ * vars and sets a 30-minute Ollama default.
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { OpenAIProvider, readTimeoutEnv } from "../src/providers/openai.js";
+import { OllamaProvider } from "../src/providers/ollama.js";
+import {
+  OPENAI_DEFAULT_TIMEOUT_MS,
+  OLLAMA_DEFAULT_TIMEOUT_MS,
+} from "../src/utils/constants.js";
+
+afterEach(() => {
+  delete process.env.OLLAMA_TIMEOUT_MS;
+  delete process.env.LLMWIKI_REQUEST_TIMEOUT_MS;
+  vi.restoreAllMocks();
+});
+
+/** Read the timeout the provider configured on the underlying OpenAI client. */
+function getClientTimeout(provider: OpenAIProvider): number | undefined {
+  // The OpenAI SDK stores the timeout as `timeout` on the client instance;
+  // we cast to `unknown` first because the field is not part of its public
+  // type, then narrow.
+  const client = (provider as unknown as { client: { timeout?: number } }).client;
+  return client.timeout;
+}
+
+describe("readTimeoutEnv", () => {
+  it("returns the parsed integer when the env var is set", () => {
+    process.env.OLLAMA_TIMEOUT_MS = "1500";
+    expect(readTimeoutEnv("OLLAMA_TIMEOUT_MS")).toBe(1500);
+  });
+
+  it("returns undefined when the env var is unset", () => {
+    expect(readTimeoutEnv("OLLAMA_TIMEOUT_MS")).toBeUndefined();
+  });
+
+  it("returns undefined when the env var is empty or whitespace", () => {
+    process.env.OLLAMA_TIMEOUT_MS = "   ";
+    expect(readTimeoutEnv("OLLAMA_TIMEOUT_MS")).toBeUndefined();
+  });
+
+  it("returns undefined when the env var is non-numeric", () => {
+    process.env.OLLAMA_TIMEOUT_MS = "thirty-minutes";
+    expect(readTimeoutEnv("OLLAMA_TIMEOUT_MS")).toBeUndefined();
+  });
+
+  it("rejects zero and negative values", () => {
+    process.env.OLLAMA_TIMEOUT_MS = "0";
+    expect(readTimeoutEnv("OLLAMA_TIMEOUT_MS")).toBeUndefined();
+    process.env.OLLAMA_TIMEOUT_MS = "-100";
+    expect(readTimeoutEnv("OLLAMA_TIMEOUT_MS")).toBeUndefined();
+  });
+});
+
+describe("OpenAIProvider timeout", () => {
+  it("falls back to the OPENAI_DEFAULT_TIMEOUT_MS when nothing is set", () => {
+    const provider = new OpenAIProvider("gpt-4o", { apiKey: "test" });
+    expect(getClientTimeout(provider)).toBe(OPENAI_DEFAULT_TIMEOUT_MS);
+  });
+
+  it("uses LLMWIKI_REQUEST_TIMEOUT_MS when set", () => {
+    process.env.LLMWIKI_REQUEST_TIMEOUT_MS = "60000";
+    const provider = new OpenAIProvider("gpt-4o", { apiKey: "test" });
+    expect(getClientTimeout(provider)).toBe(60000);
+  });
+
+  it("explicit timeoutMs option wins over env var", () => {
+    process.env.LLMWIKI_REQUEST_TIMEOUT_MS = "60000";
+    const provider = new OpenAIProvider("gpt-4o", { apiKey: "test", timeoutMs: 1234 });
+    expect(getClientTimeout(provider)).toBe(1234);
+  });
+});
+
+describe("OllamaProvider timeout", () => {
+  it("uses the higher OLLAMA_DEFAULT_TIMEOUT_MS by default", () => {
+    const provider = new OllamaProvider("llama3.1", { baseURL: "http://localhost:11434/v1" });
+    expect(getClientTimeout(provider)).toBe(OLLAMA_DEFAULT_TIMEOUT_MS);
+  });
+
+  it("OLLAMA_TIMEOUT_MS overrides the default", () => {
+    process.env.OLLAMA_TIMEOUT_MS = "120000";
+    const provider = new OllamaProvider("llama3.1", { baseURL: "http://localhost:11434/v1" });
+    expect(getClientTimeout(provider)).toBe(120000);
+  });
+
+  it("LLMWIKI_REQUEST_TIMEOUT_MS is honored when OLLAMA_TIMEOUT_MS is unset", () => {
+    process.env.LLMWIKI_REQUEST_TIMEOUT_MS = "90000";
+    const provider = new OllamaProvider("llama3.1", { baseURL: "http://localhost:11434/v1" });
+    expect(getClientTimeout(provider)).toBe(90000);
+  });
+
+  it("OLLAMA_TIMEOUT_MS wins over LLMWIKI_REQUEST_TIMEOUT_MS when both set", () => {
+    process.env.OLLAMA_TIMEOUT_MS = "120000";
+    process.env.LLMWIKI_REQUEST_TIMEOUT_MS = "90000";
+    const provider = new OllamaProvider("llama3.1", { baseURL: "http://localhost:11434/v1" });
+    expect(getClientTimeout(provider)).toBe(120000);
+  });
+
+  it("explicit timeoutMs option wins over both env vars", () => {
+    process.env.OLLAMA_TIMEOUT_MS = "120000";
+    process.env.LLMWIKI_REQUEST_TIMEOUT_MS = "90000";
+    const provider = new OllamaProvider("llama3.1", {
+      baseURL: "http://localhost:11434/v1",
+      timeoutMs: 5000,
+    });
+    expect(getClientTimeout(provider)).toBe(5000);
+  });
+});


### PR DESCRIPTION
Closes #11.

The OpenAI SDK constructs clients with its default 10-minute per-request timeout. For local Ollama models on modest hardware, individual compile-time completions can exceed that, causing the client to abort and Ollama to log `aborting completion request due to client closing the connection`.

## Changes

- **`OpenAIProvider`** accepts a new `timeoutMs` option, falls back to `LLMWIKI_REQUEST_TIMEOUT_MS`, then to `OPENAI_DEFAULT_TIMEOUT_MS` (10 minutes — matches the SDK default but now explicit).
- **`OllamaProvider`** accepts the same `timeoutMs` option, falls back to `OLLAMA_TIMEOUT_MS`, then to `LLMWIKI_REQUEST_TIMEOUT_MS`, then to `OLLAMA_DEFAULT_TIMEOUT_MS` (30 minutes — better suited to local models).
- **`readTimeoutEnv`** helper in `src/providers/openai.ts` is shared by both providers. Returns `undefined` for empty / non-numeric / zero / negative values so the caller silently falls through to the next source in the resolution chain (env-var typos like `OLLAMA_TIMEOUT_MS=30m` are not surfaced — could add a one-time warning later if it proves confusing in practice).
- **README** has a new "Request timeouts" subsection documenting the env vars and defaults.

## Test plan

- [x] 13 new unit tests in `test/provider-timeout.test.ts` cover env-var parsing edge cases (empty, non-numeric, zero, negative all → `undefined`) and the resolution precedence (option → `OLLAMA_TIMEOUT_MS` → `LLMWIKI_REQUEST_TIMEOUT_MS` → default) for both providers
- [x] `npm test` — 391 tests pass
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `npx fallow` 0 above threshold