### PR TITLE
Reconcile 0.5.0 publish metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-wiki-compiler",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-wiki-compiler",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A knowledge compiler CLI — raw sources in, interlinked wiki out",
   "type": "module",
   "bin": {
-    "llmwiki": "./dist/cli.js"
+    "llmwiki": "dist/cli.js"
   },
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
Two small metadata fixes codex caught during `npm publish --dry-run`:

- `package-lock.json` root package said 0.4.0 — bumped to 0.5.0 so the lockfile agrees with package.json.
- `bin.llmwiki` was `./dist/cli.js`; npm auto-corrects this to `dist/cli.js` on publish and warns. Pre-normalize so the warning goes away and the published metadata matches the source.

After this lands, the v0.5.0 tag and GitHub release will be moved to point at this commit (tag force-push is safe since 0.5.0 isn't on npm yet). Then publish.

## Test plan
- [x] `npm publish --dry-run` clean
- [x] `npm test` 477 pass
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `npx fallow` clean