### PR TITLE
Release 0.5.0: multimodal ingest, chunked retrieval, Node 24 minimum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-04-27
+
+Adds multimodal ingest (images, PDFs, transcripts) and chunk-level semantic retrieval with reranking and a `--debug` view. Also raises the minimum Node version to 24 so the project can use modern test-mocking tooling that depends on Node 24+ APIs.
+
+### Added
+
+- **Multimodal ingest** — `llmwiki ingest` now accepts images (vision via the active LLM provider), PDFs (text + metadata via lazy-loaded `pdf-parse`), and transcripts (`.vtt`, `.srt`, plus content-sniffed `.txt` that requires repeated speaker dialogue or anchored timestamps so plain notes aren't misclassified). Each source records its `sourceType` in frontmatter (`web` | `file` | `image` | `pdf` | `transcript`). YouTube transcript URLs are auto-routed.
+- **Chunk-level semantic retrieval** — the embedding store gained an optional v2 `chunks` schema. Pages are split on paragraph + heading boundaries (with size guardrails), embedded individually, and reused across compiles when their content hash hasn't changed. Query routing prefers chunk hits, falls back to page-level retrieval and full-index selection.
+- **BM25 reranking** over chunk candidates, blending 0.5x cosine similarity with BM25 score so semantic ranking still matters when the query has no overlapping terms.
+- **`llmwiki query --debug`** prints the top chunks (slug, score, snippet) and pages selected, so users can audit retrieval decisions. The MCP `query_wiki` tool accepts a `debug` arg too.
+- **Empty-store cold-start** — an empty v1 or v2 store with live wiki pages now triggers a full chunk embedding on next compile (previously, embeddings would only update when an existing slug changed).
+- **`@copilotkit/aimock` test infrastructure** with `mockClaudeEnv` / `mockOpenAIEnv` / `useAimockLifecycle` helpers. CLI subprocess tests can now stub LLM endpoints deterministically — closes the recurring "no subprocess test for the compile/query happy path" gap that codex flagged across review-queue, schema-layer, confidence-metadata, and chunked-retrieval.
+
+### Changed
+
+- **Minimum Node version raised from 18 to 24.** `engines.node` is `>=24`, the tsup target is `node24`, and CI runs only on Node 24. Users on older Node should pin to `<0.5.0` until they can upgrade their runtime.
+- `pdf-parse` is dynamically imported so the cost of loading pdfjs-dist is paid only when a PDF is actually being ingested.
+
+### Test infrastructure
+
+- New `runCLI` / `expectCLIExit` / `expectCLIFailure` / `formatCLIFailure` helpers in `test/fixtures/run-cli.ts` capture full subprocess diagnostics (code, signal, killed, message, stdout, stderr, args, cwd) on assertion failure — flakes now surface their root cause without rerunning.
+- `vitest globalSetup` builds dist once before the suite runs, eliminating the per-test `tsup --clean` race that caused intermittent CI flakes.
+- Tests grew from 391 to 477 in this release (and to 519 once export-bundle lands as a follow-up).
+
 ## [0.4.0] - 2026-04-25
 
 Adds claim-level source-range provenance, a first-class schema layer for typed page kinds, configurable provider request timeouts, and a slug-based wikilink format that resolves reliably in Obsidian.

--- a/README.md
+++ b/README.md
@@ -370,6 +370,12 @@ Karpathy describes an abstract pattern for turning raw data into compiled knowle
 
 ## Roadmap
 
+Shipped in 0.5.0:
+
+- ✅ Multimodal ingest (images, PDFs, transcripts)
+- ✅ Chunked retrieval with reranking and `--debug` output
+- ⚠️ Minimum Node version raised to 24 (was 18)
+
 Shipped in 0.4.0:
 
 - ✅ Claim-level provenance with source ranges
@@ -391,12 +397,20 @@ Shipped in 0.2.0:
 
 Next up:
 
-- Multimodal ingest (images, PDFs, transcripts)
-- Chunked retrieval with reranking
 - Export bundle (`llms.txt`, JSON, JSON-LD, GraphML, Marp)
 - Session-history adapters (Claude, Codex, Cursor exports)
 
-If you like ambitious problems: **multimodal ingest**, **chunked retrieval with reranking**, and **export bundles** are the meatiest. Open an issue to claim one or kick off a design discussion.
+Future ideas (open to discussion):
+
+- Recurring source refresh jobs — re-ingest URLs on a schedule, diff against the prior snapshot, re-compile only what changed
+- Graph export and a lightweight read-only graph browser for the concept network
+- A local read-only web UI for browsing the compiled wiki without Obsidian
+- MCP prompt resources — curated agent prompts (review the wiki, propose new sources, draft a comparison page) shipped as MCP resources
+- Maintenance log + log rotation so long-running watch sessions don't grow unbounded
+
+If you like ambitious problems: **graph export with a browser**, **recurring source refresh**, and **MCP prompt resources** are the meatiest of the futures. Open an issue to claim one or kick off a design discussion.
+
+Explicitly not planned (good ideas, just not for this repo): full static-site generator, desktop or mobile apps, fine-tuning, a formal ontology engine, heavy graph reasoning.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-wiki-compiler",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A knowledge compiler CLI — raw sources in, interlinked wiki out",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release prep for 0.5.0 — version bump, CHANGELOG entry, and roadmap update covering the work merged since 0.4.0:

- **#27** — multimodal ingest (images, PDFs, transcripts) with content-sniffing for `.txt` transcripts
- **#28** — chunked retrieval with BM25 reranking and `query --debug` output
- **#29** — `@copilotkit/aimock` test infrastructure + Node 18 → 24 minimum bump
- **#30** — aimock-backed subprocess tests for chunked-retrieval

## Changes

- `package.json` 0.4.0 → 0.5.0
- `CHANGELOG.md` — full 0.5.0 entry under Keep-a-Changelog format with Added, Changed, Test infrastructure sections. Calls out the Node 18 → 24 minimum bump as a notable change for upgraders.
- `README.md`:
  - New `Shipped in 0.5.0` block at the top of Roadmap with multimodal ingest, chunked retrieval, and a ⚠️ note about the Node 24 minimum
  - `Next up` now reads just export-bundle and session-adapters
  - New **Future ideas** section pulled from the deferred Phase 4 items (recurring source refresh, graph export + browser, local read-only web UI, MCP prompt resources, maintenance log + log rotation)
  - New **Explicitly not planned** note for static-site generator, desktop/mobile apps, fine-tuning, formal ontology engine, heavy graph reasoning

## Test plan

- [x] `npm test` — 477 tests pass
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `npx fallow` 0 above threshold
- [x] After merge: tag v0.5.0, push tag, npm publish, create GitHub release