### PR TITLE
feat: added GitHub Copilot provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,35 @@ export OLLAMA_HOST=http://ollama_host:11434/v1
 export OLLAMA_EMBEDDINGS_HOST=http://ollama_host:11435/v1
 ```
 
+### GitHub Copilot
+
+Uses the GitHub Copilot API (`https://api.githubcopilot.com`), an
+OpenAI-compatible endpoint available to Copilot subscribers. Requires a GitHub
+OAuth token with the `copilot` scope — **classic PATs are not supported**.
+
+First, ensure your `gh` CLI token has the required scope:
+
+```bash
+gh auth refresh --scopes copilot
+```
+
+Then run:
+
+```bash
+export LLMWIKI_PROVIDER=copilot
+export GITHUB_TOKEN=$(gh auth token)  # OAuth token required; PATs will not work
+export LLMWIKI_MODEL=gpt-4o           # optional; gpt-4o is the default
+```
+
+Available models (names use dots, not dashes): `gpt-4o`, `gpt-4o-mini`,
+`claude-sonnet-4.5`, `claude-sonnet-4.6`, `claude-opus-4.5`, `gemini-2.5-pro`,
+and others — availability depends on your Copilot plan.
+
+**Embeddings:** The GitHub Copilot API does not expose an embeddings endpoint.
+Semantic search (used by `llmwiki query` with chunked retrieval) will fall back
+to full-index selection without embeddings. For embedding-dependent workflows,
+switch to the `openai` provider and provide `OPENAI_API_KEY`.
+
 ### Request timeouts
 
 The OpenAI SDK defaults to a 10-minute per-request timeout, which can cut off long compile-time completions on slower local models. Override per provider:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -260,6 +260,7 @@ const PROVIDER_KEY_VARS: Record<string, string | null> = {
   openai: "OPENAI_API_KEY",
   ollama: null,
   minimax: "MINIMAX_API_KEY",
+  copilot: "GITHUB_TOKEN",
 };
 
 /** Exit with a helpful message if the selected provider's API key is missing. */

--- a/src/mcp/provider-check.ts
+++ b/src/mcp/provider-check.ts
@@ -16,6 +16,7 @@ const PROVIDER_KEY_VARS: Record<string, string | null> = {
   openai: "OPENAI_API_KEY",
   ollama: null,
   minimax: "MINIMAX_API_KEY",
+  copilot: "GITHUB_TOKEN",
 };
 
 /**

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -1,0 +1,35 @@
+/**
+ * GitHub Copilot LLM provider implementation.
+ *
+ * Uses the GitHub Copilot API (https://api.githubcopilot.com), which exposes
+ * an OpenAI-compatible chat endpoint. Requires a GitHub OAuth token with
+ * Copilot access — use `gh auth token` to obtain one. Classic PATs are NOT
+ * supported by this endpoint.
+ *
+ * Note: GitHub Copilot does not expose an embeddings API. Calling embed() will
+ * throw with a helpful message. For workflows that require semantic search
+ * (query with chunked retrieval), use the openai provider with OPENAI_API_KEY.
+ */
+
+import { OpenAIProvider } from "./openai.js";
+import { COPILOT_BASE_URL } from "../utils/constants.js";
+
+/** GitHub Copilot-backed LLM provider using the OpenAI-compatible endpoint. */
+export class CopilotProvider extends OpenAIProvider {
+  constructor(model: string, apiKey: string) {
+    super(model, { baseURL: COPILOT_BASE_URL, apiKey });
+  }
+
+  /**
+   * GitHub Copilot has no native embeddings API.
+   * Throws an informative error directing the user to an alternative.
+   */
+  override async embed(_text: string): Promise<number[]> {
+    throw new Error(
+      "GitHub Copilot does not support embeddings.\n" +
+      "  For semantic search (llmwiki query), switch to the OpenAI provider:\n" +
+      "    export LLMWIKI_PROVIDER=openai\n" +
+      "    export OPENAI_API_KEY=sk-...",
+    );
+  }
+}

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -131,6 +131,7 @@ export class OpenAIProvider implements LLMProvider {
       max_tokens: maxTokens,
       messages: [{ role: "system", content: system }, ...messages],
       tools: openaiTools,
+      tool_choice: "required",
     });
 
     const toolCalls = response.choices[0]?.message?.tool_calls;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -48,10 +48,14 @@ export const PROVIDER_MODELS: Record<string, string> = {
   openai: "gpt-4o",
   ollama: "llama3.1",
   minimax: "MiniMax-M2.7",
+  copilot: "gpt-4o",
 };
 
 /** Default Ollama API base URL. */
 export const OLLAMA_DEFAULT_HOST = "http://localhost:11434/v1";
+
+/** GitHub Copilot API base URL (OpenAI-compatible, requires OAuth token). */
+export const COPILOT_BASE_URL = "https://api.githubcopilot.com";
 
 /**
  * Default request timeout for cloud OpenAI-compatible providers (10 minutes).

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -11,6 +11,7 @@ import { AnthropicProvider } from "../providers/anthropic.js";
 import { OpenAIProvider } from "../providers/openai.js";
 import { OllamaProvider } from "../providers/ollama.js";
 import { MiniMaxProvider } from "../providers/minimax.js";
+import { CopilotProvider } from "../providers/copilot.js";
 import {
   resolveAnthropicAuthFromEnv,
   resolveAnthropicBaseURLFromEnv,
@@ -49,7 +50,7 @@ export interface LLMProvider {
   embed(text: string): Promise<number[]>;
 }
 
-const SUPPORTED_PROVIDERS: ReadonlySet<string> = new Set(["anthropic", "openai", "ollama", "minimax"]);
+const SUPPORTED_PROVIDERS: ReadonlySet<string> = new Set(["anthropic", "openai", "ollama", "minimax", "copilot"]);
 
 /**
  * Factory that returns the appropriate LLMProvider based on env vars.
@@ -78,6 +79,8 @@ export function getProvider(): LLMProvider {
       });
     case "minimax":
       return getMiniMaxProvider();
+    case "copilot":
+      return getCopilotProvider();
     default:
       throw new Error(`Unhandled provider: ${providerName}`);
   }
@@ -88,7 +91,7 @@ function readOptionalEnv(name: string): string | undefined {
   return value ? value : undefined;
 }
 
-function getModelForProvider(providerName: "openai" | "ollama" | "minimax"): string {
+function getModelForProvider(providerName: "openai" | "ollama" | "minimax" | "copilot"): string {
   return process.env.LLMWIKI_MODEL ?? PROVIDER_MODELS[providerName];
 }
 
@@ -101,6 +104,18 @@ function getMiniMaxProvider(): MiniMaxProvider {
     );
   }
   return new MiniMaxProvider(getModelForProvider("minimax"), apiKey);
+}
+
+function getCopilotProvider(): CopilotProvider {
+  const apiKey = process.env.GITHUB_TOKEN;
+  if (!apiKey) {
+    throw new Error(
+      "GitHub Copilot provider requires GITHUB_TOKEN environment variable.\n" +
+      "  Set it with: export GITHUB_TOKEN=ghp_...\n" +
+      "  The token must belong to a GitHub account with an active Copilot subscription.",
+    );
+  }
+  return new CopilotProvider(getModelForProvider("copilot"), apiKey);
 }
 
 function getAnthropicProvider(): AnthropicProvider {

--- a/test/provider-copilot.test.ts
+++ b/test/provider-copilot.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for the GitHub Copilot LLM provider.
+ * Covers constructor behaviour, factory resolution, and the embed() stub.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { CopilotProvider } from "../src/providers/copilot.js";
+import { getProvider } from "../src/utils/provider.js";
+import { COPILOT_BASE_URL, PROVIDER_MODELS } from "../src/utils/constants.js";
+
+describe("CopilotProvider", () => {
+  it("constructs without throwing when given a token and model", () => {
+    expect(() => new CopilotProvider("gpt-4o", "ghp_test")).not.toThrow();
+  });
+
+  it("uses the Copilot base URL", () => {
+    const provider = new CopilotProvider("gpt-4o", "ghp_test");
+    const clientBaseURL = Reflect.get(Reflect.get(provider, "client"), "baseURL") as string;
+    expect(clientBaseURL).toBe(COPILOT_BASE_URL);
+  });
+
+  it("throws on embed() with a helpful message", async () => {
+    const provider = new CopilotProvider("gpt-4o", "ghp_test");
+    await expect(provider.embed("hello")).rejects.toThrow(
+      "GitHub Copilot does not support embeddings",
+    );
+  });
+
+  it("embed() error message mentions switching to the openai provider", async () => {
+    const provider = new CopilotProvider("gpt-4o", "ghp_test");
+    await expect(provider.embed("hello")).rejects.toThrow("LLMWIKI_PROVIDER=openai");
+  });
+});
+
+describe("getProvider with copilot", () => {
+  afterEach(() => {
+    delete process.env.LLMWIKI_PROVIDER;
+    delete process.env.LLMWIKI_MODEL;
+    delete process.env.GITHUB_TOKEN;
+  });
+
+  it("returns CopilotProvider when LLMWIKI_PROVIDER=copilot", () => {
+    process.env.LLMWIKI_PROVIDER = "copilot";
+    process.env.GITHUB_TOKEN = "ghp_test";
+    const provider = getProvider();
+    expect(provider).toBeInstanceOf(CopilotProvider);
+  });
+
+  it("throws when GITHUB_TOKEN is absent for copilot provider", () => {
+    process.env.LLMWIKI_PROVIDER = "copilot";
+    delete process.env.GITHUB_TOKEN;
+    expect(() => getProvider()).toThrow("GITHUB_TOKEN");
+  });
+
+  it("uses the default copilot model (gpt-4o) when LLMWIKI_MODEL is unset", () => {
+    process.env.LLMWIKI_PROVIDER = "copilot";
+    process.env.GITHUB_TOKEN = "ghp_test";
+    delete process.env.LLMWIKI_MODEL;
+    const provider = getProvider();
+    expect(Reflect.get(provider, "model")).toBe(PROVIDER_MODELS.copilot);
+  });
+
+  it("respects LLMWIKI_MODEL override for copilot provider", () => {
+    process.env.LLMWIKI_PROVIDER = "copilot";
+    process.env.GITHUB_TOKEN = "ghp_test";
+    process.env.LLMWIKI_MODEL = "claude-sonnet-4-5";
+    const provider = getProvider();
+    expect(Reflect.get(provider, "model")).toBe("claude-sonnet-4-5");
+  });
+});


### PR DESCRIPTION
Adds `copilot` as a new LLM provider for users with a GitHub Copilot subscription.
 
 ### Changes
 
 1. **`src/providers/copilot.ts`** — new provider extending `OpenAIProvider` targeting 
`https://api.githubcopilot.com`
 2. **`src/providers/openai.ts`** — added `tool_choice: "required"` to `toolCall()` so Claude models don't skip 
tool calls and return empty results
 3. **`src/utils/provider.ts`, `src/cli.ts`, `src/mcp/provider-check.ts`** — wired `copilot` into all three 
provider registries
 4. **`test/provider-copilot.test.ts`** — 7 unit tests
 5. **`README.md`** — setup docs
 
 ### Setup
 
 ```bash
 gh auth refresh --scopes copilot
 export LLMWIKI_PROVIDER=copilot
 export GITHUB_TOKEN=$(gh auth token)
 export LLMWIKI_MODEL=claude-sonnet-4.6  # optional; gpt-4o is the default
```

 Note: The Copilot API has no embeddings endpoint — compile and query work normally but semantic chunked retrieval
 is unavailable.

Preview
<img width="658" height="131" alt="Screenshot 2026-05-10 at 11 47 13 AM" src="https://github.com/user-attachments/assets/79dd0266-1a89-4b8e-9af0-d7aa9a405786" />

<img width="852" height="752" alt="Screenshot 2026-05-10 at 11 41 34 AM" src="https://github.com/user-attachments/assets/c769c2eb-e98f-40a7-ace7-acf361d66572" />