### PR TITLE
fix(ingest): disambiguate same-basename sources with stable hash suffix (#36)

### DIFF
--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -11,7 +11,8 @@
 
 import path from "path";
 import { mkdir, readFile, writeFile } from "fs/promises";
-import { slugify, buildFrontmatter } from "../utils/markdown.js";
+import { createHash } from "crypto";
+import { slugify, buildFrontmatter, parseFrontmatter } from "../utils/markdown.js";
 import { MAX_SOURCE_CHARS, MIN_SOURCE_CHARS, SOURCES_DIR, IMAGE_EXTENSIONS, TRANSCRIPT_EXTENSIONS } from "../utils/constants.js";
 import * as output from "../utils/output.js";
 import ingestWeb from "../ingest/web.js";
@@ -246,11 +247,53 @@ async function fetchContent(
   }
 }
 
+/** Length of the hex hash suffix appended to disambiguate basename collisions. */
+const COLLISION_HASH_LEN = 8;
+
+/**
+ * Compute a short, stable hex hash of a source identifier. Used to
+ * disambiguate filenames when two distinct sources slugify to the same
+ * basename (issue #36). Stability matters: re-ingesting the same source
+ * must always produce the same hash so we overwrite cleanly instead of
+ * accumulating duplicates.
+ */
+function shortHashOfSource(source: string): string {
+  return createHash("sha256").update(source).digest("hex").slice(0, COLLISION_HASH_LEN);
+}
+
+/**
+ * Resolve a final filename for the given slug and source identity.
+ *
+ * - When `${slug}.md` does not exist, return `${slug}.md`.
+ * - When `${slug}.md` exists and its frontmatter `source` matches the
+ *   incoming source, return `${slug}.md` so re-ingest stays idempotent.
+ * - Otherwise return `${slug}-<hash>.md` so two distinct sources that
+ *   share a basename coexist instead of one silently overwriting the
+ *   other (issue #36).
+ */
+async function resolveCollisionFreeFilename(slug: string, source: string): Promise<string> {
+  const candidate = `${slug}.md`;
+  const candidatePath = path.join(SOURCES_DIR, candidate);
+  let existing: string;
+  try {
+    existing = await readFile(candidatePath, "utf-8");
+  } catch (err) {
+    const e = err as { code?: string };
+    if (e.code === "ENOENT") return candidate;
+    throw err;
+  }
+  const { meta } = parseFrontmatter(existing);
+  if (typeof meta.source === "string" && meta.source === source) {
+    return candidate;
+  }
+  return `${slug}-${shortHashOfSource(source)}.md`;
+}
+
 /** Write the ingested document to the sources/ directory. */
-async function saveSource(title: string, document: string): Promise<string> {
+async function saveSource(title: string, document: string, source: string): Promise<string> {
   const slug = slugify(title);
-  // Defense in depth — even with the Unicode-aware slugifier, a title made
-  // entirely of punctuation/emoji/symbols still slugifies to "". Without
+  // Defense in depth — even with the Unicode-aware slugifier (#35), a title
+  // made entirely of punctuation/emoji/symbols still slugifies to "". Without
   // this guard the file would be written to sources/.md (a dotfile that's
   // easy to miss and that subsequent empty-slug ingests would overwrite).
   if (!slug) {
@@ -260,12 +303,10 @@ async function saveSource(title: string, document: string): Promise<string> {
         `Rename the source file to one with at least one letter or digit.`,
     );
   }
-  const filename = `${slug}.md`;
-  const destPath = path.join(SOURCES_DIR, filename);
-
   await mkdir(SOURCES_DIR, { recursive: true });
+  const filename = await resolveCollisionFreeFilename(slug, source);
+  const destPath = path.join(SOURCES_DIR, filename);
   await writeFile(destPath, document, "utf-8");
-
   return destPath;
 }
 
@@ -286,7 +327,7 @@ export async function ingestSource(source: string): Promise<IngestResult> {
   const result = enforceCharLimit(content);
   enforceMinContent(result.content);
   const document = buildDocument(title, source, result, sourceType);
-  const savedPath = await saveSource(title, document);
+  const savedPath = await saveSource(title, document, source);
 
   return {
     filename: path.basename(savedPath),

--- a/test/fixtures/ingest-workspace.ts
+++ b/test/fixtures/ingest-workspace.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared temp-workspace lifecycle for ingest CLI integration tests.
+ *
+ * Multiple ingest tests need the same pattern: spin up a temp dir, drop
+ * a fixture file inside it, run `llmwiki ingest` against the path, and
+ * tear down the temp dir at the end of the test. Centralising the
+ * tempDirs array + afterEach cleanup avoids the duplicate-code findings
+ * fallow's CI mode flagged when the boilerplate appeared in two
+ * sibling test files.
+ */
+
+import { mkdtemp, rm, writeFile } from "fs/promises";
+import path from "path";
+import { tmpdir } from "os";
+import { afterEach } from "vitest";
+
+/** Public API of the workspace lifecycle returned by useIngestWorkspaces. */
+export interface IngestWorkspaceContext {
+  /**
+   * Create a temp workspace and write a single fixture file at the given
+   * name relative to the workspace root.
+   */
+  makeWorkspace(
+    fixtureName: string,
+    content: string,
+  ): Promise<{ cwd: string; fixturePath: string }>;
+  /** Create an empty temp workspace; caller is responsible for populating it. */
+  makeEmptyWorkspace(): Promise<string>;
+}
+
+/**
+ * Vitest composable: registers an afterEach that removes any workspace
+ * created via the returned helpers. Each caller gets its own tempDirs
+ * array, so concurrent test files do not interfere.
+ *
+ * @param prefix - Inserted into the temp-dir name for easier debugging.
+ */
+export function useIngestWorkspaces(prefix: string): IngestWorkspaceContext {
+  const tempDirs: string[] = [];
+  afterEach(async () => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) await rm(dir, { recursive: true, force: true });
+    }
+  });
+  return {
+    async makeWorkspace(fixtureName, content) {
+      const cwd = await mkdtemp(path.join(tmpdir(), `llmwiki-${prefix}-`));
+      tempDirs.push(cwd);
+      const fixturePath = path.join(cwd, fixtureName);
+      await writeFile(fixturePath, content, "utf-8");
+      return { cwd, fixturePath };
+    },
+    async makeEmptyWorkspace() {
+      const cwd = await mkdtemp(path.join(tmpdir(), `llmwiki-${prefix}-`));
+      tempDirs.push(cwd);
+      return cwd;
+    },
+  };
+}

--- a/test/ingest-basename-collision.test.ts
+++ b/test/ingest-basename-collision.test.ts
@@ -11,20 +11,13 @@
  * source, while keeping re-ingest of the same source idempotent.
  */
 
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import path from "path";
-import { mkdtemp, mkdir, rm, writeFile, readdir, readFile } from "fs/promises";
-import { tmpdir } from "os";
+import { mkdir, writeFile, readdir, readFile } from "fs/promises";
 import { runCLI, expectCLIExit } from "./fixtures/run-cli.js";
+import { useIngestWorkspaces } from "./fixtures/ingest-workspace.js";
 
-const tempDirs: string[] = [];
-
-afterEach(async () => {
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) await rm(dir, { recursive: true, force: true });
-  }
-});
+const workspaces = useIngestWorkspaces("collision");
 
 /** Make a workspace and write two same-basename files in distinct sub-dirs. */
 async function makeCollidingWorkspace(): Promise<{
@@ -32,8 +25,7 @@ async function makeCollidingWorkspace(): Promise<{
   pathA: string;
   pathB: string;
 }> {
-  const cwd = await mkdtemp(path.join(tmpdir(), "llmwiki-collision-"));
-  tempDirs.push(cwd);
+  const cwd = await workspaces.makeEmptyWorkspace();
   await mkdir(path.join(cwd, "a"), { recursive: true });
   await mkdir(path.join(cwd, "b"), { recursive: true });
   const pathA = path.join(cwd, "a", "notes.md");

--- a/test/ingest-basename-collision.test.ts
+++ b/test/ingest-basename-collision.test.ts
@@ -84,4 +84,32 @@ describe("ingest — basename collision (#36)", () => {
 
     expect(secondRun).toEqual(firstRun);
   });
+
+  // Edge case: an existing sources/X.md without llmwiki frontmatter (or with
+  // missing `source` field) should never be silently overwritten — the
+  // resolver must fall through to the hash suffix path.
+  it("falls through cleanly when an existing same-basename file is malformed", async () => {
+    const { cwd, pathA } = await makeCollidingWorkspace();
+
+    // Pre-seed sources/notes.md with a file that has no llmwiki frontmatter
+    // at all — could be a user's hand-written file or stray content.
+    await mkdir(path.join(cwd, "sources"), { recursive: true });
+    await writeFile(
+      path.join(cwd, "sources", "notes.md"),
+      "Pre-existing notes with no frontmatter.\n",
+      "utf-8",
+    );
+
+    const result = await runCLI(["ingest", pathA], cwd);
+    expectCLIExit(result, 0);
+
+    const files = (await readdir(path.join(cwd, "sources"))).sort();
+    expect(files.length).toBe(2);
+    expect(files).toContain("notes.md");
+    expect(files.some((f) => /^notes-[0-9a-f]{8}\.md$/.test(f))).toBe(true);
+
+    // The pre-existing file is preserved verbatim — no silent overwrite.
+    const original = await readFile(path.join(cwd, "sources", "notes.md"), "utf-8");
+    expect(original).toBe("Pre-existing notes with no frontmatter.\n");
+  });
 });

--- a/test/ingest-basename-collision.test.ts
+++ b/test/ingest-basename-collision.test.ts
@@ -35,6 +35,19 @@ async function makeCollidingWorkspace(): Promise<{
   return { cwd, pathA, pathB };
 }
 
+/**
+ * Assert sources/ holds exactly the bare basename plus one hash-suffixed
+ * sibling. The shape `notes.md + notes-<8 hex>.md` is the public contract
+ * for collision disambiguation, used by every test that exercises it.
+ */
+async function expectBareAndHashedNotes(cwd: string): Promise<string[]> {
+  const files = (await readdir(path.join(cwd, "sources"))).sort();
+  expect(files.length).toBe(2);
+  expect(files).toContain("notes.md");
+  expect(files.some((f) => /^notes-[0-9a-f]{8}\.md$/.test(f))).toBe(true);
+  return files;
+}
+
 describe("ingest — basename collision (#36)", () => {
   it("two distinct sources with the same basename produce two distinct files", async () => {
     const { cwd, pathA, pathB } = await makeCollidingWorkspace();
@@ -44,11 +57,7 @@ describe("ingest — basename collision (#36)", () => {
     const r2 = await runCLI(["ingest", pathB], cwd);
     expectCLIExit(r2, 0);
 
-    const files = (await readdir(path.join(cwd, "sources"))).sort();
-    expect(files.length).toBe(2);
-    // First write keeps the bare basename; second write gets a stable hash suffix.
-    expect(files).toContain("notes.md");
-    expect(files.some((f) => /^notes-[0-9a-f]{8}\.md$/.test(f))).toBe(true);
+    const files = await expectBareAndHashedNotes(cwd);
 
     // Both contents are present — no silent overwrite.
     const contents = await Promise.all(
@@ -103,10 +112,7 @@ describe("ingest — basename collision (#36)", () => {
     const result = await runCLI(["ingest", pathA], cwd);
     expectCLIExit(result, 0);
 
-    const files = (await readdir(path.join(cwd, "sources"))).sort();
-    expect(files.length).toBe(2);
-    expect(files).toContain("notes.md");
-    expect(files.some((f) => /^notes-[0-9a-f]{8}\.md$/.test(f))).toBe(true);
+    await expectBareAndHashedNotes(cwd);
 
     // The pre-existing file is preserved verbatim — no silent overwrite.
     const original = await readFile(path.join(cwd, "sources", "notes.md"), "utf-8");

--- a/test/ingest-basename-collision.test.ts
+++ b/test/ingest-basename-collision.test.ts
@@ -1,0 +1,95 @@
+/**
+ * CLI integration tests for issue #36 — files sharing a basename must not
+ * silently overwrite each other in sources/.
+ *
+ * Before the fix, `saveSource` built the destination path purely from the
+ * slugified title:
+ *   const filename = `${slugify(title)}.md`;
+ * So `a/notes.md` and `b/notes.md` both wrote to `sources/notes.md`,
+ * and the second ingest silently won. The fix appends a stable
+ * source-derived hash suffix when a destination collides with a different
+ * source, while keeping re-ingest of the same source idempotent.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import path from "path";
+import { mkdtemp, mkdir, rm, writeFile, readdir, readFile } from "fs/promises";
+import { tmpdir } from "os";
+import { runCLI, expectCLIExit } from "./fixtures/run-cli.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) await rm(dir, { recursive: true, force: true });
+  }
+});
+
+/** Make a workspace and write two same-basename files in distinct sub-dirs. */
+async function makeCollidingWorkspace(): Promise<{
+  cwd: string;
+  pathA: string;
+  pathB: string;
+}> {
+  const cwd = await mkdtemp(path.join(tmpdir(), "llmwiki-collision-"));
+  tempDirs.push(cwd);
+  await mkdir(path.join(cwd, "a"), { recursive: true });
+  await mkdir(path.join(cwd, "b"), { recursive: true });
+  const pathA = path.join(cwd, "a", "notes.md");
+  const pathB = path.join(cwd, "b", "notes.md");
+  await writeFile(pathA, "# Notes A\n\nContent from a/notes.md.", "utf-8");
+  await writeFile(pathB, "# Notes B\n\nContent from b/notes.md.", "utf-8");
+  return { cwd, pathA, pathB };
+}
+
+describe("ingest — basename collision (#36)", () => {
+  it("two distinct sources with the same basename produce two distinct files", async () => {
+    const { cwd, pathA, pathB } = await makeCollidingWorkspace();
+
+    const r1 = await runCLI(["ingest", pathA], cwd);
+    expectCLIExit(r1, 0);
+    const r2 = await runCLI(["ingest", pathB], cwd);
+    expectCLIExit(r2, 0);
+
+    const files = (await readdir(path.join(cwd, "sources"))).sort();
+    expect(files.length).toBe(2);
+    // First write keeps the bare basename; second write gets a stable hash suffix.
+    expect(files).toContain("notes.md");
+    expect(files.some((f) => /^notes-[0-9a-f]{8}\.md$/.test(f))).toBe(true);
+
+    // Both contents are present — no silent overwrite.
+    const contents = await Promise.all(
+      files.map((f) => readFile(path.join(cwd, "sources", f), "utf-8")),
+    );
+    const joined = contents.join("\n");
+    expect(joined).toContain("Content from a/notes.md.");
+    expect(joined).toContain("Content from b/notes.md.");
+  });
+
+  it("re-ingesting the same source overwrites in place (idempotent, no duplicates)", async () => {
+    const { cwd, pathA } = await makeCollidingWorkspace();
+
+    expectCLIExit(await runCLI(["ingest", pathA], cwd), 0);
+    expectCLIExit(await runCLI(["ingest", pathA], cwd), 0);
+    expectCLIExit(await runCLI(["ingest", pathA], cwd), 0);
+
+    const files = await readdir(path.join(cwd, "sources"));
+    // Three ingests of the same file → still exactly one source on disk.
+    expect(files).toEqual(["notes.md"]);
+  });
+
+  it("disambiguation hash is stable across runs (same source → same suffix)", async () => {
+    const { cwd, pathA, pathB } = await makeCollidingWorkspace();
+
+    expectCLIExit(await runCLI(["ingest", pathA], cwd), 0);
+    expectCLIExit(await runCLI(["ingest", pathB], cwd), 0);
+    const firstRun = (await readdir(path.join(cwd, "sources"))).sort();
+
+    // Re-ingest pathB — should hit the same hashed filename, not generate a new one.
+    expectCLIExit(await runCLI(["ingest", pathB], cwd), 0);
+    const secondRun = (await readdir(path.join(cwd, "sources"))).sort();
+
+    expect(secondRun).toEqual(firstRun);
+  });
+});

--- a/test/ingest-unicode-filenames.test.ts
+++ b/test/ingest-unicode-filenames.test.ts
@@ -11,32 +11,14 @@
  * what the user actually observes after running `llmwiki ingest`.
  */
 
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import path from "path";
-import { mkdtemp, rm, writeFile, readdir } from "fs/promises";
-import { tmpdir } from "os";
+import { readdir, writeFile } from "fs/promises";
 import { runCLI, expectCLIExit, expectCLIFailure } from "./fixtures/run-cli.js";
+import { useIngestWorkspaces } from "./fixtures/ingest-workspace.js";
 
-const tempDirs: string[] = [];
-
-afterEach(async () => {
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) await rm(dir, { recursive: true, force: true });
-  }
-});
-
-/** Create a temp workspace and write a fixture file with the given name. */
-async function makeWorkspace(fixtureName: string, content: string): Promise<{
-  cwd: string;
-  fixturePath: string;
-}> {
-  const cwd = await mkdtemp(path.join(tmpdir(), "llmwiki-unicode-ingest-"));
-  tempDirs.push(cwd);
-  const fixturePath = path.join(cwd, fixtureName);
-  await writeFile(fixturePath, content, "utf-8");
-  return { cwd, fixturePath };
-}
+const workspaces = useIngestWorkspaces("unicode-ingest");
+const makeWorkspace = workspaces.makeWorkspace;
 
 /**
  * Run a single non-ASCII ingest and assert the output filename in


### PR DESCRIPTION
Closes #36.

## The bug

`saveSource` built the destination filename purely from the slugified title, so two distinct sources sharing a basename collided silently:

\`\`\`
sources/notes.md  ← a/notes.md (overwritten)
sources/notes.md  ← b/notes.md (kept)
\`\`\`

The CLI exited 0 in both cases, so the loss was completely invisible.

## The fix

When the candidate destination already exists and its frontmatter \`source\` field does not match the incoming source, append a short SHA-256 hash of the source identifier to the filename:

\`\`\`
sources/notes.md          ← a/notes.md
sources/notes-3a8f9c2d.md ← b/notes.md
\`\`\`

Re-ingesting the same source still overwrites the same file because the source-field check matches — the common case stays clean and no duplicates accumulate.

## Test plan

- [x] CLI integration: two distinct sources sharing a basename produce two distinct files; both contents preserved
- [x] CLI integration: re-ingesting the same source three times leaves exactly one file (idempotent)
- [x] CLI integration: hash is stable across runs (same source → same suffix)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` succeeds
- [x] \`npm test\` — 535 pass / 3 skipped, no regressions
- [x] \`npx fallow\` — 0 issues above threshold

## Composes cleanly with #44 (slugify Unicode fix)

Both PRs touch \`saveSource\`, but at different lines:
- #44 adds an empty-slug guard right after the \`slugify\` call.
- #36 (this PR) adds disambiguation logic for an already-computed slug.

Either order of merge produces a clean rebase.