### PR TITLE
Add pack-and-install CI smoke test

### DIFF
--- a/test/pack-and-install.test.ts
+++ b/test/pack-and-install.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Pack-and-install smoke test.
+ *
+ * Reproduces what end users actually do: `npm install llm-wiki-compiler`.
+ * Our standard test suite installs from the locked dependency tree, which
+ * masks bugs that only appear when transitive deps resolve fresh. v0.5.0
+ * shipped with a startup crash for exactly this reason — `youtube-transcript`
+ * 1.3.1 added an exports map that hid the deep import we were using, but
+ * our lockfile pinned 1.3.0 so CI never saw it.
+ *
+ * What this test does:
+ *  1. `npm pack` to produce the same tarball npm publishes.
+ *  2. Install that tarball into a throwaway directory (no lockfile from
+ *     this repo, so deps resolve fresh against the registry).
+ *  3. Invoke the installed `llmwiki` binary with `--version`, `--help`,
+ *     and `ingest --help`. Any crash or non-zero exit fails the test.
+ *
+ * Because installing all production deps fresh is slow (~30–60s) and
+ * requires registry access, the test is skipped locally by default. It
+ * runs automatically in CI (where `CI=true` is set), and devs can force
+ * it locally via `RUN_PACK_INSTALL_SMOKE=1 npm test`.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { mkdtemp, rm, writeFile } from "fs/promises";
+import path from "path";
+import { tmpdir } from "os";
+
+const exec = promisify(execFile);
+
+/** Matches CI environments (GitHub Actions sets CI=true). */
+const SHOULD_RUN =
+  process.env.CI === "true" || process.env.RUN_PACK_INSTALL_SMOKE === "1";
+
+/** npm install over the network can be slow; give it a generous ceiling. */
+const INSTALL_TIMEOUT_MS = 5 * 60 * 1000;
+
+interface PackedTarball {
+  /** Absolute path to the tarball file. */
+  path: string;
+  /** Directory the tarball lives in (caller must clean up). */
+  dir: string;
+}
+
+/**
+ * Run `npm pack` against the current project and return the tarball path.
+ * Uses --json so we don't have to parse the human-readable output.
+ */
+async function packProject(): Promise<PackedTarball> {
+  const dir = await mkdtemp(path.join(tmpdir(), "llmwiki-pack-"));
+  const { stdout } = await exec(
+    "npm",
+    ["pack", "--pack-destination", dir, "--json", "--ignore-scripts"],
+    { cwd: process.cwd() },
+  );
+  const parsed = JSON.parse(stdout) as Array<{ filename: string }>;
+  return { path: path.join(dir, parsed[0].filename), dir };
+}
+
+/**
+ * Install a tarball into a fresh empty project. Deps resolve against the
+ * live registry — no lockfile inheritance from llmwiki itself — so this
+ * mirrors what `npm install -g llm-wiki-compiler` does for end users.
+ */
+async function installTarball(tarballPath: string): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "llmwiki-install-"));
+  await writeFile(
+    path.join(root, "package.json"),
+    `${JSON.stringify({ name: "llmwiki-smoke", version: "1.0.0", private: true })}\n`,
+    "utf-8",
+  );
+  await exec("npm", ["install", "--no-fund", "--no-audit", tarballPath], {
+    cwd: root,
+    timeout: INSTALL_TIMEOUT_MS,
+  });
+  return path.join(root, "node_modules", ".bin", "llmwiki");
+}
+
+const describeOrSkip = SHOULD_RUN ? describe : describe.skip;
+
+describeOrSkip("pack-and-install smoke", () => {
+  let tarball: PackedTarball;
+  let installRoot: string;
+  let bin: string;
+
+  beforeAll(async () => {
+    tarball = await packProject();
+    bin = await installTarball(tarball.path);
+    installRoot = path.dirname(path.dirname(path.dirname(bin)));
+  }, INSTALL_TIMEOUT_MS + 60_000);
+
+  afterAll(async () => {
+    if (installRoot) await rm(installRoot, { recursive: true, force: true });
+    if (tarball) await rm(tarball.dir, { recursive: true, force: true });
+  });
+
+  it("--version prints a semver string", async () => {
+    const { stdout } = await exec(bin, ["--version"]);
+    expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("--help lists the core commands", async () => {
+    const { stdout } = await exec(bin, ["--help"]);
+    expect(stdout).toContain("ingest");
+    expect(stdout).toContain("compile");
+    expect(stdout).toContain("query");
+  });
+
+  it("ingest --help exits cleanly", async () => {
+    const { stdout } = await exec(bin, ["ingest", "--help"]);
+    expect(stdout).toContain("ingest");
+  });
+});

--- a/test/pack-and-install.test.ts
+++ b/test/pack-and-install.test.ts
@@ -60,12 +60,13 @@ async function packProject(): Promise<PackedTarball> {
 }
 
 /**
- * Install a tarball into a fresh empty project. Deps resolve against the
- * live registry — no lockfile inheritance from llmwiki itself — so this
- * mirrors what `npm install -g llm-wiki-compiler` does for end users.
+ * Install a tarball into the given empty project directory. Deps resolve
+ * against the live registry — no lockfile inheritance from llmwiki itself
+ * — so this mirrors what `npm install -g llm-wiki-compiler` does for end
+ * users. Caller owns `root` lifecycle so an install failure still leaves
+ * a known directory for afterAll cleanup.
  */
-async function installTarball(tarballPath: string): Promise<string> {
-  const root = await mkdtemp(path.join(tmpdir(), "llmwiki-install-"));
+async function installTarballInto(root: string, tarballPath: string): Promise<string> {
   await writeFile(
     path.join(root, "package.json"),
     `${JSON.stringify({ name: "llmwiki-smoke", version: "1.0.0", private: true })}\n`,
@@ -81,14 +82,16 @@ async function installTarball(tarballPath: string): Promise<string> {
 const describeOrSkip = SHOULD_RUN ? describe : describe.skip;
 
 describeOrSkip("pack-and-install smoke", () => {
-  let tarball: PackedTarball;
-  let installRoot: string;
+  let tarball: PackedTarball | null = null;
+  let installRoot: string | null = null;
   let bin: string;
 
   beforeAll(async () => {
+    // Create both temp dirs upfront so afterAll can clean them up even
+    // when pack or install throws partway through.
+    installRoot = await mkdtemp(path.join(tmpdir(), "llmwiki-install-"));
     tarball = await packProject();
-    bin = await installTarball(tarball.path);
-    installRoot = path.dirname(path.dirname(path.dirname(bin)));
+    bin = await installTarballInto(installRoot, tarball.path);
   }, INSTALL_TIMEOUT_MS + 60_000);
 
   afterAll(async () => {


### PR DESCRIPTION
## Summary

Closes the gap that let v0.5.0 ship with a startup crash. Our regular test suite installs from the locked dep tree, so it never sees what `npm install -g llm-wiki-compiler` actually pulls. This new test does.

The flow:
1. `npm pack` to produce the same tarball npm publishes
2. Install that tarball into a fresh tmp directory with no inherited lockfile — deps resolve fresh against the registry, exactly like a real user
3. Invoke the installed `llmwiki` binary with `--version`, `--help`, and `ingest --help`

Any crash or non-zero exit fails the test.

## Why this catches the v0.5.0 bug

`youtube-transcript@1.3.1` added an `exports` map that hid the deep import we were using. Our lockfile pinned 1.3.0 so CI never noticed. Fresh installs got 1.3.1 and crashed on `--version`. Under this new test, the fresh `npm install` would resolve to 1.3.1 and the `--version` assertion would fail loud.

## Performance

Fresh installs over the network are slow (~30-60s cold; ~8s warm with npm cache), so the test is **skipped locally by default**. It runs automatically when `CI=true` is set (GitHub Actions does this). Devs can force it locally with `RUN_PACK_INSTALL_SMOKE=1 npm test`.

## Test plan

- [x] Local: `RUN_PACK_INSTALL_SMOKE=1 npx vitest run test/pack-and-install.test.ts` → all 3 tests pass in ~8s
- [x] Local default (no env var): all 3 tests skipped, no install attempted
- [x] `npx tsc --noEmit` clean
- [x] `npm test` full suite green (477 passed, 3 skipped on this branch)
- [x] `npx fallow` reports 0 issues above threshold
- [ ] CI runs the smoke test against this branch — should pass since main is healthy

