### PR TITLE
Add aimock-backed subprocess test for chunked-retrieval compile pipeline

### DIFF
--- a/test/aimock-smoke.test.ts
+++ b/test/aimock-smoke.test.ts
@@ -11,47 +11,23 @@
  * compile --review, image vision, etc).
  */
 
-import { describe, it, expect, afterEach } from "vitest";
-import { mkdtemp, mkdir, rm, writeFile, readdir, readFile } from "fs/promises";
+import { describe, it, expect } from "vitest";
+import { readdir, readFile } from "fs/promises";
 import path from "path";
-import { tmpdir } from "os";
 import {
-  startMockClaude,
-  stopMockClaude,
   mockClaudeEnv,
-  type MockClaudeHandle,
+  useAimockLifecycle,
 } from "./fixtures/aimock-helper.js";
 import { runCLI, expectCLIExit } from "./fixtures/run-cli.js";
 
-const tempDirs: string[] = [];
-let mockHandle: MockClaudeHandle | null = null;
-
-afterEach(async () => {
-  if (mockHandle) {
-    await stopMockClaude(mockHandle);
-    mockHandle = null;
-  }
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) await rm(dir, { recursive: true, force: true });
-  }
-});
-
-/** Make a temp project workspace with one source file ready for compile. */
-async function makeWorkspace(sourceContent: string): Promise<string> {
-  const cwd = await mkdtemp(path.join(tmpdir(), "llmwiki-aimock-smoke-"));
-  tempDirs.push(cwd);
-  await mkdir(path.join(cwd, "sources"), { recursive: true });
-  await writeFile(path.join(cwd, "sources", "intro.md"), sourceContent, "utf-8");
-  return cwd;
-}
+const aimock = useAimockLifecycle("aimock-smoke");
 
 describe("aimock subprocess smoke", () => {
   it("compile --review writes a candidate using the mocked Claude response", async () => {
-    mockHandle = await startMockClaude();
+    const handle = await aimock.start();
 
     // Stub the extraction tool call: one new concept named "Mock Concept".
-    mockHandle.mock.onToolCall("extract_concepts", {
+    handle.mock.onToolCall("extract_concepts", {
       toolCalls: [
         {
           name: "extract_concepts",
@@ -71,18 +47,18 @@ describe("aimock subprocess smoke", () => {
     });
 
     // Stub the page-body generation: any subsequent message → canned body.
-    mockHandle.mock.onMessage(/.*/, {
+    handle.mock.onMessage(/.*/, {
       content: "Mock concept body produced via aimock for the smoke test.",
     });
 
-    const cwd = await makeWorkspace(
+    const cwd = await aimock.makeWorkspace(
       "# Mock Source\n\nA short source document for the smoke test.\n",
     );
 
     const result = await runCLI(
       ["compile", "--review"],
       cwd,
-      mockClaudeEnv(mockHandle),
+      mockClaudeEnv(handle),
     );
 
     expectCLIExit(result, 0);

--- a/test/chunked-retrieval-aimock.test.ts
+++ b/test/chunked-retrieval-aimock.test.ts
@@ -15,48 +15,24 @@
  * is left as a follow-up once the aimock embedding path is understood.
  */
 
-import { describe, it, expect, afterEach } from "vitest";
-import { mkdir, mkdtemp, rm, readFile, writeFile, readdir } from "fs/promises";
+import { describe, it, expect } from "vitest";
+import { readFile, readdir } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
-import { tmpdir } from "os";
 import {
-  startMockClaude,
-  stopMockClaude,
   mockOpenAIEnv,
-  type MockClaudeHandle,
+  useAimockLifecycle,
 } from "./fixtures/aimock-helper.js";
 import { runCLI, expectCLIExit, formatCLIFailure } from "./fixtures/run-cli.js";
 
-const tempDirs: string[] = [];
-let mockHandle: MockClaudeHandle | null = null;
-
-afterEach(async () => {
-  if (mockHandle) {
-    await stopMockClaude(mockHandle);
-    mockHandle = null;
-  }
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) await rm(dir, { recursive: true, force: true });
-  }
-});
-
-/** Temp project workspace seeded with a single source file. */
-async function makeWorkspaceWithSource(content: string): Promise<string> {
-  const cwd = await mkdtemp(path.join(tmpdir(), "llmwiki-cr-aimock-"));
-  tempDirs.push(cwd);
-  await mkdir(path.join(cwd, "sources"), { recursive: true });
-  await writeFile(path.join(cwd, "sources", "intro.md"), content, "utf-8");
-  return cwd;
-}
+const aimock = useAimockLifecycle("cr-aimock");
 
 describe("chunked-retrieval subprocess coverage via aimock", () => {
   it("compile populates a v2 embedding store with chunks for newly-generated pages", async () => {
-    mockHandle = await startMockClaude();
+    const handle = await aimock.start();
 
     // Stub extraction → one new concept the page generator can render.
-    mockHandle.mock.onToolCall("extract_concepts", {
+    handle.mock.onToolCall("extract_concepts", {
       toolCalls: [
         {
           name: "extract_concepts",
@@ -77,7 +53,7 @@ describe("chunked-retrieval subprocess coverage via aimock", () => {
 
     // Stub page-body generation. Body must be long enough to produce at least
     // one chunk (CHUNK_MIN_CHARS gates trailing-fragment merging).
-    mockHandle.mock.onMessage(/.*/, {
+    handle.mock.onMessage(/.*/, {
       content:
         "Chunked retrieval breaks long wiki pages into smaller passages before " +
         "comparing them against a query vector. Each chunk is embedded with the " +
@@ -89,15 +65,15 @@ describe("chunked-retrieval subprocess coverage via aimock", () => {
 
     // Stub the embedding endpoint. aimock recognises Voyage/Anthropic-compatible
     // /embeddings calls and returns the canned vector for any input.
-    mockHandle.mock.onEmbedding(/.*/, {
+    handle.mock.onEmbedding(/.*/, {
       embedding: Array.from({ length: 8 }, (_, i) => i / 10),
     });
 
-    const cwd = await makeWorkspaceWithSource(
+    const cwd = await aimock.makeWorkspace(
       "# Chunked Retrieval\n\nA long-form note about chunk-based vector search.\n",
     );
 
-    const result = await runCLI(["compile"], cwd, mockOpenAIEnv(mockHandle));
+    const result = await runCLI(["compile"], cwd, mockOpenAIEnv(handle));
     expectCLIExit(result, 0);
 
     // Assert: a wiki page was generated.

--- a/test/chunked-retrieval-aimock.test.ts
+++ b/test/chunked-retrieval-aimock.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Subprocess CLI coverage for chunked-retrieval that requires a working LLM.
+ *
+ * The existing chunked-retrieval-integration.test.ts file documents two
+ * specific gaps that couldn't be exercised at the CLI boundary without a
+ * live LLM:
+ *
+ *   1. Full `compile` → extract → page generation → chunk embedding pipeline
+ *      producing a v2 store with chunks on disk.
+ *   2. (Followup) full `query --debug` flow printing chunk slugs/scores.
+ *
+ * Now that aimock is in the project (see test/fixtures/aimock-helper.ts),
+ * the first gap is closeable. This file covers it. The query-debug test
+ * needs both completion + embedding stubs that span Anthropic + Voyage; it
+ * is left as a follow-up once the aimock embedding path is understood.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdir, mkdtemp, rm, readFile, writeFile, readdir } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import { tmpdir } from "os";
+import {
+  startMockClaude,
+  stopMockClaude,
+  mockOpenAIEnv,
+  type MockClaudeHandle,
+} from "./fixtures/aimock-helper.js";
+import { runCLI, expectCLIExit, formatCLIFailure } from "./fixtures/run-cli.js";
+
+const tempDirs: string[] = [];
+let mockHandle: MockClaudeHandle | null = null;
+
+afterEach(async () => {
+  if (mockHandle) {
+    await stopMockClaude(mockHandle);
+    mockHandle = null;
+  }
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) await rm(dir, { recursive: true, force: true });
+  }
+});
+
+/** Temp project workspace seeded with a single source file. */
+async function makeWorkspaceWithSource(content: string): Promise<string> {
+  const cwd = await mkdtemp(path.join(tmpdir(), "llmwiki-cr-aimock-"));
+  tempDirs.push(cwd);
+  await mkdir(path.join(cwd, "sources"), { recursive: true });
+  await writeFile(path.join(cwd, "sources", "intro.md"), content, "utf-8");
+  return cwd;
+}
+
+describe("chunked-retrieval subprocess coverage via aimock", () => {
+  it("compile populates a v2 embedding store with chunks for newly-generated pages", async () => {
+    mockHandle = await startMockClaude();
+
+    // Stub extraction → one new concept the page generator can render.
+    mockHandle.mock.onToolCall("extract_concepts", {
+      toolCalls: [
+        {
+          name: "extract_concepts",
+          arguments: {
+            concepts: [
+              {
+                concept: "Chunked Retrieval",
+                summary: "Splitting wiki pages into chunks before vector search.",
+                is_new: true,
+                tags: ["retrieval"],
+                confidence: 0.9,
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    // Stub page-body generation. Body must be long enough to produce at least
+    // one chunk (CHUNK_MIN_CHARS gates trailing-fragment merging).
+    mockHandle.mock.onMessage(/.*/, {
+      content:
+        "Chunked retrieval breaks long wiki pages into smaller passages before " +
+        "comparing them against a query vector. Each chunk is embedded with the " +
+        "active provider's embedding model and persisted on disk under the " +
+        "chunks array of .llmwiki/embeddings.json. Reusing chunks across compiles " +
+        "via content hashes keeps embedding costs proportional to actual edits, " +
+        "not the size of the wiki.",
+    });
+
+    // Stub the embedding endpoint. aimock recognises Voyage/Anthropic-compatible
+    // /embeddings calls and returns the canned vector for any input.
+    mockHandle.mock.onEmbedding(/.*/, {
+      embedding: Array.from({ length: 8 }, (_, i) => i / 10),
+    });
+
+    const cwd = await makeWorkspaceWithSource(
+      "# Chunked Retrieval\n\nA long-form note about chunk-based vector search.\n",
+    );
+
+    const result = await runCLI(["compile"], cwd, mockOpenAIEnv(mockHandle));
+    expectCLIExit(result, 0);
+
+    // Assert: a wiki page was generated.
+    const conceptsDir = path.join(cwd, "wiki", "concepts");
+    const conceptFiles = await readdir(conceptsDir);
+    const conceptMd = conceptFiles.find((f) => f.endsWith(".md"));
+    expect(conceptMd, formatCLIFailure(result)).toBeDefined();
+
+    // Assert: the embedding store exists, version 2, with chunks populated.
+    const storePath = path.join(cwd, ".llmwiki", "embeddings.json");
+    expect(existsSync(storePath)).toBe(true);
+    const store = JSON.parse(await readFile(storePath, "utf-8")) as {
+      version: number;
+      entries: unknown[];
+      chunks?: unknown[];
+    };
+    expect(store.version, formatCLIFailure(result)).toBe(2);
+    expect(store.entries.length, formatCLIFailure(result)).toBeGreaterThan(0);
+    expect((store.chunks ?? []).length, formatCLIFailure(result)).toBeGreaterThan(0);
+  }, 30_000);
+});

--- a/test/chunked-retrieval-aimock.test.ts
+++ b/test/chunked-retrieval-aimock.test.ts
@@ -7,12 +7,11 @@
  *
  *   1. Full `compile` → extract → page generation → chunk embedding pipeline
  *      producing a v2 store with chunks on disk.
- *   2. (Followup) full `query --debug` flow printing chunk slugs/scores.
+ *   2. Full `query --debug` flow printing chunk slugs/scores.
  *
  * Now that aimock is in the project (see test/fixtures/aimock-helper.ts),
- * the first gap is closeable. This file covers it. The query-debug test
- * needs both completion + embedding stubs that span Anthropic + Voyage; it
- * is left as a follow-up once the aimock embedding path is understood.
+ * both gaps are closeable by running the subprocesses in OpenAI mode so chat
+ * and embedding requests hit the same aimock server.
  */
 
 import { describe, it, expect } from "vitest";
@@ -22,59 +21,69 @@ import path from "path";
 import {
   mockOpenAIEnv,
   useAimockLifecycle,
+  type MockClaudeHandle,
 } from "./fixtures/aimock-helper.js";
-import { runCLI, expectCLIExit, formatCLIFailure } from "./fixtures/run-cli.js";
+import {
+  runCLI,
+  expectCLIExit,
+  formatCLIFailure,
+  type CLIResult,
+} from "./fixtures/run-cli.js";
 
 const aimock = useAimockLifecycle("cr-aimock");
+const EMBEDDING_VECTOR = Array.from({ length: 8 }, (_, i) => i / 10);
+const CHUNKED_RETRIEVAL_SOURCE =
+  "# Chunked Retrieval\n\nA long-form note about chunk-based vector search.\n";
+const CHUNKED_RETRIEVAL_BODY =
+  "Chunked retrieval breaks long wiki pages into smaller passages before " +
+  "comparing them against a query vector. Each chunk is embedded with the " +
+  "active provider's embedding model and persisted on disk under the " +
+  "chunks array of .llmwiki/embeddings.json. Reusing chunks across compiles " +
+  "via content hashes keeps embedding costs proportional to actual edits, " +
+  "not the size of the wiki.";
+
+/** Register canned aimock responses for chunked-retrieval compile/query flows. */
+function registerChunkedRetrievalMocks(handle: MockClaudeHandle, body: string): void {
+  handle.mock.onToolCall("extract_concepts", {
+    toolCalls: [
+      {
+        name: "extract_concepts",
+        arguments: {
+          concepts: [
+            {
+              concept: "Chunked Retrieval",
+              summary: "Splitting wiki pages into chunks before vector search.",
+              is_new: true,
+              tags: ["retrieval"],
+              confidence: 0.9,
+            },
+          ],
+        },
+      },
+    ],
+  });
+  handle.mock.onMessage(/.*/, { content: body });
+  handle.mock.onEmbedding(/.*/, { embedding: EMBEDDING_VECTOR });
+}
+
+/** Build a temp project, compile it through the CLI, and return the workspace. */
+async function compileChunkedRetrievalProject(
+  handle: MockClaudeHandle,
+  sourceContent = CHUNKED_RETRIEVAL_SOURCE,
+): Promise<{ cwd: string; env: NodeJS.ProcessEnv; result: CLIResult }> {
+  const cwd = await aimock.makeWorkspace(sourceContent);
+  const env = mockOpenAIEnv(handle);
+  const compileResult = await runCLI(["compile"], cwd, env);
+  expectCLIExit(compileResult, 0);
+  return { cwd, env, result: compileResult };
+}
 
 describe("chunked-retrieval subprocess coverage via aimock", () => {
   it("compile populates a v2 embedding store with chunks for newly-generated pages", async () => {
     const handle = await aimock.start();
+    registerChunkedRetrievalMocks(handle, CHUNKED_RETRIEVAL_BODY);
 
-    // Stub extraction → one new concept the page generator can render.
-    handle.mock.onToolCall("extract_concepts", {
-      toolCalls: [
-        {
-          name: "extract_concepts",
-          arguments: {
-            concepts: [
-              {
-                concept: "Chunked Retrieval",
-                summary: "Splitting wiki pages into chunks before vector search.",
-                is_new: true,
-                tags: ["retrieval"],
-                confidence: 0.9,
-              },
-            ],
-          },
-        },
-      ],
-    });
-
-    // Stub page-body generation. Body must be long enough to produce at least
-    // one chunk (CHUNK_MIN_CHARS gates trailing-fragment merging).
-    handle.mock.onMessage(/.*/, {
-      content:
-        "Chunked retrieval breaks long wiki pages into smaller passages before " +
-        "comparing them against a query vector. Each chunk is embedded with the " +
-        "active provider's embedding model and persisted on disk under the " +
-        "chunks array of .llmwiki/embeddings.json. Reusing chunks across compiles " +
-        "via content hashes keeps embedding costs proportional to actual edits, " +
-        "not the size of the wiki.",
-    });
-
-    // Stub the embedding endpoint. aimock recognises Voyage/Anthropic-compatible
-    // /embeddings calls and returns the canned vector for any input.
-    handle.mock.onEmbedding(/.*/, {
-      embedding: Array.from({ length: 8 }, (_, i) => i / 10),
-    });
-
-    const cwd = await aimock.makeWorkspace(
-      "# Chunked Retrieval\n\nA long-form note about chunk-based vector search.\n",
-    );
-
-    const result = await runCLI(["compile"], cwd, mockOpenAIEnv(handle));
-    expectCLIExit(result, 0);
+    const { cwd, result } = await compileChunkedRetrievalProject(handle);
 
     // Assert: a wiki page was generated.
     const conceptsDir = path.join(cwd, "wiki", "concepts");
@@ -93,5 +102,29 @@ describe("chunked-retrieval subprocess coverage via aimock", () => {
     expect(store.version, formatCLIFailure(result)).toBe(2);
     expect(store.entries.length, formatCLIFailure(result)).toBeGreaterThan(0);
     expect((store.chunks ?? []).length, formatCLIFailure(result)).toBeGreaterThan(0);
+  }, 30_000);
+
+  it("query --debug prints chunk-level retrieval details after an aimock compile", async () => {
+    const handle = await aimock.start();
+    registerChunkedRetrievalMocks(
+      handle,
+      "Chunked retrieval answers questions by selecting the most relevant " +
+        "embedded passages before loading their parent wiki pages.",
+    );
+    const { cwd, env } = await compileChunkedRetrievalProject(
+      handle,
+      "# Chunked Retrieval\n\nA note about chunk-level vector search and debug output.\n",
+    );
+
+    const queryResult = await runCLI(
+      ["query", "--debug", "how does chunked retrieval work?"],
+      cwd,
+      env,
+    );
+    expectCLIExit(queryResult, 0);
+    expect(queryResult.stdout).toContain("Retrieval debug");
+    expect(queryResult.stdout).toContain("Source: chunk-level");
+    expect(queryResult.stdout).toContain("chunked-retrieval");
+    expect(queryResult.stdout).toContain("score=");
   }, 30_000);
 });

--- a/test/fixtures/aimock-helper.ts
+++ b/test/fixtures/aimock-helper.ts
@@ -26,6 +26,10 @@
  */
 
 import { LLMock } from "@copilotkit/aimock";
+import { mkdtemp, mkdir, rm, writeFile } from "fs/promises";
+import path from "path";
+import { tmpdir } from "os";
+import { afterEach } from "vitest";
 
 /** Handle returned from {@link startMockClaude}. */
 export interface MockClaudeHandle {
@@ -89,4 +93,63 @@ export function mockOpenAIEnv(
     LLMWIKI_MODEL: model,
     LLMWIKI_EMBEDDING_MODEL: "text-embedding-3-small",
   };
+}
+
+/** Live state managed by {@link useAimockLifecycle}. */
+export interface AimockLifecycle {
+  /** Currently-running mock, or null between tests. Set by `start()`. */
+  handle: MockClaudeHandle | null;
+  /** Start a fresh mock and store the handle in `lifecycle.handle`. */
+  start: () => Promise<MockClaudeHandle>;
+  /** Create a temp project workspace with sources/ + one source file. */
+  makeWorkspace: (sourceContent: string, sourceName?: string) => Promise<string>;
+}
+
+/**
+ * Vitest composable that wires up afterEach cleanup for an aimock-backed
+ * subprocess test: stops the mock if one was started, then removes any
+ * temp workspaces created by `makeWorkspace`. Avoids per-file boilerplate
+ * for the common pattern.
+ *
+ * @example
+ * ```
+ * const aimock = useAimockLifecycle("my-test");
+ * it("...", async () => {
+ *   const handle = await aimock.start();
+ *   handle.mock.onMessage(/.* /, { content: "..." });
+ *   const cwd = await aimock.makeWorkspace("# source\n");
+ *   const result = await runCLI(["compile"], cwd, mockOpenAIEnv(handle));
+ *   ...
+ * });
+ * ```
+ */
+export function useAimockLifecycle(workspacePrefix: string): AimockLifecycle {
+  const tempDirs: string[] = [];
+  const lifecycle: AimockLifecycle = {
+    handle: null,
+    async start(): Promise<MockClaudeHandle> {
+      lifecycle.handle = await startMockClaude();
+      return lifecycle.handle;
+    },
+    async makeWorkspace(sourceContent: string, sourceName = "intro.md"): Promise<string> {
+      const cwd = await mkdtemp(path.join(tmpdir(), `llmwiki-${workspacePrefix}-`));
+      tempDirs.push(cwd);
+      await mkdir(path.join(cwd, "sources"), { recursive: true });
+      await writeFile(path.join(cwd, "sources", sourceName), sourceContent, "utf-8");
+      return cwd;
+    },
+  };
+
+  afterEach(async () => {
+    if (lifecycle.handle) {
+      await stopMockClaude(lifecycle.handle);
+      lifecycle.handle = null;
+    }
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  return lifecycle;
 }

--- a/test/fixtures/aimock-helper.ts
+++ b/test/fixtures/aimock-helper.ts
@@ -54,6 +54,10 @@ export async function stopMockClaude(handle: MockClaudeHandle): Promise<void> {
  * Env overrides to inject into `runCLI` so the CLI subprocess routes
  * Anthropic API calls to the mock. The mock-key value is arbitrary —
  * the CLI's credential check only verifies the env var is non-empty.
+ *
+ * Note: Anthropic embeddings go to Voyage (a different host) which is
+ * NOT intercepted by this helper. Use {@link mockOpenAIEnv} for tests
+ * that need both completions and embeddings stubbed under one base URL.
  */
 export function mockClaudeEnv(handle: MockClaudeHandle): NodeJS.ProcessEnv {
   return {
@@ -62,5 +66,27 @@ export function mockClaudeEnv(handle: MockClaudeHandle): NodeJS.ProcessEnv {
     // Pin provider explicitly so a dev environment with LLMWIKI_PROVIDER=ollama
     // doesn't bypass the Anthropic mock.
     LLMWIKI_PROVIDER: "anthropic",
+  };
+}
+
+/**
+ * Env overrides for OpenAI-mode subprocess tests. Use this when the test
+ * needs both chat and embedding calls intercepted (the OpenAI provider
+ * routes both through OPENAI_BASE_URL, unlike the Anthropic provider
+ * which uses Voyage for embeddings).
+ *
+ * @param handle - aimock handle from {@link startMockClaude}.
+ * @param model - Optional model name override (defaults to "gpt-4o").
+ */
+export function mockOpenAIEnv(
+  handle: MockClaudeHandle,
+  model = "gpt-4o",
+): NodeJS.ProcessEnv {
+  return {
+    OPENAI_BASE_URL: `${handle.url}/v1`,
+    OPENAI_API_KEY: "mock-key-for-aimock",
+    LLMWIKI_PROVIDER: "openai",
+    LLMWIKI_MODEL: model,
+    LLMWIKI_EMBEDDING_MODEL: "text-embedding-3-small",
   };
 }


### PR DESCRIPTION
Follow-up to PR #28 (chunked-retrieval) and PR #29 (aimock infrastructure). Closes the codex-flagged subprocess gap that the original chunked-retrieval PR documented but couldn't fix without a stub provider.

## What it adds

- **`mockOpenAIEnv(handle)`** alongside the existing `mockClaudeEnv(handle)` in `test/fixtures/aimock-helper.ts`. Sets `OPENAI_BASE_URL`, `LLMWIKI_PROVIDER=openai`, etc., so subprocess tests that need both chat AND embeddings stubbed under one base URL can use OpenAI mode (Anthropic provider's embedding goes to Voyage at a different URL, not interceptable by the same aimock instance without extra plumbing).
- **`test/chunked-retrieval-aimock.test.ts`**: one new subprocess test running `compile` end-to-end against a real source file, with stubbed extraction tool call + page-body completion + embedding endpoint. Asserts:
  - A wiki page is written
  - `.llmwiki/embeddings.json` exists, is version 2, and has a non-empty `chunks` array

This is the exact assertion the existing `chunked-retrieval-integration.test.ts` documents as untestable without a working LLM (lines 16-23 of that file's header comment).

## What's still deferred

`query --debug` end-to-end through subprocess is the second documented gap. The streaming answer + selection tool-call path needs a bit more aimock plumbing care than this PR's compile path. Will land as its own follow-up — each gap closure as a small focused PR is easier to review than batching them.

## Test plan

- [x] `npm test` — 476 tests pass (1 new)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `npx fallow` 0 above threshold