### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-05-02
+
+Adds session-history ingest (Claude / Codex / Cursor exports), configurable output language, and a defensive cap that prevents `compile` from crashing on popular concepts. Closes a batch of CJK / collision / silent-loss bugs in the ingest path. Tightens `compile --review` so candidates carry both schema AND provenance lint findings before approval. Extracts a shared `ProvenanceMetadata` shape and removes an unreliable LLM extraction-time estimate in favour of body-derived counts.
+
+### Added
+
+- **`llmwiki ingest-session <path>`** — imports AI coding-session exports as wiki sources. Auto-detects three formats: Claude (`.jsonl`), Codex (`.json`), Cursor (`.json`, both `tabs` and flat schemas). Single file or whole directory. Each session lands in `sources/<slug>.md` with frontmatter recording the adapter, source path, ingest timestamp, and (where available) session start/end times. Adapter validation requires ≥ 1 user-or-assistant turn — recognised-but-empty exports fail loudly instead of producing a content-free page.
+- **`LLMWIKI_OUTPUT_LANG` env var + `--lang <code>` CLI flag** on `compile` and `query`. When set, every prompt builder (extraction, page generation, seed page, query answer) appends `Write the output in <lang>.` to the system prompt. Unset preserves current behaviour byte-for-byte. Useful for `--lang Chinese`, `--lang Japanese`, etc.
+- **`compile --review` provenance lint** — review candidates now carry both `schemaViolations` and `provenanceViolations` (malformed claim citations, broken-source / out-of-bounds line spans). `review show` prints both blocks. Reviewers see citation issues before approving a page rather than discovering them on a later compile.
+- **`npm run fallow:ci`** — contributor script that runs `fallow` with the same `--changed-since <PR-base-sha>` scoping the GitHub Action uses, so most CI fallow findings surface locally before pushing. Documented in CONTRIBUTING.md (including the fork-workflow `upstream/main` resolution and the platform-binary parity caveat).
+
+### Fixed
+
+- **Non-ASCII filename ingest** (#35) — `slugify` previously used `\w` without the `/u` flag, so titles like `测试文档` collapsed to the empty string and `ingest` wrote `sources/.md` (a dotfile that subsequent CJK ingests would overwrite). `slugify` now uses Unicode property escapes (`\p{L}`, `\p{N}`); pure-emoji titles that still strip to `""` fail with an actionable error rather than writing a dotfile.
+- **Same-basename source collision** (#36) — two distinct sources slugifying to the same name (e.g. `a/notes.md` and `b/notes.md`) used to silently overwrite. `saveSource` now checks for the collision and falls through to `<slug>-<8-hex-of-source>.md` when the existing file's frontmatter `source` doesn't match. Re-ingesting the same source still overwrites in place — no duplicate accumulation.
+- **Compile crash on popular concepts** (#39) — `mergeExtractions` used to concatenate every contributing source's full content into the page-generation prompt. Linear in source count; reliably blew past the LLM provider's context window once many sources discussed the same topic. New defensive cap (`LLMWIKI_PROMPT_BUDGET_CHARS`, default 200,000) gives every contributing source a fair share of the budget when the raw total would overflow, with a clear truncation marker. Typical workloads stay byte-identical.
+- **Body-derived `excess-inferred-paragraphs`** — the lint rule used to trust an LLM-estimated `inferredParagraphs` frontmatter field when present, falling back to body counting. The estimate was made before the page even existed and routinely disagreed with what the model actually produced. The rule now unconditionally counts uncited prose paragraphs in the rendered body, with Unicode-aware prose detection (`\p{L}`) so pages produced via `--lang Chinese` etc. are correctly counted. Legacy `inferredParagraphs` frontmatter values are intentionally ignored.
+
+### Changed
+
+- **`ProvenanceMetadata` is now a single shared interface** in `src/utils/types.ts` that both `ExtractedConcept` and `WikiFrontmatter` extend. Drops the duplicate private declaration that had drifted into `src/utils/markdown.ts`. JSON shapes serialised on disk and over the LLM tool boundary are byte-identical to before — pure refactor.
+- **`inferredParagraphs` is no longer written to frontmatter or sent to the LLM extractor**. The field has moved entirely to body-derived lint at lint time. Old on-disk pages with the field still parse — the loader just ignores the unrecognised key.
+- **`CompileResult.pages` now includes seed-page slugs** alongside concept-page slugs. Seed pages used to land on disk silently and stay absent from the result; downstream consumers (MCP, embeddings, programmatic callers) had no way to discover them without scanning `wiki/`. They're also threaded into `finalizeWiki` so `resolveLinks` and `updateEmbeddings` cover them.
+- **Lint helper dedupe** — `checkSchemaCrossLinks` (on-disk walker) now delegates to `checkPageCrossLinks` (per-page) so the `schema-cross-link-minimum` rule lives in exactly one place.
+
+### Test infrastructure
+
+- **`useIngestWorkspaces` and `useAimockLifecycle.findSystemPromptByUserMessage`** composables in `test/fixtures/` consolidate temp-workspace and aimock recording boilerplate that had drifted across multiple integration tests.
+- Tests grew from 480 (post-0.5.1) to 632 in this release.
+
+### Contributors
+
+Thanks to **@lllcccwww** for filing four high-quality bug reports back-to-back (#35, #36, #37, #39) — every one had a clear repro and pointed at the offending file:line, which made the fixes obvious. Also thanks to **@babysource** for asking about embedding configuration (#42) and **@ishan5ain** for volunteering to take on the read-only Web UI roadmap item (#38).
+
 ## [0.5.1] - 2026-04-27
 
 Patch release fixing a CLI startup crash that broke 0.5.0 for everyone installing via npm.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ Generated wiki content defaults to whatever language the model produces from the
 
 Unset preserves prior behaviour byte-for-byte.
 
+### Per-concept prompt budget
+
+When many sources contribute to the same compiled concept, `compile` enforces a per-concept character cap on the combined source content sent to the LLM so popular shared concepts don't blow past the model's context window. Each contributing source gets a fair share when truncation kicks in.
+
+- `LLMWIKI_PROMPT_BUDGET_CHARS` — character ceiling for the combined per-concept prompt. Defaults to `200000` (~50k tokens), which fits modern context windows with headroom. Raise it for larger-context models, lower it for local small-context models.
+
+A truncation warning prints to stderr when the cap fires so you know which concept hit the budget.
+
 ## Why not just RAG?
 
 RAG retrieves chunks at query time. Every question re-discovers the same relationships from scratch. Nothing accumulates.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ The OpenAI SDK defaults to a 10-minute per-request timeout, which can cut off lo
 
 Defaults: 10 minutes for `openai`, 30 minutes for `ollama` (local models commonly need more).
 
+### Output language
+
+Generated wiki content defaults to whatever language the model produces from the source material — typically English. Override with either:
+
+- `LLMWIKI_OUTPUT_LANG` — e.g. `zh-CN`, `Chinese`, `ja`, `Japanese`. Applies to every prompt the compile and query pipelines make.
+- `--lang <code>` on `llmwiki compile` and `llmwiki query` — same effect, scoped to one invocation. Wins over the env var.
+
+Unset preserves prior behaviour byte-for-byte.
+
 ## Why not just RAG?
 
 RAG retrieves chunks at query time. Every question re-discovers the same relationships from scratch. Nothing accumulates.
@@ -167,8 +176,10 @@ Pages include source attribution in frontmatter. Paragraphs are annotated with `
 | Command | What it does |
 |---------|-------------|
 | `llmwiki ingest <url\|file>` | Fetch a URL or copy a local file into `sources/` |
+| `llmwiki ingest-session <path>` | Import a Claude/Codex/Cursor session export (single file or whole directory) into `sources/` |
 | `llmwiki compile` | Incremental compile: extract concepts, generate wiki pages |
 | `llmwiki compile --review` | Write candidate pages to `.llmwiki/candidates/` instead of `wiki/` so you can review before they land |
+| `llmwiki compile --lang <code>` | Generate wiki content in the given language (e.g. `Chinese`, `ja`, `zh-CN`); also works on `query` |
 | `llmwiki review list` | List pending candidate pages |
 | `llmwiki review show <id>` | Print a candidate's title, summary, and body |
 | `llmwiki review approve <id>` | Promote a candidate into `wiki/` and refresh index/MOC/embeddings |
@@ -177,6 +188,7 @@ Pages include source attribution in frontmatter. Paragraphs are annotated with `
 | `llmwiki schema show` | Print the resolved schema for the current project |
 | `llmwiki query "question"` | Ask questions against your compiled wiki |
 | `llmwiki query "question" --save` | Answer and save the result as a wiki page |
+| `llmwiki export [--target <name>]` | Export the wiki to portable formats — `llms.txt`, `llms-full.txt`, JSON, JSON-LD, GraphML, Marp slides |
 | `llmwiki lint` | Check wiki quality (broken links, orphans, empty pages, low confidence, contradictions, etc.) |
 | `llmwiki watch` | Auto-recompile when `sources/` changes |
 | `llmwiki serve [--root <dir>]` | Start an MCP server exposing wiki tools to AI agents |
@@ -372,6 +384,9 @@ Karpathy describes an abstract pattern for turning raw data into compiled knowle
 Shipped in 0.6.0:
 
 - ✅ Export bundle (`llms.txt`, JSON, JSON-LD, GraphML, Marp slides)
+- ✅ Session-history adapters — `llmwiki ingest-session` for Claude, Codex, and Cursor exports
+- ✅ Configurable output language — `--lang <code>` and `LLMWIKI_OUTPUT_LANG`
+- ✅ Defensive per-concept prompt budget so popular shared concepts don't crash compile
 
 Shipped in 0.5.0:
 
@@ -397,10 +412,6 @@ Shipped in 0.2.0:
 - ✅ Larger-corpus query strategy (semantic search, embeddings)
 - ✅ Deeper Obsidian integration (tags, aliases, Map of Content)
 - ✅ MCP server for agent integration
-
-Next up:
-
-- Session-history adapters (Claude, Codex, Cursor exports)
 
 Future ideas (open to discussion):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-wiki-compiler",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-wiki-compiler",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-wiki-compiler",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "A knowledge compiler CLI — raw sources in, interlinked wiki out",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Cuts the 0.6.0 release covering ten merged PRs since 0.5.1.

## What's in 0.6.0

**New features**
- \`llmwiki ingest-session\` — Claude / Codex / Cursor session imports (#49)
- \`LLMWIKI_OUTPUT_LANG\` + \`--lang <code>\` — non-English wiki output (#46)
- \`compile --review\` provenance lint — citations checked before approval (#50)
- \`npm run fallow:ci\` — local fallow that mirrors CI's \`--changed-since\` scoping (#48)

**Bug fixes**
- Non-ASCII filename ingest no longer silently writes \`sources/.md\` (#35 / PR #44)
- Same-basename sources no longer overwrite each other silently (#36 / PR #45)
- Compile no longer crashes on popular concepts that pull in many sources (#39 / PR #47)

**Internal cleanup (post-merge audit)**
- Shared \`ProvenanceMetadata\` interface; drops drift hazard between \`ExtractedConcept\` and \`WikiFrontmatter\` (#51)
- \`inferredParagraphs\` derived from rendered body instead of an unreliable LLM extraction-time estimate (#52)
- Lint helper dedupe + seed pages surfaced on \`CompileResult.pages\` (#53)

Test count grew from 480 (post-0.5.1) to 632.

Full release notes in CHANGELOG.md.

## Pre-publish checklist

- [x] \`CHANGELOG.md\` entry
- [x] \`package.json\` version bumped to 0.6.0
- [x] \`package-lock.json\` synced (root \`version\` field updated)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` succeeds
- [x] \`npm test\` — 632 pass / 3 skipped (smoke), no regressions
- [x] \`npm run fallow:ci\` — 0 issues above threshold

## After merge

1. \`git tag -a v0.6.0 -m "Release 0.6.0"\`
2. \`git push origin v0.6.0\`
3. \`gh release create v0.6.0\` (auto-fills from CHANGELOG)
4. \`! npm publish --ignore-scripts\`