### PR TITLE
refactor: unify ProvenanceMetadata across ExtractedConcept and WikiFrontmatter

### DIFF
--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -10,6 +10,7 @@ import yaml from "js-yaml";
 import type {
   ClaimCitation,
   ContradictionRef,
+  ProvenanceMetadata,
   ProvenanceState,
   SourceSpan,
 } from "./types.js";
@@ -30,14 +31,6 @@ const VALID_PROVENANCE_STATES: ReadonlySet<ProvenanceState> = new Set([
   "inferred",
   "ambiguous",
 ]);
-
-/** Provenance metadata parsed from a page's frontmatter. */
-interface ProvenanceMetadata {
-  confidence?: number;
-  provenanceState?: ProvenanceState;
-  contradictedBy?: ContradictionRef[];
-  inferredParagraphs?: number;
-}
 
 /**
  * Convert a human-readable concept title to a filename slug.

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -30,10 +30,11 @@ export interface ContradictionRef {
  * paragraph count — so a single shared shape keeps the two ends of the
  * pipeline from drifting apart as new fields are added.
  *
- * Composed (not extended) into {@link ExtractedConcept} and
- * {@link WikiFrontmatter} so the JSON shapes serialised on disk and over
- * the LLM tool boundary stay byte-identical to the previous flat layout
- * (TypeScript erases the indirection at compile time).
+ * Extended by {@link ExtractedConcept} and {@link WikiFrontmatter} via
+ * `interface … extends ProvenanceMetadata`, so the JSON shapes
+ * serialised on disk and over the LLM tool boundary stay byte-identical
+ * to the previous flat layout (TypeScript erases the indirection at
+ * compile time).
  */
 export interface ProvenanceMetadata {
   /** Numeric confidence in 0..1 — overall confidence in the content. */

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -23,23 +23,35 @@ export interface ContradictionRef {
   reason?: string;
 }
 
+/**
+ * Provenance metadata shared between extraction-time concept records and
+ * page-frontmatter records. Both surfaces carry the same four optional
+ * fields — confidence, lifecycle state, contradictions, and inferred
+ * paragraph count — so a single shared shape keeps the two ends of the
+ * pipeline from drifting apart as new fields are added.
+ *
+ * Composed (not extended) into {@link ExtractedConcept} and
+ * {@link WikiFrontmatter} so the JSON shapes serialised on disk and over
+ * the LLM tool boundary stay byte-identical to the previous flat layout
+ * (TypeScript erases the indirection at compile time).
+ */
+export interface ProvenanceMetadata {
+  /** Numeric confidence in 0..1 — overall confidence in the content. */
+  confidence?: number;
+  /** Lifecycle state describing how the content was produced. */
+  provenanceState?: ProvenanceState;
+  /** Slugs of other concepts/pages whose evidence contradicts this one. */
+  contradictedBy?: ContradictionRef[];
+  /** Number of paragraphs that are inferred rather than directly extracted. */
+  inferredParagraphs?: number;
+}
+
 /** A single concept extracted from a source by the LLM. */
-export interface ExtractedConcept {
+export interface ExtractedConcept extends ProvenanceMetadata {
   concept: string;
   summary: string;
   is_new: boolean;
   tags?: string[];
-  /** Numeric confidence in 0..1 — how certain the model is in this concept. */
-  confidence?: number;
-  /** Lifecycle state describing how this concept was produced. */
-  provenanceState?: ProvenanceState;
-  /** Slugs of concepts whose evidence contradicts this one. */
-  contradictedBy?: ContradictionRef[];
-  /**
-   * Number of paragraphs the model considers inferred (not directly extracted).
-   * Used by the inferred-without-citations lint rule.
-   */
-  inferredParagraphs?: number;
 }
 
 /** Per-source entry in .llmwiki/state.json. */
@@ -65,7 +77,7 @@ export interface SourceChange {
 }
 
 /** Wiki page frontmatter parsed from YAML. */
-export interface WikiFrontmatter {
+export interface WikiFrontmatter extends ProvenanceMetadata {
   title: string;
   sources: string[];
   summary: string;
@@ -81,14 +93,6 @@ export interface WikiFrontmatter {
    * type-only so it is erased at compile time and creates no runtime cycle.
    */
   kind?: PageKind;
-  /** Numeric confidence in 0..1 — overall confidence in the page's claims. */
-  confidence?: number;
-  /** Lifecycle state describing how the page's content was produced. */
-  provenanceState?: ProvenanceState;
-  /** Slugs of pages whose evidence contradicts this one. */
-  contradictedBy?: ContradictionRef[];
-  /** Number of inferred paragraphs in the page body without direct citations. */
-  inferredParagraphs?: number;
 }
 
 /** Summary entry used in index.md generation. */

--- a/test/provenance-metadata-shape.test.ts
+++ b/test/provenance-metadata-shape.test.ts
@@ -9,9 +9,16 @@
  * src/utils/types.ts, plus drops the duplicate private interface that
  * lived in src/utils/markdown.ts.
  *
- * The assertions below are static type-system checks expressed as
- * runtime assignments so a future re-introduction of the drift fails
- * `npx tsc --noEmit` rather than silently re-creating the gap.
+ * The two type-level assertions at the top are the strict guard: they
+ * compile only when every key present on ProvenanceMetadata is also a
+ * key of ExtractedConcept / WikiFrontmatter. Removing the `extends`
+ * clause and inlining the fields would still pass — but DROPPING any
+ * ProvenanceMetadata key from one of the two surfaces (the actual
+ * drift codex worried about) would break `npx tsc --noEmit`.
+ *
+ * The runtime assignment tests below are weaker (every field is
+ * optional, so an unrelated empty object would also be assignable) but
+ * exercise the runtime field shape end-to-end.
  */
 
 import { describe, it, expect } from "vitest";
@@ -21,8 +28,22 @@ import type {
   WikiFrontmatter,
 } from "../src/utils/types.js";
 
+// Type-level assertions — fail to compile if ExtractedConcept or
+// WikiFrontmatter no longer carry every key from ProvenanceMetadata.
+// Conditional resolves to `true` when the keys are a superset, otherwise
+// to `never`, which would make the constant assignment fail tsc.
+type AssertExtractedConceptCoversProvenance =
+  keyof ProvenanceMetadata extends keyof ExtractedConcept ? true : never;
+type AssertWikiFrontmatterCoversProvenance =
+  keyof ProvenanceMetadata extends keyof WikiFrontmatter ? true : never;
+const _extractedConceptCovers: AssertExtractedConceptCoversProvenance = true;
+const _wikiFrontmatterCovers: AssertWikiFrontmatterCoversProvenance = true;
+// Reference the constants so a future "unused variable" sweep keeps them.
+void _extractedConceptCovers;
+void _wikiFrontmatterCovers;
+
 describe("ProvenanceMetadata shared shape", () => {
-  it("ExtractedConcept satisfies ProvenanceMetadata so the four fields are unified", () => {
+  it("ExtractedConcept carries every ProvenanceMetadata field at runtime", () => {
     const concept: ExtractedConcept = {
       concept: "Concept",
       summary: "summary",
@@ -32,16 +53,12 @@ describe("ProvenanceMetadata shared shape", () => {
       contradictedBy: [{ slug: "other" }],
       inferredParagraphs: 2,
     };
-    // Compile-time assertion: assigning to ProvenanceMetadata proves the
-    // shared fields are structurally compatible. If a future change drops
-    // a field from ProvenanceMetadata or renames it on ExtractedConcept,
-    // this line stops type-checking.
     const provenance: ProvenanceMetadata = concept;
     expect(provenance.confidence).toBe(0.9);
     expect(provenance.provenanceState).toBe("extracted");
   });
 
-  it("WikiFrontmatter satisfies ProvenanceMetadata for the same reason", () => {
+  it("WikiFrontmatter carries every ProvenanceMetadata field at runtime", () => {
     const frontmatter: WikiFrontmatter = {
       title: "Sample",
       summary: "An example.",

--- a/test/provenance-metadata-shape.test.ts
+++ b/test/provenance-metadata-shape.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Compile-time pin for the shared ProvenanceMetadata shape.
+ *
+ * Codex's post-merge schema-overlap audit flagged that ExtractedConcept
+ * and WikiFrontmatter independently re-declared the same four optional
+ * fields (confidence, provenanceState, contradictedBy,
+ * inferredParagraphs), which was a drift hazard. The fix composes both
+ * surfaces from a single exported `ProvenanceMetadata` interface in
+ * src/utils/types.ts, plus drops the duplicate private interface that
+ * lived in src/utils/markdown.ts.
+ *
+ * The assertions below are static type-system checks expressed as
+ * runtime assignments so a future re-introduction of the drift fails
+ * `npx tsc --noEmit` rather than silently re-creating the gap.
+ */
+
+import { describe, it, expect } from "vitest";
+import type {
+  ExtractedConcept,
+  ProvenanceMetadata,
+  WikiFrontmatter,
+} from "../src/utils/types.js";
+
+describe("ProvenanceMetadata shared shape", () => {
+  it("ExtractedConcept satisfies ProvenanceMetadata so the four fields are unified", () => {
+    const concept: ExtractedConcept = {
+      concept: "Concept",
+      summary: "summary",
+      is_new: true,
+      confidence: 0.9,
+      provenanceState: "extracted",
+      contradictedBy: [{ slug: "other" }],
+      inferredParagraphs: 2,
+    };
+    // Compile-time assertion: assigning to ProvenanceMetadata proves the
+    // shared fields are structurally compatible. If a future change drops
+    // a field from ProvenanceMetadata or renames it on ExtractedConcept,
+    // this line stops type-checking.
+    const provenance: ProvenanceMetadata = concept;
+    expect(provenance.confidence).toBe(0.9);
+    expect(provenance.provenanceState).toBe("extracted");
+  });
+
+  it("WikiFrontmatter satisfies ProvenanceMetadata for the same reason", () => {
+    const frontmatter: WikiFrontmatter = {
+      title: "Sample",
+      summary: "An example.",
+      sources: ["src.md"],
+      createdAt: "2026-04-30T00:00:00.000Z",
+      updatedAt: "2026-04-30T00:00:00.000Z",
+      confidence: 0.8,
+      provenanceState: "merged",
+      contradictedBy: [{ slug: "alt" }],
+      inferredParagraphs: 1,
+    };
+    const provenance: ProvenanceMetadata = frontmatter;
+    expect(provenance.contradictedBy).toEqual([{ slug: "alt" }]);
+    expect(provenance.inferredParagraphs).toBe(1);
+  });
+});


### PR DESCRIPTION
Second of four pre-0.6.0 audit-fix PRs.

## What

`ExtractedConcept` and `WikiFrontmatter` independently re-declared the same four optional fields (`confidence`, `provenanceState`, `contradictedBy`, `inferredParagraphs`). They are intentionally a pipeline-boundary pair — extraction-time concept records vs. on-disk page frontmatter — but the lack of a shared shape meant any future field addition or rename risked drifting one surface from the other.

Define a single exported `ProvenanceMetadata` interface in `src/utils/types.ts` and compose both surfaces from it via interface extension. TypeScript erases the indirection at compile time, so the JSON shapes serialised on disk and over the LLM tool boundary stay byte-identical to the previous flat layout — pure refactor, no behaviour change.

Also drops the duplicate private `ProvenanceMetadata` interface that lived in `src/utils/markdown.ts` (used by `parseProvenanceMetadata` and the lint rules) and re-uses the canonical exported type instead, so the lint surface tracks the same shared shape.

## Test plan

- [x] New compile-time pin in `test/provenance-metadata-shape.test.ts` asserts that both `ExtractedConcept` and `WikiFrontmatter` remain assignable to `ProvenanceMetadata` — future drift fails `npx tsc --noEmit` rather than silently re-creating the gap
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds
- [x] `npm test` — 632 pass / 3 skipped (smoke), no regressions
- [x] `npm run fallow:ci` — 0 issues above threshold

## Up next (remaining audit follow-ups)

- Derive `inferredParagraphs` from rendered page bodies/citations rather than trusting extraction-time metadata
- Dedupe `checkSchemaCrossLinks` / `checkPageCrossLinks` shared logic (lower priority)
- Surface seed pages in `generation.pages` so downstream consumers know they changed (lower priority)