### PR TITLE
refactor(audit): dedupe cross-link lint helper + surface seed pages

### DIFF
--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -267,7 +267,7 @@ async function runCompilePipeline(
       await generateSeedPages(root, schema, emptyGeneration);
       // Rebuild index/MOC so the newly-written seed pages become discoverable,
       // and propagate any seed-page validation errors into the returned result.
-      await finalizeWiki(root, emptyGeneration.pages);
+      await finalizeWiki(root, emptyGeneration.pages, emptyGeneration.seedSlugs);
       return {
         ...emptyCompileResult(),
         skipped: buckets.unchanged.length,
@@ -312,7 +312,7 @@ async function runCompilePipeline(
     // Seed pages write directly into wiki/, so skip them in review mode
     // to honour the "no wiki/ mutation" contract of that mode.
     await generateSeedPages(root, schema, generation);
-    await finalizeWiki(root, generation.pages);
+    await finalizeWiki(root, generation.pages, generation.seedSlugs);
   }
   return summarizeCompile(buckets, generation, extractions, options);
 }
@@ -374,10 +374,25 @@ async function runExtractionPhases(
   return extractions;
 }
 
-/** Resolve interlinks, regenerate index/MOC, refresh embeddings post-write. */
-async function finalizeWiki(root: string, pages: MergedConcept[]): Promise<void> {
-  const allChangedSlugs = pages.map((entry) => entry.slug);
-  const allNewSlugs = pages.filter((entry) => entry.concept.is_new).map((entry) => entry.slug);
+/**
+ * Resolve interlinks, regenerate index/MOC, refresh embeddings
+ * post-write. Seed-page slugs are folded into both the changed-slug
+ * set (so embeddings refresh covers them) and the new-slug set (so
+ * inbound-link resolution scans existing pages for mentions of seed
+ * titles). Without that, schema-declared seed pages would land on
+ * disk but stay unlinked and absent from the embedding store.
+ */
+async function finalizeWiki(
+  root: string,
+  pages: MergedConcept[],
+  seedSlugs: string[] = [],
+): Promise<void> {
+  const conceptChangedSlugs = pages.map((entry) => entry.slug);
+  const conceptNewSlugs = pages
+    .filter((entry) => entry.concept.is_new)
+    .map((entry) => entry.slug);
+  const allChangedSlugs = [...conceptChangedSlugs, ...seedSlugs];
+  const allNewSlugs = [...conceptNewSlugs, ...seedSlugs];
 
   if (allChangedSlugs.length > 0) {
     output.status("🔗", output.info("Resolving interlinks..."));

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -146,6 +146,14 @@ interface PageGenerationResult {
   errors: string[];
   /** Candidate ids written when running in --review mode. Empty otherwise. */
   candidates: string[];
+  /**
+   * Slugs of seed pages written this run (overview / comparison / entity).
+   * Concept pages live on `pages`; seed pages don't fit MergedConcept's
+   * source-list shape, so they're tracked separately here. summarizeCompile
+   * concatenates these into CompileResult.pages so downstream consumers
+   * (MCP, embeddings, programmatic callers) see seed-page changes too.
+   */
+  seedSlugs: string[];
 }
 
 /** Phase 2: generate pages for merged concepts in parallel, capturing errors. */
@@ -173,7 +181,7 @@ async function generatePagesPhase(
       return entry;
     })),
   );
-  return { pages, errors, candidates };
+  return { pages, errors, candidates, seedSlugs: [] };
 }
 
 /** Persist source state for every extraction that produced concepts. */
@@ -213,12 +221,17 @@ function summarizeCompile(
     }
   }
 
+  // Concept-page slugs first, then seed-page slugs from the same run, so
+  // downstream consumers see every page the compile actually produced.
+  // Seed pages are deterministic schema-driven writes; before this they
+  // landed on disk silently and never appeared on CompileResult.pages.
+  const conceptSlugs = generation.pages.map((entry) => entry.slug);
   const baseResult: CompileResult = {
     compiled: buckets.toCompile.length,
     skipped: buckets.unchanged.length,
     deleted: buckets.deleted.length,
     concepts: generation.pages.map((entry) => entry.concept.concept),
-    pages: generation.pages.map((entry) => entry.slug),
+    pages: [...conceptSlugs, ...generation.seedSlugs],
     errors,
   };
   if (options.review) {
@@ -245,7 +258,12 @@ async function runCompilePipeline(
     // no source files changed, so adding a seed page to schema.json takes
     // effect on the next compile without needing a source file edit.
     if (!options.review) {
-      const emptyGeneration: PageGenerationResult = { pages: [], errors: [], candidates: [] };
+      const emptyGeneration: PageGenerationResult = {
+        pages: [],
+        errors: [],
+        candidates: [],
+        seedSlugs: [],
+      };
       await generateSeedPages(root, schema, emptyGeneration);
       // Rebuild index/MOC so the newly-written seed pages become discoverable,
       // and propagate any seed-page validation errors into the returned result.
@@ -253,6 +271,10 @@ async function runCompilePipeline(
       return {
         ...emptyCompileResult(),
         skipped: buckets.unchanged.length,
+        // Surface seed-page slugs alongside any errors so downstream
+        // consumers (MCP, embeddings, programmatic callers) can see what
+        // landed even on the no-source-changes early-return path.
+        pages: [...emptyGeneration.seedSlugs],
         errors: emptyGeneration.errors,
       };
     }
@@ -618,9 +640,19 @@ async function generateSeedPages(
 ): Promise<void> {
   if (schema.seedPages.length === 0) return;
   for (const seed of schema.seedPages) {
-    const error = await generateSingleSeedPage(root, schema, seed);
-    if (error) generation.errors.push(error);
+    const result = await generateSingleSeedPage(root, schema, seed);
+    if (result.error) {
+      generation.errors.push(result.error);
+      continue;
+    }
+    generation.seedSlugs.push(result.slug);
   }
+}
+
+/** Outcome of a single seed-page generation: slug always, error when the write failed validation. */
+interface SeedPageOutcome {
+  slug: string;
+  error?: string;
 }
 
 /** Build, prompt, and persist a single seed page. */
@@ -628,7 +660,7 @@ async function generateSingleSeedPage(
   root: string,
   schema: SchemaConfig,
   seed: SeedPage,
-): Promise<string | null> {
+): Promise<SeedPageOutcome> {
   const slug = slugify(seed.title);
   const pagePath = path.join(root, CONCEPTS_DIR, `${slug}.md`);
   const relatedContent = await loadSeedRelatedPages(root, seed.relatedSlugs ?? []);
@@ -654,7 +686,8 @@ async function generateSingleSeedPage(
   const frontmatterFields: Record<string, unknown> = { ...typedFields };
   addObsidianMeta(frontmatterFields, seed.title, []);
   const frontmatter = buildFrontmatter(frontmatterFields);
-  return await writePageIfValid(pagePath, `${frontmatter}\n\n${pageBody}\n`, seed.title);
+  const error = await writePageIfValid(pagePath, `${frontmatter}\n\n${pageBody}\n`, seed.title);
+  return error ? { slug, error } : { slug };
 }
 
 /** Load the bodies of the related concept pages a seed page should weave together. */

--- a/src/linter/rules.ts
+++ b/src/linter/rules.ts
@@ -362,6 +362,10 @@ interface ParsedLineRange {
  * body has fewer wikilinks than the rule requires. Pages with kind `concept`
  * and a minimum of 0 (the default) generate no diagnostics, so existing
  * projects without a schema file see no behaviour change.
+ *
+ * Implementation delegates to {@link checkPageCrossLinks} per page so the
+ * actual rule logic lives in exactly one place — the on-disk walker just
+ * fans the per-page helper across `collectAllPages`.
  * @param root - Project root directory.
  * @param schema - Resolved schema config.
  */
@@ -371,26 +375,9 @@ export async function checkSchemaCrossLinks(
 ): Promise<LintResult[]> {
   const pages = await collectAllPages(root);
   const results: LintResult[] = [];
-
   for (const page of pages) {
-    const { meta, body } = parseFrontmatter(page.content);
-    const kind = resolvePageKind(meta.kind, schema);
-    const rule = schema.kinds[kind];
-    if (rule.minWikilinks <= 0) continue;
-
-    const linkCount = countWikilinks(body);
-    if (linkCount >= rule.minWikilinks) continue;
-
-    results.push({
-      rule: "schema-cross-link-minimum",
-      severity: "warning",
-      file: page.filePath,
-      message:
-        `Page kind "${kind}" requires at least ${rule.minWikilinks} ` +
-        `[[wikilinks]] but only ${linkCount} found.`,
-    });
+    results.push(...checkPageCrossLinks(page.content, page.filePath, schema));
   }
-
   return results;
 }
 

--- a/test/seed-pages-early-return.test.ts
+++ b/test/seed-pages-early-return.test.ts
@@ -55,16 +55,25 @@ async function writeSchemaWithSeedPage(rootDir: string, seedTitle: string): Prom
   );
 }
 
+/**
+ * Stand up a workspace with a one-seed schema, stub the LLM, silence
+ * console output, then run compileAndReport — the four-line dance every
+ * test below repeats. fallow's CI mode flagged the duplicate boilerplate
+ * as a clone group otherwise.
+ */
+async function runSeedPageCompile(
+  seedTitle: string,
+  options: { review?: boolean } = {},
+): Promise<Awaited<ReturnType<typeof compileAndReport>>> {
+  await writeSchemaWithSeedPage(root.dir, seedTitle);
+  await stubLLMForSeedPage(seedTitle);
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  return compileAndReport(root.dir, options);
+}
+
 describe("seed pages generated when no source files changed", () => {
   it("creates the seed page even when all sources are up to date", async () => {
-    const seedTitle = "Project Overview";
-    await writeSchemaWithSeedPage(root.dir, seedTitle);
-    await stubLLMForSeedPage(seedTitle);
-    vi.spyOn(console, "log").mockImplementation(() => {});
-
-    // No sources present → compile detects nothing to compile and would
-    // previously early-return before generating seed pages.
-    const result = await compileAndReport(root.dir, {});
+    const result = await runSeedPageCompile("Project Overview");
     expect(result.compiled).toBe(0);
 
     // The seed page must be written to wiki/concepts/<slug>.md
@@ -73,12 +82,7 @@ describe("seed pages generated when no source files changed", () => {
   });
 
   it("rebuilds wiki/index.md after writing seed pages on the early-return path", async () => {
-    const seedTitle = "Domain Overview";
-    await writeSchemaWithSeedPage(root.dir, seedTitle);
-    await stubLLMForSeedPage(seedTitle);
-    vi.spyOn(console, "log").mockImplementation(() => {});
-
-    await compileAndReport(root.dir, {});
+    await runSeedPageCompile("Domain Overview");
 
     // wiki/index.md must exist and reference the newly-written seed page
     const indexPath = path.join(root.dir, "wiki", "index.md");
@@ -88,12 +92,7 @@ describe("seed pages generated when no source files changed", () => {
   });
 
   it("does not generate seed pages in review mode (review keeps wiki/ clean)", async () => {
-    const seedTitle = "Review Overview";
-    await writeSchemaWithSeedPage(root.dir, seedTitle);
-    await stubLLMForSeedPage(seedTitle);
-    vi.spyOn(console, "log").mockImplementation(() => {});
-
-    await compileAndReport(root.dir, { review: true });
+    await runSeedPageCompile("Review Overview", { review: true });
 
     // Seed pages must not land in wiki/ when running in review mode
     const seedPath = path.join(root.dir, CONCEPTS_DIR, "review-overview.md");
@@ -105,27 +104,17 @@ describe("seed pages generated when no source files changed", () => {
     // landed on disk silently — they were absent from CompileResult.pages
     // even though they were just written. Downstream MCP / programmatic
     // consumers had no way to discover them without scanning wiki/.
-    const seedTitle = "Reportable Overview";
-    await writeSchemaWithSeedPage(root.dir, seedTitle);
-    await stubLLMForSeedPage(seedTitle);
-    vi.spyOn(console, "log").mockImplementation(() => {});
-
-    const result = await compileAndReport(root.dir, {});
-
+    const result = await runSeedPageCompile("Reportable Overview");
     expect(result.pages).toContain("reportable-overview");
   });
 
   it("propagates seed-page validation errors into CompileResult on the early-return path", async () => {
-    const seedTitle = "Broken Overview";
-    await writeSchemaWithSeedPage(root.dir, seedTitle);
-    await stubLLMForSeedPage(seedTitle);
-    vi.spyOn(console, "log").mockImplementation(() => {});
-
-    // Force validateWikiPage to reject the seed page so an error is recorded
+    // Force validateWikiPage to reject the seed page so an error is recorded.
+    // Spy is set BEFORE compile runs so the validation rejection takes effect.
     const markdownUtils = await import("../src/utils/markdown.js");
     vi.spyOn(markdownUtils, "validateWikiPage").mockReturnValue(false);
 
-    const result = await compileAndReport(root.dir, {});
+    const result = await runSeedPageCompile("Broken Overview");
 
     // The seed-page error must surface in CompileResult.errors
     expect(result.errors.length).toBeGreaterThan(0);

--- a/test/seed-pages-early-return.test.ts
+++ b/test/seed-pages-early-return.test.ts
@@ -100,6 +100,21 @@ describe("seed pages generated when no source files changed", () => {
     expect(existsSync(seedPath)).toBe(false);
   });
 
+  it("surfaces successfully-written seed slugs on CompileResult.pages", async () => {
+    // Seed pages are deterministic schema-driven writes that previously
+    // landed on disk silently — they were absent from CompileResult.pages
+    // even though they were just written. Downstream MCP / programmatic
+    // consumers had no way to discover them without scanning wiki/.
+    const seedTitle = "Reportable Overview";
+    await writeSchemaWithSeedPage(root.dir, seedTitle);
+    await stubLLMForSeedPage(seedTitle);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const result = await compileAndReport(root.dir, {});
+
+    expect(result.pages).toContain("reportable-overview");
+  });
+
   it("propagates seed-page validation errors into CompileResult on the early-return path", async () => {
     const seedTitle = "Broken Overview";
     await writeSchemaWithSeedPage(root.dir, seedTitle);


### PR DESCRIPTION
Fourth and final pre-0.6.0 audit-fix PR. Wraps up the post-merge schema-overlap cluster cleanup.

## What

Two lower-priority items from the audit:

### 1. Dedupe `checkSchemaCrossLinks` and `checkPageCrossLinks`

The on-disk walker (`checkSchemaCrossLinks`) duplicated the per-page helper's rule logic verbatim — same fields, same message, same rule name. Refactor the walker to delegate to `checkPageCrossLinks` so the `schema-cross-link-minimum` rule lives in exactly one place. Pure refactor, output unchanged.

### 2. Surface seed pages on `CompileResult.pages`

Seed pages (overview / comparison / entity) used to land on disk silently — they were absent from `CompileResult.pages`, so MCP / embeddings / programmatic consumers had no way to discover them without scanning `wiki/`. Track successful seed-page slugs on a new `seedSlugs` field on `PageGenerationResult`, and concatenate them into `CompileResult.pages` alongside concept-page slugs. Both the normal compile path and the no-source-changes early-return path now surface seed slugs on the result.

## Test plan

- [x] New regression test pins that `CompileResult.pages` includes the seed slug after a compile that wrote one
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds
- [x] `npm test` — 632 pass / 3 skipped (smoke), no regressions
- [x] `npm run fallow:ci` — 0 issues above threshold

## After this lands

All four pre-0.6.0 audit items shipped. Ready to cut 0.6.0.