### PR TITLE
feat: configurable output language for compile and query (#37)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,8 +53,13 @@ program
     "--review",
     "Write generated pages as review candidates under .llmwiki/candidates/ instead of mutating wiki/. Orphan-marking for deleted sources is deferred until the next non-review compile.",
   )
-  .action(async (options: { review?: boolean }) => {
+  .option(
+    "--lang <code>",
+    "Target language for generated wiki content (e.g. \"Chinese\", \"ja\", \"zh-CN\"). Equivalent to setting LLMWIKI_OUTPUT_LANG.",
+  )
+  .action(async (options: { review?: boolean; lang?: string }) => {
     try {
+      applyLanguageOption(options.lang);
       requireProvider();
       await compileCommand({ review: options.review });
     } catch (err) {
@@ -120,15 +125,25 @@ program
   .description("Ask a question against the wiki")
   .option("--save", "Save the answer as a wiki page")
   .option("--debug", "Print which pages and chunks were selected and their scores")
-  .action(async (question: string, options: { save?: boolean; debug?: boolean }) => {
-    try {
-      requireProvider();
-      await queryCommand(process.cwd(), question, options);
-    } catch (err) {
-      console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
-      process.exit(1);
-    }
-  });
+  .option(
+    "--lang <code>",
+    "Target language for the answer (e.g. \"Chinese\", \"ja\", \"zh-CN\"). Equivalent to setting LLMWIKI_OUTPUT_LANG.",
+  )
+  .action(
+    async (
+      question: string,
+      options: { save?: boolean; debug?: boolean; lang?: string },
+    ) => {
+      try {
+        applyLanguageOption(options.lang);
+        requireProvider();
+        await queryCommand(process.cwd(), question, options);
+      } catch (err) {
+        console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
+        process.exit(1);
+      }
+    },
+  );
 
 program
   .command("watch")
@@ -214,6 +229,17 @@ program
       process.exit(1);
     }
   });
+
+/**
+ * Apply the --lang CLI option by setting LLMWIKI_OUTPUT_LANG so prompt
+ * builders pick it up (issue #37). Single env slot keeps the resolution
+ * order simple: explicit flag wins over the inherited environment.
+ */
+function applyLanguageOption(lang: string | undefined): void {
+  if (lang && lang.trim().length > 0) {
+    process.env.LLMWIKI_OUTPUT_LANG = lang.trim();
+  }
+}
 
 /** API key env var required per provider. Null means no key needed. */
 const PROVIDER_KEY_VARS: Record<string, string | null> = {

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -16,6 +16,7 @@ import path from "path";
 import { callClaude } from "../utils/llm.js";
 import type { LLMTool } from "../utils/provider.js";
 import { atomicWrite, safeReadFile, slugify, buildFrontmatter, parseFrontmatter } from "../utils/markdown.js";
+import { languageDirective } from "../utils/output-language.js";
 import { generateIndex } from "../compiler/indexgen.js";
 import * as output from "../utils/output.js";
 import {
@@ -302,11 +303,20 @@ export async function loadSelectedPages(root: string, slugs: string[]): Promise<
   return sections.join("\n\n");
 }
 
-/** Shared system prompt for the answer-generation step. */
-const ANSWER_SYSTEM_PROMPT =
+/** Base system prompt body. The output-language directive is appended at call time. */
+const ANSWER_SYSTEM_PROMPT_BASE =
   "You are a knowledge assistant. Answer the question using ONLY the wiki content provided. " +
   "Cite specific pages using [[Page Title]] wikilinks. " +
   "If the wiki doesn't contain enough information, say so.";
+
+/**
+ * Build the answer-generation system prompt, appending the configured
+ * output-language directive when present (issue #37).
+ */
+function buildAnswerSystemPrompt(): string {
+  const lang = languageDirective();
+  return lang ? `${ANSWER_SYSTEM_PROMPT_BASE} ${lang}` : ANSWER_SYSTEM_PROMPT_BASE;
+}
 
 /**
  * Call the LLM with the loaded wiki pages as grounding context. When chunk
@@ -324,7 +334,7 @@ async function callAnswerLLM(
   const userMessage =
     `Question: ${question}\n\nRelevant wiki pages:\n${pagesContent}${provenance}`;
   return callClaude({
-    system: ANSWER_SYSTEM_PROMPT,
+    system: buildAnswerSystemPrompt(),
     messages: [{ role: "user", content: userMessage }],
     stream: Boolean(onToken),
     onToken,

--- a/src/compiler/prompts.ts
+++ b/src/compiler/prompts.ts
@@ -11,6 +11,18 @@ import type {
   ProvenanceState,
 } from "../utils/types.js";
 import type { PageKindRule, SeedPage } from "../schema/index.js";
+import { languageDirective } from "../utils/output-language.js";
+
+/**
+ * Build a list of optional prompt lines, omitting empty entries so the
+ * default-case prompt is byte-identical to the previous version. Used by
+ * the prompt builders to splice in the output-language directive only
+ * when the user opted in.
+ */
+function withLangLine(...lines: string[]): string[] {
+  const lang = languageDirective();
+  return lang ? [...lines, lang] : lines;
+}
 
 /** Allowed provenance state strings emitted by the LLM tool schema. */
 const PROVENANCE_STATE_VALUES: ProvenanceState[] = [
@@ -106,11 +118,13 @@ export function buildExtractionPrompt(
     : "\n\nNo existing wiki pages yet.";
 
   return [
-    "You are a knowledge extraction engine. Analyze the following source document",
-    "and identify 3-8 distinct, meaningful concepts worth documenting as wiki pages.",
-    "Each concept should be a standalone topic that someone might look up.",
-    "Focus on key ideas, techniques, patterns, or entities — not trivial details.",
-    "Use the extract_concepts tool to return your findings.",
+    ...withLangLine(
+      "You are a knowledge extraction engine. Analyze the following source document",
+      "and identify 3-8 distinct, meaningful concepts worth documenting as wiki pages.",
+      "Each concept should be a standalone topic that someone might look up.",
+      "Focus on key ideas, techniques, patterns, or entities — not trivial details.",
+      "Use the extract_concepts tool to return your findings.",
+    ),
     "",
     "For every concept, emit provenance metadata so downstream tools can reason",
     "about reliability:",
@@ -152,11 +166,13 @@ export function buildPagePrompt(
     : "";
 
   return [
-    `You are a wiki author. Write a clear, well-structured markdown page about "${concept}".`,
-    "Draw facts only from the provided source material.",
-    "Include a ## Sources section at the end listing the source document.",
-    "Suggest [[wikilinks]] to related concepts where appropriate.",
-    "Write in a neutral, informative tone. Be concise but thorough.",
+    ...withLangLine(
+      `You are a wiki author. Write a clear, well-structured markdown page about "${concept}".`,
+      "Draw facts only from the provided source material.",
+      "Include a ## Sources section at the end listing the source document.",
+      "Suggest [[wikilinks]] to related concepts where appropriate.",
+      "Write in a neutral, informative tone. Be concise but thorough.",
+    ),
     "",
     "Source attribution: at the end of each prose paragraph, append a citation",
     "marker showing which source file(s) the paragraph drew from.",
@@ -258,12 +274,14 @@ export function buildSeedPagePrompt(
     ? `Include at least ${minLinks} [[wikilinks]] to related pages.`
     : "Use [[wikilinks]] when referencing other pages.";
   return [
-    `You are a wiki author. Write a ${seed.kind} page titled "${seed.title}".`,
-    `Page-kind guidance: ${rule.description}`,
-    `Summary line for context: ${seed.summary}`,
-    "Draw facts only from the related wiki pages provided below.",
-    linkExpectation,
-    "Write in a neutral, informative tone. Be concise but thorough.",
+    ...withLangLine(
+      `You are a wiki author. Write a ${seed.kind} page titled "${seed.title}".`,
+      `Page-kind guidance: ${rule.description}`,
+      `Summary line for context: ${seed.summary}`,
+      "Draw facts only from the related wiki pages provided below.",
+      linkExpectation,
+      "Write in a neutral, informative tone. Be concise but thorough.",
+    ),
     "\n\n--- RELATED PAGES ---\n\n",
     relatedPagesContent,
   ].join("\n");

--- a/src/utils/output-language.ts
+++ b/src/utils/output-language.ts
@@ -1,0 +1,37 @@
+/**
+ * Output-language configuration for LLM-generated wiki content (issue #37).
+ *
+ * Resolves the user's chosen target language for compile and query
+ * prompts. The CLI's `--lang <code>` flag and the `LLMWIKI_OUTPUT_LANG`
+ * environment variable both write into the same env slot, so prompt
+ * builders only need to read one source of truth.
+ *
+ * When unset, the resolver returns null — preserving the historical
+ * behaviour where the LLM follows its own default (typically the
+ * source-document language, often English).
+ */
+
+const LANG_ENV_VAR = "LLMWIKI_OUTPUT_LANG";
+
+/**
+ * Read the configured output language. Returns null when the user has
+ * not opted into a specific target language.
+ */
+export function getOutputLanguage(): string | null {
+  const raw = process.env[LANG_ENV_VAR];
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Build the language-directive line to inject into a system prompt.
+ * Returns an empty string when no language is configured, which lets
+ * callers concatenate unconditionally without producing an extra blank
+ * line in the default case.
+ */
+export function languageDirective(): string {
+  const lang = getOutputLanguage();
+  if (!lang) return "";
+  return `Write the output in ${lang}.`;
+}

--- a/test/output-language-integration.test.ts
+++ b/test/output-language-integration.test.ts
@@ -1,0 +1,107 @@
+/**
+ * CLI integration test for issue #37 — `--lang` and LLMWIKI_OUTPUT_LANG
+ * must thread through to the system prompt the LLM actually receives.
+ *
+ * Uses aimock to capture the request the CLI subprocess sent and asserts
+ * that the configured language directive is present in the system prompt.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  mockClaudeEnv,
+  useAimockLifecycle,
+} from "./fixtures/aimock-helper.js";
+import { runCLI, expectCLIExit } from "./fixtures/run-cli.js";
+
+const aimock = useAimockLifecycle("output-language");
+
+/** Stub the canned compile responses (extraction + page body) on a handle. */
+function stubCannedCompile(handle: import("./fixtures/aimock-helper.js").MockClaudeHandle): void {
+  handle.mock.onToolCall("extract_concepts", {
+    toolCalls: [
+      {
+        name: "extract_concepts",
+        arguments: {
+          concepts: [
+            {
+              concept: "Lang Concept",
+              summary: "Concept emitted by aimock for the lang test.",
+              is_new: true,
+              tags: ["lang-test"],
+              confidence: 0.9,
+            },
+          ],
+        },
+      },
+    ],
+  });
+  handle.mock.onMessage(/.*/, { content: "Page body produced for the lang test." });
+}
+
+/**
+ * Concatenate every system prompt aimock saw across all recorded
+ * requests. aimock normalises Anthropic's top-level `system` field into
+ * a `{role: "system", content: ...}` message in `body.messages`, so we
+ * walk the messages array (not body.system) to find them.
+ */
+function collectSystemPrompts(
+  handle: import("./fixtures/aimock-helper.js").MockClaudeHandle,
+): string {
+  const requests = handle.mock.getRequests() as Array<{ body?: unknown }>;
+  const collected: string[] = [];
+  for (const req of requests) {
+    const body = req.body as { messages?: unknown } | undefined;
+    if (!Array.isArray(body?.messages)) continue;
+    for (const msg of body.messages as Array<{ role?: unknown; content?: unknown }>) {
+      if (msg.role === "system" && typeof msg.content === "string") {
+        collected.push(msg.content);
+      }
+    }
+  }
+  return collected.join("\n---REQUEST-BOUNDARY---\n");
+}
+
+describe("output-language CLI integration (#37)", () => {
+  it("compile --lang Spanish injects the directive into the system prompt", async () => {
+    const handle = await aimock.start();
+    stubCannedCompile(handle);
+
+    const cwd = await aimock.makeWorkspace("# Source\n\nA short source for the lang test.\n");
+    const result = await runCLI(
+      ["compile", "--review", "--lang", "Spanish"],
+      cwd,
+      mockClaudeEnv(handle),
+    );
+    expectCLIExit(result, 0);
+
+    const allSystemPrompts = collectSystemPrompts(handle);
+    expect(allSystemPrompts).toContain("Write the output in Spanish.");
+  }, 30_000);
+
+  it("LLMWIKI_OUTPUT_LANG env var has the same effect as --lang", async () => {
+    const handle = await aimock.start();
+    stubCannedCompile(handle);
+
+    const cwd = await aimock.makeWorkspace("# Source\n\nAnother short source.\n");
+    const result = await runCLI(["compile", "--review"], cwd, {
+      ...mockClaudeEnv(handle),
+      LLMWIKI_OUTPUT_LANG: "Japanese",
+    });
+    expectCLIExit(result, 0);
+
+    const allSystemPrompts = collectSystemPrompts(handle);
+    expect(allSystemPrompts).toContain("Write the output in Japanese.");
+  }, 30_000);
+
+  it("compile without --lang leaves the directive out of the system prompt", async () => {
+    const handle = await aimock.start();
+    stubCannedCompile(handle);
+
+    const cwd = await aimock.makeWorkspace("# Source\n\nA third short source.\n");
+    const result = await runCLI(["compile", "--review"], cwd, mockClaudeEnv(handle));
+    expectCLIExit(result, 0);
+
+    const allSystemPrompts = collectSystemPrompts(handle);
+    expect(allSystemPrompts).not.toContain("Write the output in");
+  }, 30_000);
+});

--- a/test/output-language-query-integration.test.ts
+++ b/test/output-language-query-integration.test.ts
@@ -1,0 +1,125 @@
+/**
+ * CLI integration test for #37 query path.
+ *
+ * Companion to test/output-language-integration.test.ts which only
+ * exercises compile. Codex flagged that query --lang and the answer
+ * system prompt path lacked subprocess coverage. This test stages a
+ * minimal wiki, stubs both the page-selection tool call and the answer
+ * generation, runs `query --lang Spanish` via the CLI subprocess, and
+ * asserts the directive lands in the system prompt aimock observed for
+ * the answer call.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+import {
+  mockClaudeEnv,
+  useAimockLifecycle,
+  type MockClaudeHandle,
+} from "./fixtures/aimock-helper.js";
+import { runCLI, expectCLIExit } from "./fixtures/run-cli.js";
+
+const aimock = useAimockLifecycle("output-language-query");
+
+const PAGE_SLUG = "lang-test-page";
+const PAGE_TITLE = "Lang Test Page";
+const ANSWER_TEXT = "Stubbed answer body for the lang test.";
+
+/** Stage a workspace with a wiki/index.md and one concept page. */
+async function makeQueryWorkspace(): Promise<string> {
+  const cwd = await aimock.makeWorkspace("# placeholder\n", "placeholder.md");
+  const conceptsDir = path.join(cwd, "wiki", "concepts");
+  await mkdir(conceptsDir, { recursive: true });
+  await writeFile(
+    path.join(conceptsDir, `${PAGE_SLUG}.md`),
+    "---\n" +
+      `title: "${PAGE_TITLE}"\n` +
+      'summary: "Page used by the query --lang integration test."\n' +
+      "sources: []\n" +
+      "---\n\n" +
+      "Body content for the lang test page.\n",
+    "utf-8",
+  );
+  await mkdir(path.join(cwd, "wiki"), { recursive: true });
+  await writeFile(
+    path.join(cwd, "wiki", "index.md"),
+    `# Wiki\n\n- **${PAGE_SLUG}**: ${PAGE_TITLE} — Page used by the query --lang integration test.\n`,
+    "utf-8",
+  );
+  return cwd;
+}
+
+/** Stub the two LLM calls query makes: page selection, then answer generation. */
+function stubQueryResponses(handle: MockClaudeHandle): void {
+  handle.mock.onToolCall("select_pages", {
+    toolCalls: [
+      {
+        name: "select_pages",
+        arguments: {
+          pages: [PAGE_SLUG],
+          reasoning: "Stubbed selection for the lang test.",
+        },
+      },
+    ],
+  });
+  handle.mock.onMessage(/.*/, { content: ANSWER_TEXT });
+}
+
+/** Pull the system prompt for the answer-generation request out of aimock's recording. */
+function findAnswerSystemPrompt(handle: MockClaudeHandle): string | null {
+  const requests = handle.mock.getRequests() as Array<{ body?: unknown }>;
+  for (const req of requests) {
+    const body = req.body as { messages?: unknown } | undefined;
+    if (!Array.isArray(body?.messages)) continue;
+    let systemPrompt = "";
+    let userPrompt = "";
+    for (const msg of body.messages as Array<{ role?: unknown; content?: unknown }>) {
+      if (msg.role === "system" && typeof msg.content === "string") systemPrompt = msg.content;
+      if (msg.role === "user" && typeof msg.content === "string") userPrompt = msg.content;
+    }
+    // The answer-generation request includes "Relevant wiki pages:" in the user
+    // message; the page-selection request includes "Wiki Index:" instead.
+    if (userPrompt.includes("Relevant wiki pages:")) {
+      return systemPrompt;
+    }
+  }
+  return null;
+}
+
+describe("query --lang CLI integration (#37 query path)", () => {
+  it("query --lang Spanish injects the directive into the answer system prompt", async () => {
+    const handle = await aimock.start();
+    stubQueryResponses(handle);
+    const cwd = await makeQueryWorkspace();
+
+    const result = await runCLI(
+      ["query", "--lang", "Spanish", "What is the lang test?"],
+      cwd,
+      mockClaudeEnv(handle),
+    );
+    expectCLIExit(result, 0);
+    expect(result.stdout).toContain(ANSWER_TEXT);
+
+    const answerPrompt = findAnswerSystemPrompt(handle);
+    expect(answerPrompt, "answer system prompt should be recorded").not.toBeNull();
+    expect(answerPrompt).toContain("Write the output in Spanish.");
+  }, 30_000);
+
+  it("query without --lang leaves the answer system prompt unchanged", async () => {
+    const handle = await aimock.start();
+    stubQueryResponses(handle);
+    const cwd = await makeQueryWorkspace();
+
+    const result = await runCLI(
+      ["query", "What is the lang test?"],
+      cwd,
+      mockClaudeEnv(handle),
+    );
+    expectCLIExit(result, 0);
+
+    const answerPrompt = findAnswerSystemPrompt(handle);
+    expect(answerPrompt).not.toBeNull();
+    expect(answerPrompt).not.toContain("Write the output in");
+  }, 30_000);
+});

--- a/test/output-language.test.ts
+++ b/test/output-language.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for the output-language resolver and its impact on the
+ * prompt builders (issue #37).
+ *
+ * Default behaviour (no env, no flag) must produce prompts byte-identical
+ * to the previous implementation. When `LLMWIKI_OUTPUT_LANG` is set, the
+ * directive must appear in every system prompt the compile and seed
+ * pipelines emit.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  getOutputLanguage,
+  languageDirective,
+} from "../src/utils/output-language.js";
+import {
+  buildExtractionPrompt,
+  buildPagePrompt,
+  buildSeedPagePrompt,
+} from "../src/compiler/prompts.js";
+import type { PageKindRule, SeedPage } from "../src/schema/index.js";
+
+const ENV_KEY = "LLMWIKI_OUTPUT_LANG";
+
+afterEach(() => {
+  delete process.env[ENV_KEY];
+});
+
+describe("getOutputLanguage", () => {
+  it("returns null when env var is unset", () => {
+    expect(getOutputLanguage()).toBeNull();
+  });
+
+  it("returns null when env var is empty or whitespace", () => {
+    process.env[ENV_KEY] = "   ";
+    expect(getOutputLanguage()).toBeNull();
+  });
+
+  it("returns the trimmed value when set", () => {
+    process.env[ENV_KEY] = "  zh-CN  ";
+    expect(getOutputLanguage()).toBe("zh-CN");
+  });
+});
+
+describe("languageDirective", () => {
+  it("returns an empty string when no language is configured", () => {
+    expect(languageDirective()).toBe("");
+  });
+
+  it("returns 'Write the output in <lang>.' when configured", () => {
+    process.env[ENV_KEY] = "Chinese";
+    expect(languageDirective()).toBe("Write the output in Chinese.");
+  });
+});
+
+describe("prompt builders honour LLMWIKI_OUTPUT_LANG (#37)", () => {
+  it("buildExtractionPrompt omits the directive by default", () => {
+    const out = buildExtractionPrompt("source", "");
+    expect(out).not.toContain("Write the output in");
+  });
+
+  it("buildExtractionPrompt includes the directive when set", () => {
+    process.env[ENV_KEY] = "Spanish";
+    const out = buildExtractionPrompt("source", "");
+    expect(out).toContain("Write the output in Spanish.");
+  });
+
+  it("buildPagePrompt omits the directive by default", () => {
+    const out = buildPagePrompt("Concept", "src", "", "");
+    expect(out).not.toContain("Write the output in");
+  });
+
+  it("buildPagePrompt includes the directive when set", () => {
+    process.env[ENV_KEY] = "Japanese";
+    const out = buildPagePrompt("Concept", "src", "", "");
+    expect(out).toContain("Write the output in Japanese.");
+  });
+
+  it("buildSeedPagePrompt omits the directive by default", () => {
+    const seed: SeedPage = {
+      title: "Overview",
+      kind: "overview",
+      summary: "test",
+      relatedSlugs: [],
+    };
+    const rule: PageKindRule = {
+      description: "an overview page",
+      minWikilinks: 0,
+    };
+    const out = buildSeedPagePrompt(seed, rule, "related");
+    expect(out).not.toContain("Write the output in");
+  });
+
+  it("buildSeedPagePrompt includes the directive when set", () => {
+    process.env[ENV_KEY] = "Cantonese";
+    const seed: SeedPage = {
+      title: "Overview",
+      kind: "overview",
+      summary: "test",
+      relatedSlugs: [],
+    };
+    const rule: PageKindRule = {
+      description: "an overview page",
+      minWikilinks: 0,
+    };
+    const out = buildSeedPagePrompt(seed, rule, "related");
+    expect(out).toContain("Write the output in Cantonese.");
+  });
+});


### PR DESCRIPTION
Closes #37.

## What

Adds a way to make `llmwiki compile` and `llmwiki query` write their generated content in a language other than English.

\`\`\`bash
# CLI flag
llmwiki compile --lang Chinese
llmwiki query \"What is X?\" --lang Japanese

# Or via env var (equivalent)
export LLMWIKI_OUTPUT_LANG=zh-CN
llmwiki compile
\`\`\`

When set, every prompt builder (extraction, page generation, seed page generation, and query answer) appends \`Write the output in <lang>.\` to the system prompt. When unset, the prompts are byte-identical to the previous version — no behaviour change for existing users.

## Why this design

- **Single source of truth.** The CLI flag writes into \`LLMWIKI_OUTPUT_LANG\`, so prompt builders only need to read one place. Keeps the wiring simple.
- **No signature churn.** Threading the lang through compile→callers would have meant changes across many call sites. A tiny env-backed resolver in \`src/utils/output-language.ts\` lets each builder look it up locally.
- **Default-case identical.** Builders use a \`withLangLine()\` helper that splices in the directive only when set, so unconfigured prompts are character-for-character what they were before.

## Test plan

- [x] Unit: \`getOutputLanguage()\` and \`languageDirective()\` resolve null/empty/trimmed values correctly.
- [x] Unit: each of the three prompt builders includes the directive when set and omits it when unset.
- [x] aimock CLI integration: \`compile --lang Spanish\` and \`LLMWIKI_OUTPUT_LANG=Japanese compile\` both result in \`Write the output in <lang>.\` appearing in the system prompt aimock observed; unconfigured runs do not.
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` succeeds
- [x] \`npm test\` — 546 pass / 3 skipped (smoke)
- [x] \`npx fallow\` — 0 issues above threshold