### PR TITLE
fix(ingest): preserve non-ASCII filenames; fail loudly on empty slugs (#35)

### DIFF
--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -248,7 +248,19 @@ async function fetchContent(
 
 /** Write the ingested document to the sources/ directory. */
 async function saveSource(title: string, document: string): Promise<string> {
-  const filename = `${slugify(title)}.md`;
+  const slug = slugify(title);
+  // Defense in depth — even with the Unicode-aware slugifier, a title made
+  // entirely of punctuation/emoji/symbols still slugifies to "". Without
+  // this guard the file would be written to sources/.md (a dotfile that's
+  // easy to miss and that subsequent empty-slug ingests would overwrite).
+  if (!slug) {
+    throw new Error(
+      `Could not derive a filename from title "${title}". ` +
+        `The title contains no letter or number characters. ` +
+        `Rename the source file to one with at least one letter or digit.`,
+    );
+  }
+  const filename = `${slug}.md`;
   const destPath = path.join(SOURCES_DIR, filename);
 
   await mkdir(SOURCES_DIR, { recursive: true });

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -39,12 +39,24 @@ interface ProvenanceMetadata {
   inferredParagraphs?: number;
 }
 
-/** Convert a human-readable concept title to a filename slug. */
+/**
+ * Convert a human-readable concept title to a filename slug.
+ *
+ * Unicode-aware: keeps letters and numbers from any script (Latin, CJK,
+ * Cyrillic, Greek, Arabic, etc.). Strips punctuation, emoji, and other
+ * symbols. The previous implementation used `\w` without the `u` flag,
+ * which only matches `[A-Za-z0-9_]` — that silently dropped CJK titles
+ * to the empty string and caused the bug fixed in #35.
+ *
+ * Returns an empty string when the title contains no letters or numbers
+ * at all (callers that write files should detect this and fail loudly
+ * instead of writing a dotfile).
+ */
 export function slugify(title: string): string {
   return title
     .toLowerCase()
     .replace(/['']/g, "")
-    .replace(/[^\w\s-]/g, "")
+    .replace(/[^\p{L}\p{N}\s-]/gu, "")
     .replace(/\s+/g, "-")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "");

--- a/test/ingest-unicode-filenames.test.ts
+++ b/test/ingest-unicode-filenames.test.ts
@@ -1,0 +1,107 @@
+/**
+ * CLI integration tests for issue #35 — non-ASCII filenames must not be
+ * silently dropped on ingest.
+ *
+ * Before the fix, `slugify` used `\w` without the `/u` flag, which only
+ * matches `[A-Za-z0-9_]`. A title like `测试文档` slugified to the empty
+ * string and ingest wrote `sources/.md` — a dotfile that's easy to miss
+ * and that every subsequent CJK ingest would overwrite.
+ *
+ * These tests exercise the full CLI subprocess so the assertion is on
+ * what the user actually observes after running `llmwiki ingest`.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import path from "path";
+import { mkdtemp, rm, writeFile, readdir } from "fs/promises";
+import { tmpdir } from "os";
+import { runCLI, expectCLIExit, expectCLIFailure } from "./fixtures/run-cli.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) await rm(dir, { recursive: true, force: true });
+  }
+});
+
+/** Create a temp workspace and write a fixture file with the given name. */
+async function makeWorkspace(fixtureName: string, content: string): Promise<{
+  cwd: string;
+  fixturePath: string;
+}> {
+  const cwd = await mkdtemp(path.join(tmpdir(), "llmwiki-unicode-ingest-"));
+  tempDirs.push(cwd);
+  const fixturePath = path.join(cwd, fixtureName);
+  await writeFile(fixturePath, content, "utf-8");
+  return { cwd, fixturePath };
+}
+
+describe("ingest — non-ASCII filenames (#35)", () => {
+  it("CJK-named file is written under sources/ with a Unicode slug", async () => {
+    const { cwd, fixturePath } = await makeWorkspace(
+      "测试文档.md",
+      "# 测试\n\nThis is a Chinese-titled document.",
+    );
+
+    const result = await runCLI(["ingest", fixturePath], cwd);
+    expectCLIExit(result, 0);
+
+    const files = await readdir(path.join(cwd, "sources"));
+    // Exactly one file, named after the CJK title — not the silent ".md" dotfile.
+    expect(files).toEqual(["测试文档.md"]);
+  });
+
+  it("Japanese-named file is written under sources/ with the original characters", async () => {
+    const { cwd, fixturePath } = await makeWorkspace(
+      "こんにちは.md",
+      "# こんにちは\n\nA Japanese-titled document.",
+    );
+
+    const result = await runCLI(["ingest", fixturePath], cwd);
+    expectCLIExit(result, 0);
+
+    const files = await readdir(path.join(cwd, "sources"));
+    expect(files).toEqual(["こんにちは.md"]);
+  });
+
+  it("two distinct CJK-named files do not collide on sources/.md", async () => {
+    const { cwd: cwdA, fixturePath: pathA } = await makeWorkspace(
+      "测试文档.md",
+      "# A\n\nFirst Chinese doc.",
+    );
+    const result1 = await runCLI(["ingest", pathA], cwdA);
+    expectCLIExit(result1, 0);
+
+    // Re-use the workspace by writing a second CJK file alongside the first
+    // and ingest it in the same cwd so we can assert they end up under
+    // distinct filenames in the same sources/ directory.
+    const pathB = path.join(cwdA, "另一个文档.md");
+    await writeFile(pathB, "# B\n\nSecond Chinese doc.", "utf-8");
+    const result2 = await runCLI(["ingest", pathB], cwdA);
+    expectCLIExit(result2, 0);
+
+    const files = (await readdir(path.join(cwdA, "sources"))).sort();
+    expect(files).toEqual(["另一个文档.md", "测试文档.md"]);
+  });
+
+  it("title with no letters or numbers fails loudly with an actionable error", async () => {
+    const { cwd, fixturePath } = await makeWorkspace(
+      "🎉🎊.md",
+      "# 🎉🎊\n\nA file whose title is purely emoji.",
+    );
+
+    const result = await runCLI(["ingest", fixturePath], cwd);
+    expectCLIFailure(result);
+    expect(result.stderr).toContain("Could not derive a filename");
+    // Critically: no .md dotfile was written — the ingest aborted.
+    let files: string[] = [];
+    try {
+      files = await readdir(path.join(cwd, "sources"));
+    } catch {
+      // sources/ may not have been created; either outcome is acceptable.
+    }
+    expect(files).not.toContain(".md");
+  });
+});

--- a/test/ingest-unicode-filenames.test.ts
+++ b/test/ingest-unicode-filenames.test.ts
@@ -38,32 +38,40 @@ async function makeWorkspace(fixtureName: string, content: string): Promise<{
   return { cwd, fixturePath };
 }
 
+/**
+ * Run a single non-ASCII ingest and assert the output filename in
+ * sources/ matches what the Unicode-aware slugifier should produce. The
+ * shared helper exists to keep the per-script test cases byte-light and
+ * to avoid duplicate-code findings from the per-script smoke tests.
+ */
+async function expectIngestProducesUnicodeFilename(
+  fixtureName: string,
+  fixtureContent: string,
+  expectedSourcesEntry: string,
+): Promise<void> {
+  const { cwd, fixturePath } = await makeWorkspace(fixtureName, fixtureContent);
+  const result = await runCLI(["ingest", fixturePath], cwd);
+  expectCLIExit(result, 0);
+  const files = await readdir(path.join(cwd, "sources"));
+  expect(files).toEqual([expectedSourcesEntry]);
+}
+
 describe("ingest — non-ASCII filenames (#35)", () => {
   it("CJK-named file is written under sources/ with a Unicode slug", async () => {
-    const { cwd, fixturePath } = await makeWorkspace(
+    // Exactly one file, named after the CJK title — not the silent ".md" dotfile.
+    await expectIngestProducesUnicodeFilename(
       "测试文档.md",
       "# 测试\n\nThis is a Chinese-titled document.",
+      "测试文档.md",
     );
-
-    const result = await runCLI(["ingest", fixturePath], cwd);
-    expectCLIExit(result, 0);
-
-    const files = await readdir(path.join(cwd, "sources"));
-    // Exactly one file, named after the CJK title — not the silent ".md" dotfile.
-    expect(files).toEqual(["测试文档.md"]);
   });
 
   it("Japanese-named file is written under sources/ with the original characters", async () => {
-    const { cwd, fixturePath } = await makeWorkspace(
+    await expectIngestProducesUnicodeFilename(
       "こんにちは.md",
       "# こんにちは\n\nA Japanese-titled document.",
+      "こんにちは.md",
     );
-
-    const result = await runCLI(["ingest", fixturePath], cwd);
-    expectCLIExit(result, 0);
-
-    const files = await readdir(path.join(cwd, "sources"));
-    expect(files).toEqual(["こんにちは.md"]);
   });
 
   it("two distinct CJK-named files do not collide on sources/.md", async () => {

--- a/test/slugify.test.ts
+++ b/test/slugify.test.ts
@@ -37,4 +37,30 @@ describe("slugify", () => {
   it("handles single word", () => {
     expect(slugify("Concept")).toBe("concept");
   });
+
+  // Issue #35: slugify must be Unicode-aware so non-ASCII titles don't
+  // silently collapse to the empty string.
+  it("preserves CJK characters", () => {
+    expect(slugify("测试文档")).toBe("测试文档");
+  });
+
+  it("preserves Japanese hiragana and katakana", () => {
+    expect(slugify("こんにちは カタカナ")).toBe("こんにちは-カタカナ");
+  });
+
+  it("preserves Cyrillic", () => {
+    expect(slugify("Привет Мир")).toBe("привет-мир");
+  });
+
+  it("mixes Latin and CJK in the same slug", () => {
+    expect(slugify("Hello 世界")).toBe("hello-世界");
+  });
+
+  it("strips emoji while keeping the surrounding letters", () => {
+    expect(slugify("Hello 🌍 World")).toBe("hello-world");
+  });
+
+  it("returns empty string when the title has no letters or numbers", () => {
+    expect(slugify("🎉🎊!!!")).toBe("");
+  });
 });


### PR DESCRIPTION
Closes #35.

## The bug

`slugify` used `\w` without the `/u` flag, which only matches `[A-Za-z0-9_]`. A title like `测试文档` collapsed to the empty string and `saveSource` wrote `sources/.md` — a dotfile that's easy to miss and that every subsequent CJK-named ingest would silently overwrite. The CLI exited 0, so the failure was completely silent.

## The fix

Two layers of defense:

1. **Unicode-aware slugifier.** `slugify` now uses Unicode property escapes (`\p{L}`, `\p{N}`) with the `/u` flag, so letters and numbers from any script (Latin, CJK, Cyrillic, Greek, Arabic, etc.) survive. Punctuation, emoji, and symbols are still stripped.
2. **Fail-loud guard in `saveSource`.** Even with the better slugifier, a title made entirely of punctuation/emoji still slugifies to `\"\"` (e.g. `🎉🎊!!!`). The ingest path now throws an actionable error in that case rather than writing a dotfile.

## Test plan

- [x] `slugify` unit tests cover CJK, Japanese hiragana/katakana, Cyrillic, mixed Latin+CJK, emoji-stripping, and the empty-result case.
- [x] New CLI integration test file exercises ingest end-to-end through the compiled binary:
  - CJK-named file produces `sources/测试文档.md` (not `sources/.md`)
  - Japanese-named file is preserved
  - Two distinct CJK files do not collide on `sources/.md`
  - Pure-emoji title fails with an actionable stderr message and creates no dotfile
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] `npm test` — 542 pass / 3 skipped (smoke); no regressions
- [x] `npx fallow` — 0 issues above threshold
- [x] CI green on this branch