### PR TITLE
fix(compiler): bound per-concept prompt size to prevent blowup (#39)

### DIFF
--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -44,6 +44,7 @@ import {
 import { markOrphaned, orphanUnownedFrozenPages } from "./orphan.js";
 import { resolveLinks } from "./resolver.js";
 import { generateIndex } from "./indexgen.js";
+import { buildBudgetedCombinedContent, type SourceSlice } from "./prompt-budget.js";
 import { addObsidianMeta, generateMOC } from "./obsidian.js";
 import { updateEmbeddings } from "../utils/embeddings.js";
 import { writeCandidate } from "./candidates.js";
@@ -462,12 +463,19 @@ export function reconcileConceptMetadata(
  * contributing material rather than just the last source processed.
  * Metadata is reconciled across all contributing concepts via
  * reconcileConceptMetadata so contradictions from later sources are not lost.
+ *
+ * Combined content is then run through {@link buildBudgetedCombinedContent}
+ * so popular concepts that appear in many overlapping sources do not blow
+ * past the LLM provider's context window (issue #39). When the raw total
+ * fits the budget, the output is byte-identical to the previous unbudgeted
+ * concatenation.
  */
 function mergeExtractions(
   extractions: ExtractionResult[],
   frozenSlugs: Set<string>,
 ): MergedConcept[] {
   const bySlug = new Map<string, MergedConcept>();
+  const slicesBySlug = new Map<string, SourceSlice[]>();
 
   for (const result of extractions) {
     if (result.concepts.length === 0) continue;
@@ -480,16 +488,28 @@ function mergeExtractions(
       if (existing) {
         existing.concept = reconcileConceptMetadata(existing.concept, concept);
         existing.sourceFiles.push(result.sourceFile);
-        existing.combinedContent += `\n\n--- SOURCE: ${result.sourceFile} ---\n\n${result.sourceContent}`;
       } else {
         bySlug.set(slug, {
           slug,
           concept,
           sourceFiles: [result.sourceFile],
-          combinedContent: `--- SOURCE: ${result.sourceFile} ---\n\n${result.sourceContent}`,
+          combinedContent: "",
         });
+        slicesBySlug.set(slug, []);
       }
+      slicesBySlug.get(slug)!.push({
+        file: result.sourceFile,
+        content: result.sourceContent,
+      });
     }
+  }
+
+  for (const merged of bySlug.values()) {
+    const slices = slicesBySlug.get(merged.slug) ?? [];
+    merged.combinedContent = buildBudgetedCombinedContent(
+      merged.concept.concept,
+      slices,
+    );
   }
 
   return Array.from(bySlug.values());

--- a/src/compiler/prompt-budget.ts
+++ b/src/compiler/prompt-budget.ts
@@ -1,0 +1,105 @@
+/**
+ * Per-concept prompt-budget enforcement (issue #39).
+ *
+ * When the same concept is extracted from many overlapping sources, the
+ * page-generation prompt would otherwise concatenate every full source
+ * — linear in source count — and reliably blow past the LLM provider's
+ * context window. This module clips each contributing source's slice to
+ * a fair share of a configurable total budget and emits a single warning
+ * when truncation kicks in.
+ *
+ * The fix is deliberately defensive (proportional truncation) rather than
+ * smart (semantic ranking / summarisation). It prevents crashes while a
+ * deeper retrieval-driven solution is designed.
+ */
+
+import * as output from "../utils/output.js";
+import {
+  DEFAULT_PROMPT_BUDGET_CHARS,
+  PROMPT_BUDGET_ENV_VAR,
+} from "../utils/constants.js";
+
+/** Marker appended to a source slice when it was truncated to fit the budget. */
+const TRUNCATION_MARKER = "\n\n[…truncated for prompt budget — see #39…]";
+
+/** A single source's contribution to the combined per-concept content. */
+export interface SourceSlice {
+  /** Source filename (e.g. "ml-paper.md") shown as a section header in the prompt. */
+  file: string;
+  /** Raw extracted source content, before any budgeting. */
+  content: string;
+}
+
+/**
+ * Resolve the active prompt-budget character cap. Reads the
+ * `LLMWIKI_PROMPT_BUDGET_CHARS` env var when present and parseable; falls
+ * back to `DEFAULT_PROMPT_BUDGET_CHARS`. Invalid values (non-numeric or
+ * <= 0) are ignored so a typo can't accidentally truncate every prompt
+ * to nothing.
+ */
+export function resolvePromptBudgetChars(): number {
+  const raw = process.env[PROMPT_BUDGET_ENV_VAR];
+  if (!raw) return DEFAULT_PROMPT_BUDGET_CHARS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_PROMPT_BUDGET_CHARS;
+  return parsed;
+}
+
+/**
+ * Combine per-source slices into the single content blob the LLM prompt
+ * receives, applying a fair-share budget when the raw total would exceed
+ * the configured ceiling. When no truncation is needed the output is
+ * byte-identical to the previous unbudgeted concatenation, so existing
+ * compile output is unchanged for typical workloads.
+ *
+ * @param concept - Human-readable concept title (used in the warning only).
+ * @param slices - One entry per contributing source, in arrival order.
+ * @returns The combined content string suitable for buildPagePrompt.
+ */
+export function buildBudgetedCombinedContent(
+  concept: string,
+  slices: SourceSlice[],
+): string {
+  const budget = resolvePromptBudgetChars();
+  const totalRaw = slices.reduce((sum, s) => sum + s.content.length, 0);
+
+  if (totalRaw <= budget) {
+    return formatSlices(slices);
+  }
+
+  const perSource = Math.max(1, Math.floor(budget / slices.length));
+  warnTruncation(concept, totalRaw, slices.length, perSource, budget);
+
+  const trimmed = slices.map((s) =>
+    s.content.length > perSource
+      ? { ...s, content: s.content.slice(0, perSource) + TRUNCATION_MARKER }
+      : s,
+  );
+  return formatSlices(trimmed);
+}
+
+/** Render the slice list using the same `--- SOURCE: ---` headers the LLM is taught to read. */
+function formatSlices(slices: SourceSlice[]): string {
+  return slices
+    .map((s) => `--- SOURCE: ${s.file} ---\n\n${s.content}`)
+    .join("\n\n");
+}
+
+/** Emit a single, actionable warning when the budget kicks in for a concept. */
+function warnTruncation(
+  concept: string,
+  totalRaw: number,
+  sourceCount: number,
+  perSource: number,
+  budget: number,
+): void {
+  output.status(
+    "!",
+    output.warn(
+      `Combined source content for "${concept}" (${totalRaw.toLocaleString()} chars across ` +
+        `${sourceCount} sources) exceeds the ${budget.toLocaleString()}-char prompt budget; ` +
+        `truncating each source to ~${perSource.toLocaleString()} chars. ` +
+        `Raise via ${PROMPT_BUDGET_ENV_VAR} when running against larger-context models.`,
+    ),
+  );
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -9,6 +9,25 @@ export const MAX_SOURCE_CHARS = 100_000;
 /** Minimum source content length to ingest without a warning. */
 export const MIN_SOURCE_CHARS = 50;
 
+/**
+ * Default character budget for the combined source content sent to the LLM
+ * during page generation for a single concept (issue #39).
+ *
+ * Caps the per-prompt content at ~200,000 chars (~50k tokens). When two or
+ * more sources contribute to the same concept and their combined raw size
+ * exceeds this budget, each source's slice is proportionally truncated so
+ * the prompt fits the model's context window. Without this cap, popular
+ * concepts that appear in many overlapping documents reliably blow past
+ * the LLM provider's context limit and the compile crashes.
+ *
+ * Override via the LLMWIKI_PROMPT_BUDGET_CHARS env var when running against
+ * larger-context (raise) or smaller-context (lower) models.
+ */
+export const DEFAULT_PROMPT_BUDGET_CHARS = 200_000;
+
+/** Env var that overrides DEFAULT_PROMPT_BUDGET_CHARS at runtime. */
+export const PROMPT_BUDGET_ENV_VAR = "LLMWIKI_PROMPT_BUDGET_CHARS";
+
 /** Number of most relevant wiki pages to load for query context. */
 export const QUERY_PAGE_LIMIT = 5;
 

--- a/test/fixtures/aimock-helper.ts
+++ b/test/fixtures/aimock-helper.ts
@@ -95,6 +95,37 @@ export function mockOpenAIEnv(
   };
 }
 
+/**
+ * Walk aimock's recorded requests and return the system-prompt content
+ * from the first request whose user-message content satisfies the
+ * predicate. Returns null when no matching request is found.
+ *
+ * Centralised because every aimock-backed CLI test that wants to assert
+ * "the LLM saw <X> in the system prompt" has to slice the same way:
+ * aimock normalises Anthropic's top-level `system` field into a
+ * `{role: "system", content: ...}` message in `body.messages`, so the
+ * walker has to inspect both system and user messages per request and
+ * disambiguate by user-message content.
+ */
+export function findSystemPromptByUserMessage(
+  handle: MockClaudeHandle,
+  predicate: (userMessage: string) => boolean,
+): string | null {
+  const requests = handle.mock.getRequests() as Array<{ body?: unknown }>;
+  for (const req of requests) {
+    const body = req.body as { messages?: unknown } | undefined;
+    if (!Array.isArray(body?.messages)) continue;
+    let systemPrompt = "";
+    let userPrompt = "";
+    for (const msg of body.messages as Array<{ role?: unknown; content?: unknown }>) {
+      if (msg.role === "system" && typeof msg.content === "string") systemPrompt = msg.content;
+      if (msg.role === "user" && typeof msg.content === "string") userPrompt = msg.content;
+    }
+    if (predicate(userPrompt)) return systemPrompt;
+  }
+  return null;
+}
+
 /** Live state managed by {@link useAimockLifecycle}. */
 export interface AimockLifecycle {
   /** Currently-running mock, or null between tests. Set by `start()`. */

--- a/test/output-language-query-integration.test.ts
+++ b/test/output-language-query-integration.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect } from "vitest";
 import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 import {
+  findSystemPromptByUserMessage,
   mockClaudeEnv,
   useAimockLifecycle,
   type MockClaudeHandle,
@@ -66,25 +67,14 @@ function stubQueryResponses(handle: MockClaudeHandle): void {
   handle.mock.onMessage(/.*/, { content: ANSWER_TEXT });
 }
 
-/** Pull the system prompt for the answer-generation request out of aimock's recording. */
+/**
+ * Pull the system prompt for the answer-generation request out of aimock's
+ * recording. The answer-generation request includes "Relevant wiki pages:"
+ * in the user message; the page-selection request includes "Wiki Index:"
+ * instead, so the predicate disambiguates the two.
+ */
 function findAnswerSystemPrompt(handle: MockClaudeHandle): string | null {
-  const requests = handle.mock.getRequests() as Array<{ body?: unknown }>;
-  for (const req of requests) {
-    const body = req.body as { messages?: unknown } | undefined;
-    if (!Array.isArray(body?.messages)) continue;
-    let systemPrompt = "";
-    let userPrompt = "";
-    for (const msg of body.messages as Array<{ role?: unknown; content?: unknown }>) {
-      if (msg.role === "system" && typeof msg.content === "string") systemPrompt = msg.content;
-      if (msg.role === "user" && typeof msg.content === "string") userPrompt = msg.content;
-    }
-    // The answer-generation request includes "Relevant wiki pages:" in the user
-    // message; the page-selection request includes "Wiki Index:" instead.
-    if (userPrompt.includes("Relevant wiki pages:")) {
-      return systemPrompt;
-    }
-  }
-  return null;
+  return findSystemPromptByUserMessage(handle, (u) => u.includes("Relevant wiki pages:"));
 }
 
 describe("query --lang CLI integration (#37 query path)", () => {

--- a/test/prompt-blowup-integration.test.ts
+++ b/test/prompt-blowup-integration.test.ts
@@ -20,6 +20,7 @@ import { describe, it, expect } from "vitest";
 import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 import {
+  findSystemPromptByUserMessage,
   mockClaudeEnv,
   useAimockLifecycle,
   type MockClaudeHandle,
@@ -76,26 +77,16 @@ async function makeMultiSourceWorkspace(): Promise<string> {
   return cwd;
 }
 
-/** Pull the single page-generation system prompt out of aimock's recording. */
+/**
+ * Pull the single page-generation system prompt out of aimock's recording.
+ * The page-generation request is the one whose user message asks for a
+ * wiki page for our shared concept (the extraction request asks to
+ * "Extract the key concepts" instead), so the predicate disambiguates.
+ */
 function findPageGenerationSystemPrompt(handle: MockClaudeHandle): string | null {
-  const requests = handle.mock.getRequests() as Array<{ body?: unknown }>;
-  for (const req of requests) {
-    const body = req.body as { messages?: unknown } | undefined;
-    if (!Array.isArray(body?.messages)) continue;
-    let systemPrompt = "";
-    let userPrompt = "";
-    for (const msg of body.messages as Array<{ role?: unknown; content?: unknown }>) {
-      if (msg.role === "system" && typeof msg.content === "string") systemPrompt = msg.content;
-      if (msg.role === "user" && typeof msg.content === "string") userPrompt = msg.content;
-    }
-    // The page-generation request is the one whose user message asks for a
-    // wiki page for our shared concept (the extraction request asks to
-    // "Extract the key concepts" instead).
-    if (userPrompt.includes(`Write the wiki page for "${SHARED_CONCEPT}"`)) {
-      return systemPrompt;
-    }
-  }
-  return null;
+  return findSystemPromptByUserMessage(handle, (u) =>
+    u.includes(`Write the wiki page for "${SHARED_CONCEPT}"`),
+  );
 }
 
 /**

--- a/test/prompt-blowup-integration.test.ts
+++ b/test/prompt-blowup-integration.test.ts
@@ -1,0 +1,162 @@
+/**
+ * CLI integration test for issue #39 — prompt-blowup defence.
+ *
+ * Stages a workspace with five source documents that all extract the same
+ * shared concept, sets a very tight prompt budget, runs `compile --review`
+ * via the CLI subprocess, and asserts:
+ *
+ *   1. compile exits 0 (does NOT crash with a context-length error path).
+ *   2. The system prompt aimock observed for the page-generation call is
+ *      bounded — does not contain the full raw concatenation of every
+ *      source.
+ *   3. The truncation marker appears, proving the budget actually ran.
+ *
+ * Without the fix in src/compiler/prompt-budget.ts, the page-generation
+ * prompt would include all five sources at full size (~1MB+) regardless
+ * of the budget setting.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+import {
+  mockClaudeEnv,
+  useAimockLifecycle,
+  type MockClaudeHandle,
+} from "./fixtures/aimock-helper.js";
+import { runCLI, expectCLIExit } from "./fixtures/run-cli.js";
+
+const aimock = useAimockLifecycle("prompt-blowup");
+
+const SHARED_CONCEPT = "Shared Topic";
+const SHARED_CONCEPT_SLUG = "shared-topic";
+const SOURCE_COUNT = 5;
+const SOURCE_CHARS = 4_000;
+const TIGHT_BUDGET = "5000";
+
+/**
+ * Stub the extraction call so every source returns the same shared concept,
+ * forcing all five into the merge bucket for SHARED_CONCEPT.
+ */
+function stubSharedConceptExtraction(handle: MockClaudeHandle): void {
+  handle.mock.onToolCall("extract_concepts", {
+    toolCalls: [
+      {
+        name: "extract_concepts",
+        arguments: {
+          concepts: [
+            {
+              concept: SHARED_CONCEPT,
+              summary: "A topic that every source touches.",
+              is_new: true,
+              tags: ["shared"],
+              confidence: 0.9,
+            },
+          ],
+        },
+      },
+    ],
+  });
+  handle.mock.onMessage(/.*/, { content: "Shared topic page body." });
+}
+
+/** Create a workspace populated with N distinct sources, each ~SOURCE_CHARS long. */
+async function makeMultiSourceWorkspace(): Promise<string> {
+  const cwd = await aimock.makeWorkspace("# placeholder\n", "placeholder.md");
+  const sourcesDir = path.join(cwd, "sources");
+  await mkdir(sourcesDir, { recursive: true });
+  for (let i = 0; i < SOURCE_COUNT; i++) {
+    const filler = `paragraph-${i} `.repeat(Math.ceil(SOURCE_CHARS / 12)).slice(0, SOURCE_CHARS);
+    await writeFile(
+      path.join(sourcesDir, `source-${i}.md`),
+      `# Source ${i}\n\n${filler}\n`,
+      "utf-8",
+    );
+  }
+  return cwd;
+}
+
+/** Pull the single page-generation system prompt out of aimock's recording. */
+function findPageGenerationSystemPrompt(handle: MockClaudeHandle): string | null {
+  const requests = handle.mock.getRequests() as Array<{ body?: unknown }>;
+  for (const req of requests) {
+    const body = req.body as { messages?: unknown } | undefined;
+    if (!Array.isArray(body?.messages)) continue;
+    let systemPrompt = "";
+    let userPrompt = "";
+    for (const msg of body.messages as Array<{ role?: unknown; content?: unknown }>) {
+      if (msg.role === "system" && typeof msg.content === "string") systemPrompt = msg.content;
+      if (msg.role === "user" && typeof msg.content === "string") userPrompt = msg.content;
+    }
+    // The page-generation request is the one whose user message asks for a
+    // wiki page for our shared concept (the extraction request asks to
+    // "Extract the key concepts" instead).
+    if (userPrompt.includes(`Write the wiki page for "${SHARED_CONCEPT}"`)) {
+      return systemPrompt;
+    }
+  }
+  return null;
+}
+
+describe("prompt blowup defence (#39)", () => {
+  it("compile bounds the page prompt and emits the truncation marker", async () => {
+    const handle = await aimock.start();
+    stubSharedConceptExtraction(handle);
+
+    const cwd = await makeMultiSourceWorkspace();
+    const result = await runCLI(["compile", "--review"], cwd, {
+      ...mockClaudeEnv(handle),
+      LLMWIKI_PROMPT_BUDGET_CHARS: TIGHT_BUDGET,
+    });
+    expectCLIExit(result, 0);
+
+    const systemPrompt = findPageGenerationSystemPrompt(handle);
+    expect(systemPrompt, "page-generation system prompt should be recorded").not.toBeNull();
+
+    // Bounded: well under the unbudgeted total (5 × 4,000 = 20,000 chars of source
+    // content alone, plus prompt boilerplate). With a 5,000-char budget we expect
+    // the source-content portion to land near 5k; the whole prompt stays well under
+    // the unbudgeted ~20k+ blowup.
+    expect(systemPrompt!.length).toBeLessThan(15_000);
+
+    // The truncation marker must be present — proves budgeting ran.
+    expect(systemPrompt).toContain("truncated for prompt budget");
+
+    // All five source headers are still represented (fair-share, not first-N-only).
+    for (let i = 0; i < SOURCE_COUNT; i++) {
+      expect(systemPrompt).toContain(`--- SOURCE: source-${i}.md ---`);
+    }
+
+    // Sanity: page-generation also emitted a warning to stdout/stderr.
+    const stdio = result.stdout + result.stderr;
+    expect(stdio).toMatch(new RegExp(`Combined source content for "${SHARED_CONCEPT}"`));
+  }, 60_000);
+
+  it("compile without an explicit budget keeps the prompt unbudgeted (no truncation marker)", async () => {
+    const handle = await aimock.start();
+    stubSharedConceptExtraction(handle);
+
+    const cwd = await makeMultiSourceWorkspace();
+    const result = await runCLI(["compile", "--review"], cwd, mockClaudeEnv(handle));
+    expectCLIExit(result, 0);
+
+    const systemPrompt = findPageGenerationSystemPrompt(handle);
+    expect(systemPrompt).not.toBeNull();
+    // 5 × 4,000 = 20,000 raw source chars — well under the 200,000-char default
+    // budget, so the prompt should NOT carry the truncation marker.
+    expect(systemPrompt).not.toContain("truncated for prompt budget");
+  }, 60_000);
+
+  // The shared-concept slug should land under the configured concept directory.
+  it("compile produces exactly one merged candidate for the shared concept", async () => {
+    const handle = await aimock.start();
+    stubSharedConceptExtraction(handle);
+    const cwd = await makeMultiSourceWorkspace();
+    const result = await runCLI(["compile", "--review"], cwd, {
+      ...mockClaudeEnv(handle),
+      LLMWIKI_PROMPT_BUDGET_CHARS: TIGHT_BUDGET,
+    });
+    expectCLIExit(result, 0);
+    expect(result.stdout).toContain(SHARED_CONCEPT_SLUG);
+  }, 60_000);
+});

--- a/test/prompt-blowup-integration.test.ts
+++ b/test/prompt-blowup-integration.test.ts
@@ -98,28 +98,43 @@ function findPageGenerationSystemPrompt(handle: MockClaudeHandle): string | null
   return null;
 }
 
+/**
+ * Stage the multi-source workspace and run a single `compile --review`
+ * subprocess against the shared-concept extraction stub. Centralised so
+ * each test reads as the assertion that distinguishes it (budget set vs
+ * not) rather than the boilerplate they share.
+ */
+async function runSharedConceptCompile(
+  envOverrides: NodeJS.ProcessEnv,
+): Promise<{
+  result: import("./fixtures/run-cli.js").CLIResult;
+  systemPrompt: string;
+  handle: MockClaudeHandle;
+}> {
+  const handle = await aimock.start();
+  stubSharedConceptExtraction(handle);
+  const cwd = await makeMultiSourceWorkspace();
+  const result = await runCLI(["compile", "--review"], cwd, {
+    ...mockClaudeEnv(handle),
+    ...envOverrides,
+  });
+  expectCLIExit(result, 0);
+  const systemPrompt = findPageGenerationSystemPrompt(handle);
+  expect(systemPrompt, "page-generation system prompt should be recorded").not.toBeNull();
+  return { result, systemPrompt: systemPrompt!, handle };
+}
+
 describe("prompt blowup defence (#39)", () => {
   it("compile bounds the page prompt and emits the truncation marker", async () => {
-    const handle = await aimock.start();
-    stubSharedConceptExtraction(handle);
-
-    const cwd = await makeMultiSourceWorkspace();
-    const result = await runCLI(["compile", "--review"], cwd, {
-      ...mockClaudeEnv(handle),
+    const { result, systemPrompt } = await runSharedConceptCompile({
       LLMWIKI_PROMPT_BUDGET_CHARS: TIGHT_BUDGET,
     });
-    expectCLIExit(result, 0);
-
-    const systemPrompt = findPageGenerationSystemPrompt(handle);
-    expect(systemPrompt, "page-generation system prompt should be recorded").not.toBeNull();
 
     // Bounded: well under the unbudgeted total (5 × 4,000 = 20,000 chars of source
     // content alone, plus prompt boilerplate). With a 5,000-char budget we expect
     // the source-content portion to land near 5k; the whole prompt stays well under
     // the unbudgeted ~20k+ blowup.
-    expect(systemPrompt!.length).toBeLessThan(15_000);
-
-    // The truncation marker must be present — proves budgeting ran.
+    expect(systemPrompt.length).toBeLessThan(15_000);
     expect(systemPrompt).toContain("truncated for prompt budget");
 
     // All five source headers are still represented (fair-share, not first-N-only).
@@ -133,15 +148,7 @@ describe("prompt blowup defence (#39)", () => {
   }, 60_000);
 
   it("compile without an explicit budget keeps the prompt unbudgeted (no truncation marker)", async () => {
-    const handle = await aimock.start();
-    stubSharedConceptExtraction(handle);
-
-    const cwd = await makeMultiSourceWorkspace();
-    const result = await runCLI(["compile", "--review"], cwd, mockClaudeEnv(handle));
-    expectCLIExit(result, 0);
-
-    const systemPrompt = findPageGenerationSystemPrompt(handle);
-    expect(systemPrompt).not.toBeNull();
+    const { systemPrompt } = await runSharedConceptCompile({});
     // 5 × 4,000 = 20,000 raw source chars — well under the 200,000-char default
     // budget, so the prompt should NOT carry the truncation marker.
     expect(systemPrompt).not.toContain("truncated for prompt budget");
@@ -149,14 +156,9 @@ describe("prompt blowup defence (#39)", () => {
 
   // The shared-concept slug should land under the configured concept directory.
   it("compile produces exactly one merged candidate for the shared concept", async () => {
-    const handle = await aimock.start();
-    stubSharedConceptExtraction(handle);
-    const cwd = await makeMultiSourceWorkspace();
-    const result = await runCLI(["compile", "--review"], cwd, {
-      ...mockClaudeEnv(handle),
+    const { result } = await runSharedConceptCompile({
       LLMWIKI_PROMPT_BUDGET_CHARS: TIGHT_BUDGET,
     });
-    expectCLIExit(result, 0);
     expect(result.stdout).toContain(SHARED_CONCEPT_SLUG);
   }, 60_000);
 });

--- a/test/prompt-budget.test.ts
+++ b/test/prompt-budget.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for the prompt-budget helper (issue #39).
+ *
+ * The default-case behaviour must be byte-identical to the previous
+ * unbudgeted concatenation — these tests pin that contract so future
+ * refactors can't accidentally drift.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  buildBudgetedCombinedContent,
+  resolvePromptBudgetChars,
+  type SourceSlice,
+} from "../src/compiler/prompt-budget.js";
+import { DEFAULT_PROMPT_BUDGET_CHARS } from "../src/utils/constants.js";
+
+const ENV_KEY = "LLMWIKI_PROMPT_BUDGET_CHARS";
+
+afterEach(() => {
+  delete process.env[ENV_KEY];
+});
+
+describe("resolvePromptBudgetChars", () => {
+  it("returns the default when env is unset", () => {
+    expect(resolvePromptBudgetChars()).toBe(DEFAULT_PROMPT_BUDGET_CHARS);
+  });
+
+  it("honours a numeric env override", () => {
+    process.env[ENV_KEY] = "50000";
+    expect(resolvePromptBudgetChars()).toBe(50_000);
+  });
+
+  it("ignores non-numeric env values", () => {
+    process.env[ENV_KEY] = "not-a-number";
+    expect(resolvePromptBudgetChars()).toBe(DEFAULT_PROMPT_BUDGET_CHARS);
+  });
+
+  it("ignores zero or negative env values", () => {
+    process.env[ENV_KEY] = "0";
+    expect(resolvePromptBudgetChars()).toBe(DEFAULT_PROMPT_BUDGET_CHARS);
+    process.env[ENV_KEY] = "-100";
+    expect(resolvePromptBudgetChars()).toBe(DEFAULT_PROMPT_BUDGET_CHARS);
+  });
+});
+
+describe("buildBudgetedCombinedContent", () => {
+  it("default case: total under budget produces unbudgeted concatenation", () => {
+    const slices: SourceSlice[] = [
+      { file: "a.md", content: "alpha content" },
+      { file: "b.md", content: "beta content" },
+    ];
+    const out = buildBudgetedCombinedContent("Concept", slices);
+    expect(out).toBe(
+      "--- SOURCE: a.md ---\n\nalpha content\n\n--- SOURCE: b.md ---\n\nbeta content",
+    );
+    expect(out).not.toContain("truncated");
+  });
+
+  it("over-budget: each source is truncated to a fair share", () => {
+    process.env[ENV_KEY] = "60"; // tiny budget to force truncation
+    const slices: SourceSlice[] = [
+      { file: "a.md", content: "X".repeat(100) },
+      { file: "b.md", content: "Y".repeat(100) },
+      { file: "c.md", content: "Z".repeat(100) },
+    ];
+    const out = buildBudgetedCombinedContent("Concept", slices);
+    // perSource = floor(60 / 3) = 20. Each slice is trimmed to 20 chars + marker.
+    expect(out).toContain("X".repeat(20));
+    expect(out).toContain("Y".repeat(20));
+    expect(out).toContain("Z".repeat(20));
+    expect(out).not.toContain("X".repeat(21));
+    expect(out).toContain("truncated");
+  });
+
+  it("over-budget: small source under per-share budget is preserved untrimmed", () => {
+    process.env[ENV_KEY] = "60";
+    const slices: SourceSlice[] = [
+      { file: "small.md", content: "tiny" }, // 4 chars, under per-share = 30
+      { file: "big.md", content: "Y".repeat(200) },
+    ];
+    const out = buildBudgetedCombinedContent("Concept", slices);
+    // perSource = floor(60 / 2) = 30. Small source survives intact.
+    expect(out).toContain("--- SOURCE: small.md ---\n\ntiny");
+    // Big source is truncated to 30 chars + marker.
+    expect(out).toContain("Y".repeat(30));
+    expect(out).not.toContain("Y".repeat(31));
+  });
+
+  it("preserves source order and section headers", () => {
+    process.env[ENV_KEY] = "30";
+    const slices: SourceSlice[] = [
+      { file: "first.md", content: "A".repeat(50) },
+      { file: "second.md", content: "B".repeat(50) },
+    ];
+    const out = buildBudgetedCombinedContent("Concept", slices);
+    const firstIdx = out.indexOf("first.md");
+    const secondIdx = out.indexOf("second.md");
+    expect(firstIdx).toBeGreaterThanOrEqual(0);
+    expect(secondIdx).toBeGreaterThan(firstIdx);
+  });
+
+  it("handles a single source larger than the budget without divide-by-zero", () => {
+    process.env[ENV_KEY] = "20";
+    const slices: SourceSlice[] = [{ file: "only.md", content: "X".repeat(500) }];
+    const out = buildBudgetedCombinedContent("Concept", slices);
+    expect(out).toContain("X".repeat(20));
+    expect(out).not.toContain("X".repeat(21));
+    expect(out).toContain("truncated");
+  });
+
+  it("empty slice list yields empty content (no crash)", () => {
+    expect(buildBudgetedCombinedContent("Concept", [])).toBe("");
+  });
+});


### PR DESCRIPTION
Closes #39.

## The bug

When the same concept was extracted from many overlapping sources, \`mergeExtractions\` concatenated every contributing source's full content into a single page-generation prompt:

\`\`\`ts
existing.combinedContent += \`\n\n--- SOURCE: \${result.sourceFile} ---\n\n\${result.sourceContent}\`;
\`\`\`

Combined size was linear in the number of sources, so popular concepts that appeared in many documents reliably blew past the LLM provider's context window and the compile crashed with \`prompt is too long\` / \`context window exceeds\`. The bug compounded on incremental updates: adding a new source that touched an already-established concept re-triggered the blowup on the existing page.

## The fix

A defensive per-concept character budget for the combined source content. New module \`src/compiler/prompt-budget.ts\` exposes \`buildBudgetedCombinedContent(concept, slices)\` which:

- Returns the unbudgeted concatenation when the raw total fits the budget — typical compiles produce **byte-identical output** to before, so existing wiki content is unchanged.
- Otherwise gives every contributing source a fair share (\`perSource = floor(budget / N)\`), truncates oversize slices to that share with a clear \`[…truncated for prompt budget — see #39…]\` marker, and emits a warning that names the concept, the raw size, and the env var to raise the cap.

Default budget: **200,000 chars** (~50k tokens), well under modern context windows. Override with \`LLMWIKI_PROMPT_BUDGET_CHARS\` for larger-context (raise) or local small-context (lower) models.

## Scope note

This is a **defensive cap, not a smart-retrieval solution.** Proportional truncation prevents crashes today; a future PR can replace it with semantic ranking once the chunked-retrieval store is generalised beyond \`query\`.

## Test plan

- [x] Unit tests pin every branch:
  - default-case byte-identical output
  - fair-share truncation
  - small-source preservation under per-share budget
  - source-order stability
  - single-source overflow (no divide-by-zero)
  - empty slice list
  - env var resolution: default, numeric override, non-numeric ignored, zero/negative ignored
- [x] aimock CLI integration: 5 sources × 4,000 chars all extracting the same shared concept; \`LLMWIKI_PROMPT_BUDGET_CHARS=5000\`; run \`compile --review\`; assert the system prompt aimock observed is (a) bounded under 15k chars, (b) carries the truncation marker, (c) still includes all 5 source headers (fair-share, not first-N-only). Control test with the default budget verifies the marker is absent for typical workloads.
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` succeeds
- [x] \`npm test\` — 545 pass / 3 skipped
- [x] \`npx fallow\` — 0 issues above threshold