### PR TITLE
fix(ingest): resolve youtube-transcript startup import error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "p-limit": "^6.0.0",
         "pdf-parse": "^2.4.5",
         "turndown": "^7.2.0",
-        "youtube-transcript": "^1.3.0",
+        "youtube-transcript": "^1.3.1",
         "zod": "^3.25.76"
       },
       "bin": {
@@ -4431,9 +4431,9 @@
       }
     },
     "node_modules/youtube-transcript": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/youtube-transcript/-/youtube-transcript-1.3.0.tgz",
-      "integrity": "sha512-laWv9RcKIWh6rZUH3hVnOngEvtKAhFMV5UepUO6AgevPYqe2zv8KW/uCkZJDSnPwf5/AdVu0Q66/1RDblKsp6Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/youtube-transcript/-/youtube-transcript-1.3.1.tgz",
+      "integrity": "sha512-NDCjwad113TGybbYF51y9Z4tcwzBHUZWQdF9veULNca18L+FdDbHHtTHIr69WVa3bB90l67S8kN0HtL2JO9fhg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "p-limit": "^6.0.0",
     "pdf-parse": "^2.4.5",
     "turndown": "^7.2.0",
-    "youtube-transcript": "^1.3.0",
+    "youtube-transcript": "^1.3.1",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/src/ingest/transcript.ts
+++ b/src/ingest/transcript.ts
@@ -14,25 +14,10 @@
 import { readFile } from "fs/promises";
 import path from "path";
 import { titleFromFilename, type IngestedSource } from "./shared.js";
-// The youtube-transcript@1.3.0 package ships a CJS file as its `main` entry
-// while declaring `"type": "module"` in its package.json — the main entry is
-// unloadable from native ESM at runtime. Bypass the broken main by importing
-// the bundled ESM dist file directly. We attach a local type for the only
-// method we use because the deep import path lacks bundled .d.ts.
-// @ts-expect-error -- deep import: see comment above.
-import { YoutubeTranscript as YoutubeTranscriptUntyped } from "youtube-transcript/dist/youtube-transcript.esm.js";
-
-interface YoutubeTranscriptSegment {
-  text: string;
-  offset: number;
-  duration: number;
-}
-
-interface YoutubeTranscriptApi {
-  fetchTranscript(videoId: string): Promise<YoutubeTranscriptSegment[]>;
-}
-
-const YoutubeTranscript = YoutubeTranscriptUntyped as YoutubeTranscriptApi;
+// youtube-transcript exports proper ESM via its package.json `exports` map.
+// Import from the package root; the "import" condition resolves to
+// ./dist/esm/index.js and includes bundled .d.ts types.
+import { YoutubeTranscript } from "youtube-transcript";
 
 /** Pattern that identifies a YouTube URL. */
 const YOUTUBE_URL_PATTERN = /^https?:\/\/(www\.)?(youtube\.com\/watch|youtu\.be\/)/;


### PR DESCRIPTION
## Summary

Fixes a CLI startup crash caused by importing a non-exported deep path from `youtube-transcript`.

In issue #33, `llmwiki --version` and other commands failed before execution with:

`ERR_PACKAGE_PATH_NOT_EXPORTED: './dist/youtube-transcript.esm.js'`

Root cause: we imported `youtube-transcript/dist/youtube-transcript.esm.js`, but newer `youtube-transcript` versions only expose the package root via `exports`.

## What Changed

- Updated transcript ingestion import to use the package root:
  - from `youtube-transcript/dist/youtube-transcript.esm.js`
  - to `youtube-transcript`
- Removed local untyped casting/interfaces that were only needed for the deep import.
- Updated inline comments in `src/ingest/transcript.ts` to reflect `exports`-map behavior.
- Bumped dependency:
  - `youtube-transcript` from `^1.3.0` to `^1.3.1` in `package.json`
  - synced `package-lock.json` to `youtube-transcript@1.3.1`

## Why This Approach

Importing from the package root aligns with the library’s public export surface and is forward-compatible with its current module layout.

## How To Test

1. `npx tsc --noEmit`
2. `npm run build`
3. `npm test`
4. `npx fallow`

Additional smoke check:
- `node dist/cli.js --version` should print the version and not throw `ERR_PACKAGE_PATH_NOT_EXPORTED`.

## Issue

Closes #33 