### PR TITLE
Release 0.4.0: claim provenance, schema layer, configurable timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Adds claim-level source-range provenance, a first-class schema layer for typed p
 
 ### Contributors
 
-Thanks to **@ludevica** for #15 (slug-based wikilinks), **@BenGSt** for reporting the Ollama timeout (#11), and **@sy2ruto** for reporting the multi-source citation lint bug (#10) — the fix shipped in 0.3.0 via PR #19, the issue was closed this cycle.
+Thanks to **@ludevica** for #15 (slug-based wikilinks) and **@BenGSt** for reporting the Ollama timeout (#11).
 
 ## [0.3.0] - 2026-04-23
 
@@ -60,6 +60,10 @@ Adds a candidate review queue for `compile` and richer epistemic metadata on com
 ### Infrastructure
 
 - Tests grew from 222 to 291 across all new features.
+
+### Contributors
+
+Thanks to **@ishan5ain** for #12 (split embedding endpoints for OpenAI-compatible providers) and **@sy2ruto** for reporting the multi-source citation lint bug (#10) — the parsing fix shipped here in PR #19.
 
 ## [0.2.0] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Adds claim-level source-range provenance, a first-class schema layer for typed p
 
 ### Contributors
 
-Thanks to **@ludevica** for #15 (slug-based wikilinks) and **@BenGSt** for reporting the Ollama timeout (#11).
+Thanks to **@ludevica** for #15 (slug-based wikilinks), **@BenGSt** for reporting the Ollama timeout (#11), and **@sy2ruto** for reporting the multi-source citation lint bug (#10) — the fix shipped in 0.3.0 via PR #19, the issue was closed this cycle.
 
 ## [0.3.0] - 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-04-25
+
+Adds claim-level source-range provenance, a first-class schema layer for typed page kinds, configurable provider request timeouts, and a slug-based wikilink format that resolves reliably in Obsidian.
+
+### Added
+
+- **Claim-level provenance with source ranges** — citations can now pin specific lines: `^[paper.md:42-58]` (colon form) or `^[paper.md#L42-L58]` (GitHub anchor form). Single-line `^[paper.md:7]` works too, as do mixed multi-source markers like `^[a.md, b.md:1-3]`. The legacy paragraph form `^[paper.md]` continues to work unchanged.
+- **`extractClaimCitations(body)`** returns structured `{ raw, spans: [{ file, lines? }] }` records for tooling. **`inspectProvenance(body)`** groups spans by source file (deduped), useful for "this page draws from" UIs.
+- **`checkBrokenCitations`** lint rule now flags out-of-bounds spans (e.g. `^[src.md:42-58]` against a 3-line source) with cached per-file line counts so a page with many spans into the same source only reads it once.
+- **`checkMalformedClaimCitations`** new lint rule catches malformed entries: non-numeric ranges (`:abc-xyz`), half-baked hash forms (`#X9`), line `0`, and reversed ranges (`5-3`). Semantic invalidity is rejected at parse time so `extractClaimCitations` doesn't return impossible spans.
+- **First-class schema layer** for typed page kinds. Projects can declare `.llmwiki/schema.json|yaml|yml` (or `wiki/.schema.yaml|yml`) defining page kinds (`concept`, `entity`, `comparison`, `overview`), per-kind `minWikilinks`, and seed pages.
+- **`llmwiki schema init`** writes a starter schema file. **`llmwiki schema show`** prints the resolved schema and its source path.
+- **`schema-cross-link-minimum`** lint rule enforces per-kind link expectations.
+- **Schema-driven seed pages** are generated during compile and run on the early-return path too, so adding a seed-page entry triggers its creation on the next `compile` even when no source files changed.
+- **Review-mode schema violations** — `compile --review` runs in-memory schema lint per candidate and stamps any violations onto the candidate JSON. `review show <id>` prints a "Schema violations" block when present.
+- **Configurable provider request timeouts** — `LLMWIKI_REQUEST_TIMEOUT_MS` (provider-agnostic) and `OLLAMA_TIMEOUT_MS` (Ollama-specific) override the per-request timeout. Defaults: 10 minutes for OpenAI (matches the SDK), 30 minutes for Ollama (better suited to local models).
+- **Slug-based wikilinks** — index, MOC, and the in-body wikilink resolver now emit `[[slug|Title]]` so Obsidian targets the file directly regardless of whether the slug differs from the display title.
+- **Test infrastructure for subprocess CLI tests** — `runCLI`/`expectCLIExit`/`expectCLIFailure`/`formatCLIFailure` helpers in `test/fixtures/run-cli.ts` capture full subprocess diagnostics (code, signal, killed, message, stdout, stderr, args, cwd) so flakes surface their root cause without rerunning. dist/ is built once via `vitest globalSetup` so parallel workers don't race on `tsup --clean`.
+
+### Changed
+
+- `extractCitations(body)` continues to return a flat filename list for backward compatibility, but is now backed by `extractClaimCitations` and strips span suffixes when collecting filenames.
+- `WikiFrontmatter.kind` references the canonical `PageKind` type from `src/schema/types.ts` via `import type` (no runtime cycle).
+- `compile --review` defers seed-page generation and `finalizeWiki` to honor the no-`wiki/`-mutation contract.
+
+### Contributors
+
+Thanks to **@ludevica** for #15 (slug-based wikilinks) and **@BenGSt** for reporting the Ollama timeout (#11).
+
 ## [0.3.0] - 2026-04-23
 
 Adds a candidate review queue for `compile` and richer epistemic metadata on compiled pages.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ A raw source like a Wikipedia article on knowledge compilation becomes a structu
 ---
 title: Knowledge Compilation
 summary: Techniques for converting knowledge representations into forms that support efficient reasoning.
+kind: concept
 sources:
   - knowledge-compilation.md
 createdAt: "2026-04-05T12:00:00Z"
@@ -159,7 +160,7 @@ a knowledge base into a target language that supports efficient queries.
 Related concepts: [[Propositional Logic]], [[Model Counting]]
 ```
 
-Pages include source attribution in frontmatter. Paragraphs are annotated with `^[filename.md]` markers pointing back to the source file that contributed the content.
+Pages include source attribution in frontmatter. Paragraphs are annotated with `^[filename.md]` markers pointing back to the source file that contributed the content; specific claims can use line ranges like `^[filename.md:42-58]` or `^[filename.md#L42-L58]`.
 
 ## Commands
 
@@ -172,6 +173,8 @@ Pages include source attribution in frontmatter. Paragraphs are annotated with `
 | `llmwiki review show <id>` | Print a candidate's title, summary, and body |
 | `llmwiki review approve <id>` | Promote a candidate into `wiki/` and refresh index/MOC/embeddings |
 | `llmwiki review reject <id>` | Archive a candidate without touching `wiki/` |
+| `llmwiki schema init` | Write a starter `.llmwiki/schema.json` file |
+| `llmwiki schema show` | Print the resolved schema for the current project |
 | `llmwiki query "question"` | Ask questions against your compiled wiki |
 | `llmwiki query "question" --save` | Answer and save the result as a wiki page |
 | `llmwiki lint` | Check wiki quality (broken links, orphans, empty pages, low confidence, contradictions, etc.) |
@@ -186,6 +189,7 @@ wiki/
   queries/          saved query answers, included in index and retrieval
   index.md          auto-generated table of contents
 .llmwiki/
+  schema.json       optional page-kind and cross-link policy
   candidates/       pending review candidates from `compile --review`
   candidates/archive/  rejected candidates kept for audit
 ```
@@ -236,6 +240,41 @@ When multiple sources merge into one slug, metadata is reconciled: `min` confide
 - `low-confidence` — flags pages with `confidence` below a threshold
 - `contradicted-page` — flags pages with non-empty `contradictedBy`
 - `excess-inferred-paragraphs` — flags pages with too many inferred paragraphs without citations
+
+## Claim-level provenance
+
+Paragraph citations continue to use the original source-marker form:
+
+```markdown
+This paragraph is grounded in the source. ^[source.md]
+```
+
+For claims that need tighter verification, pages can pin a statement to a line range in the ingested source:
+
+```markdown
+The system uses a two-phase compile pipeline. ^[architecture-notes.md:42-58]
+The same range can also use GitHub-style anchors. ^[architecture-notes.md#L42-L58]
+```
+
+`llmwiki lint` validates both forms. It reports missing source files, malformed claim citations, impossible ranges like line `0` or `8-3`, and ranges that extend past the end of the source file.
+
+## Schema layer
+
+Projects can optionally define `.llmwiki/schema.json` to shape the wiki beyond flat concept pages. Existing projects do not need a schema file; missing or invalid `kind` values fall back to `concept`.
+
+```bash
+llmwiki schema init
+llmwiki schema show
+```
+
+The schema supports four page kinds:
+
+- `concept` — standalone idea or pattern
+- `entity` — specific person, product, organization, or named artifact
+- `comparison` — side-by-side analysis across concepts or entities
+- `overview` — map page that connects several concepts in a domain
+
+Schema rules can set per-kind `minWikilinks` and optional `seedPages`. Compile can materialize seed pages such as overviews, lint enforces page-kind-specific cross-link minimums, and review candidates surface schema violations before approval.
 
 ## Demo
 
@@ -331,6 +370,11 @@ Karpathy describes an abstract pattern for turning raw data into compiled knowle
 
 ## Roadmap
 
+Shipped in 0.4.0:
+
+- ✅ Claim-level provenance with source ranges
+- ✅ First-class schema layer with typed page kinds (`concept`, `entity`, `comparison`, `overview`)
+
 Shipped in 0.3.0:
 
 - ✅ Candidate review queue (approve compile output before pages are written)
@@ -347,14 +391,12 @@ Shipped in 0.2.0:
 
 Next up:
 
-- Claim-level provenance with source ranges
-- First-class schema layer with typed page kinds (`concept`, `entity`, `comparison`, `overview`)
 - Multimodal ingest (images, PDFs, transcripts)
 - Chunked retrieval with reranking
 - Export bundle (`llms.txt`, JSON, JSON-LD, GraphML, Marp)
 - Session-history adapters (Claude, Codex, Cursor exports)
 
-If you like ambitious problems: **schema layer + typed page kinds**, **claim-level provenance**, and **chunked retrieval with reranking** are the meatiest. Open an issue to claim one or kick off a design discussion.
+If you like ambitious problems: **multimodal ingest**, **chunked retrieval with reranking**, and **export bundles** are the meatiest. Open an issue to claim one or kick off a design discussion.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-wiki-compiler",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A knowledge compiler CLI — raw sources in, interlinked wiki out",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release prep for 0.4.0 — version bump, CHANGELOG entry, and README docs covering everything merged since 0.3.0:

- **#15** — slug-based wikilinks (`[[slug|Title]]`) so Obsidian resolves reliably
- **#22** — claim-level provenance with source ranges, plus the malformed/out-of-bounds lint coverage
- **#23** — first-class schema layer with typed page kinds and per-kind cross-link lint
- **#25** — configurable OpenAI/Ollama request timeouts (closes #11)

## Changes

- `package.json` 0.3.0 → 0.4.0
- `CHANGELOG.md` — full 0.4.0 entry under Keep-a-Changelog format with sections for Added, Changed, and Contributors
- `README.md` — moves claim provenance + schema layer from "Next up" into a new "Shipped in 0.4.0" block. The earlier in-flight README docs (claim-level citation syntax, schema commands, page-metadata fields, request-timeout env vars) are already on this branch from prior commits.

## Test plan

- [x] `npm test` — 391 tests pass
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `npx fallow` 0 above threshold
- [x] After merge: tag v0.4.0, push tag, npm publish, create GitHub release