### PR TITLE
chore: add npm run fallow:ci script with --changed-since scoping

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,9 +53,16 @@ npx fallow          # Codebase health (dead code, duplication, complexity)
 npm run fallow:ci   # Run fallow scoped to changes since origin/main (matches CI args)
 ```
 
-**A note on `npm run fallow:ci`:** the `codebase-health` job in CI passes `--changed-since <PR-base-sha>` so it scopes analysis to the diff. `npm run fallow:ci` mirrors that locally by computing `git merge-base origin/main HEAD`. It catches most of what CI would flag before you push.
+**A note on `npm run fallow:ci`:** the `codebase-health` job in CI passes `--changed-since <PR-base-sha>` so it scopes analysis to the diff. `npm run fallow:ci` mirrors that locally by computing the merge-base between `HEAD` and the canonical main branch. The script prefers `upstream/main` when an `upstream` remote is configured (the fork workflow), and falls back to `origin/main` for direct clones. To make sure the comparison uses the canonical main from atomicmemory/llm-wiki-compiler:
 
-There is one known parity gap: fallow's clone-detection occasionally returns different results across platforms (CI Linux x64 vs macOS arm64). When CI flags a clone you can't reproduce locally, dedupe by intent and re-push — it's not a bug in your branch.
+```bash
+# One-time setup on your fork
+git remote add upstream https://github.com/atomicmemory/llm-wiki-compiler.git
+```
+
+Without an `upstream` remote on a fork checkout, the script compares against your fork's `origin/main`, which can drift from the canonical main and miss findings CI will catch.
+
+There is also one known parity gap that no flag closes: fallow's clone-detection occasionally returns different results across platforms (CI Linux x64 vs macOS arm64). When CI flags a clone you can't reproduce locally, dedupe by intent and re-push — it's not a bug in your branch.
 
 ### Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,12 @@ npx tsc --noEmit   # Type-check
 npm run build       # Build
 npm test            # Tests
 npx fallow          # Codebase health (dead code, duplication, complexity)
+npm run fallow:ci   # Run fallow scoped to changes since origin/main (matches CI args)
 ```
+
+**A note on `npm run fallow:ci`:** the `codebase-health` job in CI passes `--changed-since <PR-base-sha>` so it scopes analysis to the diff. `npm run fallow:ci` mirrors that locally by computing `git merge-base origin/main HEAD`. It catches most of what CI would flag before you push.
+
+There is one known parity gap: fallow's clone-detection occasionally returns different results across platforms (CI Linux x64 vs macOS arm64). When CI flags a clone you can't reproduce locally, dedupe by intent and re-push — it's not a bug in your branch.
 
 ### Code Style
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",
+    "fallow:ci": "bash scripts/fallow-ci.sh",
     "prepublishOnly": "npm run build && npm test",
     "prepare": "husky"
   },

--- a/scripts/fallow-ci.sh
+++ b/scripts/fallow-ci.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# scripts/fallow-ci.sh
+#
+# Run fallow with the same flags GitHub Actions uses for the
+# `codebase-health` job, so issues that would block PR merge are
+# surfaced locally before pushing.
+#
+# What this mirrors (from fallow-rs/fallow@v2 action.yml + analyze.sh):
+#   - bare command (runs dead-code, dupes, and health analyses together)
+#   - --root .
+#   - --quiet
+#   - --format human (CI uses json for parsing; human is friendlier locally)
+#   - --changed-since <merge-base with origin/main>
+#       (CI uses the PR base SHA; merge-base is the closest local equivalent)
+#
+# IMPORTANT — known parity gap:
+#   fallow's clone-detection has empirical platform variation. The same
+#   command, fallow version, commit, and base SHA can return 0 dupes on
+#   macOS arm64 and 1+ dupes on the CI Linux x64 runner. This is a
+#   tooling-level limitation, not a config bug. This script catches
+#   most issues most of the time, but CI remains the ground truth.
+#   When CI flags a clone you can't reproduce locally, just dedupe by
+#   intent and re-push.
+
+set -euo pipefail
+
+# Make sure origin/main is fresh — CI's PR base SHA is whatever main
+# pointed at when the PR was opened, so we mirror by syncing first.
+git fetch --quiet origin main
+
+BASE_SHA=$(git merge-base origin/main HEAD)
+
+if [ -z "$BASE_SHA" ]; then
+  echo "Could not determine merge-base with origin/main; running fallow without --changed-since."
+  exec npx fallow --root . --format human
+fi
+
+echo "Running fallow scoped to changes since $(git rev-parse --short "$BASE_SHA")..."
+exec npx fallow --root . --format human --changed-since "$BASE_SHA"

--- a/scripts/fallow-ci.sh
+++ b/scripts/fallow-ci.sh
@@ -8,10 +8,17 @@
 # What this mirrors (from fallow-rs/fallow@v2 action.yml + analyze.sh):
 #   - bare command (runs dead-code, dupes, and health analyses together)
 #   - --root .
-#   - --quiet
 #   - --format human (CI uses json for parsing; human is friendlier locally)
-#   - --changed-since <merge-base with origin/main>
+#   - --changed-since <merge-base with the canonical PR base branch>
 #       (CI uses the PR base SHA; merge-base is the closest local equivalent)
+#
+# Fork-aware base resolution:
+#   - Prefer `upstream/main` when an `upstream` remote is configured (the
+#     fork-and-PR workflow described in CONTRIBUTING.md, where `origin`
+#     points at the contributor's fork and `upstream` at atomicmemory/*).
+#   - Fall back to `origin/main` for direct clones.
+#   - When neither remote tracks main, fall back to running fallow without
+#     `--changed-since` (full-tree analysis).
 #
 # IMPORTANT — known parity gap:
 #   fallow's clone-detection has empirical platform variation. The same
@@ -24,16 +31,31 @@
 
 set -euo pipefail
 
-# Make sure origin/main is fresh — CI's PR base SHA is whatever main
-# pointed at when the PR was opened, so we mirror by syncing first.
-git fetch --quiet origin main
+# Resolve the upstream base branch ref. Forks should configure an
+# `upstream` remote pointing at atomicmemory/llm-wiki-compiler so the
+# script compares against the canonical main, not the fork's main.
+if git remote get-url upstream >/dev/null 2>&1; then
+  BASE_REMOTE="upstream"
+else
+  BASE_REMOTE="origin"
+fi
+BASE_REF="${BASE_REMOTE}/main"
 
-BASE_SHA=$(git merge-base origin/main HEAD)
+# Refresh the base ref so the merge-base reflects what CI's PR base SHA
+# would point at right now. A fetch failure (offline, auth issue) is
+# non-fatal — we'll fall back to whatever's already cached locally.
+git fetch --quiet "$BASE_REMOTE" main || \
+  echo "warning: could not fetch ${BASE_REF}; using last-known cached state."
+
+# `git merge-base` returns non-zero when the ref is missing or there's no
+# common ancestor. Suppress the failure with `|| true` so the empty-result
+# fallback below is reachable under `set -e`.
+BASE_SHA=$(git merge-base "$BASE_REF" HEAD 2>/dev/null || true)
 
 if [ -z "$BASE_SHA" ]; then
-  echo "Could not determine merge-base with origin/main; running fallow without --changed-since."
+  echo "Could not determine merge-base with ${BASE_REF}; running fallow without --changed-since."
   exec npx fallow --root . --format human
 fi
 
-echo "Running fallow scoped to changes since $(git rev-parse --short "$BASE_SHA")..."
+echo "Running fallow scoped to changes since $(git rev-parse --short "$BASE_SHA") (${BASE_REF})..."
 exec npx fallow --root . --format human --changed-since "$BASE_SHA"


### PR DESCRIPTION
## What

Adds `npm run fallow:ci` (backed by `scripts/fallow-ci.sh`) that runs `fallow` with the same `--changed-since <PR-base-sha>` scoping the GitHub Action uses, so contributors can catch most CI fallow findings before pushing.

\`\`\`bash
npm run fallow:ci
# → fetches origin/main, computes merge-base, runs:
#   npx fallow --root . --format human --changed-since <merge-base>
\`\`\`

## Why

Over the last batch of PRs (#44/#45/#47) we hit four rounds of fallow CI failures that local \`npx fallow\` ran clean for. Investigation: CI passes \`--changed-since <PR-base-sha>\` (auto-detected by \`fallow-rs/fallow@v2\`), and that scoping matters for which clones get reported. Local invocations without it analyze the whole tree at slightly different sensitivity.

## Honest caveat (documented in CONTRIBUTING.md)

Even with this script, there's a residual parity gap: empirically, fallow 2.42.0's clone detector sometimes returns different results across platforms (CI Linux x64 vs developer macOS arm64) on the same commit, same flags, same fallow version, fresh \`npm ci\`, clean cache. I couldn't fully reverse-engineer it. The script catches most of what CI flags; when CI flags a clone you can't reproduce locally, dedupe by intent and re-push.

## Test plan

- [x] \`npm run fallow:ci\` runs cleanly on this branch
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — 575 pass / 3 skipped
- [x] \`npx fallow\` — 0 issues above threshold