### PR TITLE
feat(lint): persist last-run summary to .llmwiki/last-lint.json

### DIFF
--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -7,6 +7,7 @@
  */
 
 import { lint } from "../linter/index.js";
+import { writeLintCache } from "../linter/cache.js";
 import * as output from "../utils/output.js";
 import type { LintResult } from "../linter/types.js";
 import { loadSchema } from "../schema/index.js";
@@ -57,6 +58,8 @@ export default async function lintCommand(): Promise<void> {
     output.info(`${summary.info} info`),
   ].join(", ");
   output.status("*", summaryLine);
+
+  await writeLintCache(process.cwd(), summary);
 
   if (summary.errors > 0) {
     process.exit(1);

--- a/src/linter/cache.ts
+++ b/src/linter/cache.ts
@@ -25,6 +25,13 @@ export interface LintCacheEntry {
 }
 
 /**
+ * The exact ISO-8601 shape `writeLintCache` produces and `readLintCache` accepts.
+ * Exported so tests can assert against the same regex the validator enforces and
+ * never drift from the documented contract.
+ */
+export const LINT_CACHE_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+/**
  * Persist a lint summary to `.llmwiki/last-lint.json` after a completed run.
  * Creates the `.llmwiki/` directory if missing. Overwrites any prior entry so
  * the cache reflects the most recent run, including zero-issue runs.
@@ -61,13 +68,27 @@ export async function readLintCache(root: string): Promise<LintCacheEntry | null
   return { warnings: parsed.warnings, errors: parsed.errors, at: parsed.at };
 }
 
-/** Type guard for the cache entry shape — rejects partial or wrongly-typed JSON. */
+/** True for finite non-negative integers, including zero. NaN and Infinity fail Number.isInteger. */
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+/**
+ * Strict type guard for the persisted cache entry.
+ *
+ * Counts must be finite non-negative integers (the writer only ever persists
+ * `LintSummary` severity counts, which originate from a length on an array, so
+ * anything else means the file was hand-edited or corrupted). The timestamp
+ * must match the exact ISO-8601 shape the writer produces, otherwise downstream
+ * consumers risk surfacing values like "2026-01-01" as full timestamps.
+ */
 function isValidEntry(value: unknown): value is LintCacheEntry {
   if (typeof value !== "object" || value === null) return false;
   const candidate = value as Record<string, unknown>;
   return (
-    typeof candidate.warnings === "number" &&
-    typeof candidate.errors === "number" &&
-    typeof candidate.at === "string"
+    isNonNegativeInteger(candidate.warnings) &&
+    isNonNegativeInteger(candidate.errors) &&
+    typeof candidate.at === "string" &&
+    LINT_CACHE_TIMESTAMP_PATTERN.test(candidate.at)
   );
 }

--- a/src/linter/cache.ts
+++ b/src/linter/cache.ts
@@ -1,0 +1,73 @@
+/**
+ * Persistent cache of the most recent `llmwiki lint` run.
+ *
+ * Written by the lint command after a completed run, before any non-zero exit
+ * for lint findings, so the cache always reflects the run the user just saw.
+ * Crashed or partial runs leave the prior cache untouched.
+ *
+ * Consumers (e.g., the upcoming viewer's /api/health endpoint) read the cache
+ * to surface lint counts without re-running lint per request. A missing or
+ * malformed cache reads as null, which means "lint has not been run yet."
+ */
+
+import { mkdir, readFile } from "fs/promises";
+import path from "path";
+import { atomicWrite } from "../utils/markdown.js";
+import { LLMWIKI_DIR, LAST_LINT_FILE } from "../utils/constants.js";
+import type { LintSummary } from "./types.js";
+
+/** One persisted lint summary. Shape is part of the public viewer-cache contract. */
+export interface LintCacheEntry {
+  warnings: number;
+  errors: number;
+  /** ISO-8601 timestamp of the run that produced these counts. */
+  at: string;
+}
+
+/**
+ * Persist a lint summary to `.llmwiki/last-lint.json` after a completed run.
+ * Creates the `.llmwiki/` directory if missing. Overwrites any prior entry so
+ * the cache reflects the most recent run, including zero-issue runs.
+ */
+export async function writeLintCache(root: string, summary: LintSummary): Promise<void> {
+  await mkdir(path.join(root, LLMWIKI_DIR), { recursive: true });
+  const entry: LintCacheEntry = {
+    warnings: summary.warnings,
+    errors: summary.errors,
+    at: new Date().toISOString(),
+  };
+  await atomicWrite(path.join(root, LAST_LINT_FILE), `${JSON.stringify(entry, null, 2)}\n`);
+}
+
+/**
+ * Read the cached lint summary, returning null for missing or malformed files.
+ * Validation is strict: every field must have its expected type, otherwise the
+ * cache is treated as absent so callers do not surface garbage counts.
+ */
+export async function readLintCache(root: string): Promise<LintCacheEntry | null> {
+  let raw: string;
+  try {
+    raw = await readFile(path.join(root, LAST_LINT_FILE), "utf-8");
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!isValidEntry(parsed)) return null;
+  return { warnings: parsed.warnings, errors: parsed.errors, at: parsed.at };
+}
+
+/** Type guard for the cache entry shape — rejects partial or wrongly-typed JSON. */
+function isValidEntry(value: unknown): value is LintCacheEntry {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.warnings === "number" &&
+    typeof candidate.errors === "number" &&
+    typeof candidate.at === "string"
+  );
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -81,6 +81,7 @@ export const LOCK_FILE = ".llmwiki/lock";
 export const INDEX_FILE = "wiki/index.md";
 export const MOC_FILE = "wiki/MOC.md";
 export const EMBEDDINGS_FILE = ".llmwiki/embeddings.json";
+export const LAST_LINT_FILE = ".llmwiki/last-lint.json";
 
 /** Supported image file extensions for vision-based ingest. */
 export const IMAGE_EXTENSIONS = new Set([".jpg", ".jpeg", ".png", ".gif", ".webp"]);

--- a/test/lint-cache-integration.test.ts
+++ b/test/lint-cache-integration.test.ts
@@ -13,8 +13,7 @@ import { runCLI, expectCLIExit, expectCLIFailure } from "./fixtures/run-cli.js";
 import { makeLintTempRoot } from "./fixtures/lint-temp-root.js";
 import type { LintTempRoot } from "./fixtures/lint-temp-root.js";
 import { LAST_LINT_FILE } from "../src/utils/constants.js";
-
-const ISO_8601_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+import { LINT_CACHE_TIMESTAMP_PATTERN } from "../src/linter/cache.js";
 
 let fx: LintTempRoot;
 
@@ -51,7 +50,7 @@ describe("`llmwiki lint` cache side effect", () => {
     const cached = await readCache();
     expect(cached.errors).toBe(0);
     expect(cached.warnings).toBe(0);
-    expect(cached.at).toMatch(ISO_8601_PATTERN);
+    expect(cached.at).toMatch(LINT_CACHE_TIMESTAMP_PATTERN);
   }, 30_000);
 
   it("writes the cache before exiting non-zero when lint finds errors", async () => {
@@ -66,7 +65,7 @@ describe("`llmwiki lint` cache side effect", () => {
     expect(await cacheExists()).toBe(true);
     const cached = await readCache();
     expect((cached.errors as number) >= 1).toBe(true);
-    expect(cached.at).toMatch(ISO_8601_PATTERN);
+    expect(cached.at).toMatch(LINT_CACHE_TIMESTAMP_PATTERN);
   }, 30_000);
 
   it("creates .llmwiki/ recursively even when it did not exist", async () => {

--- a/test/lint-cache-integration.test.ts
+++ b/test/lint-cache-integration.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Subprocess-level integration tests for the lint cache side effect.
+ *
+ * Exercises the actual `llmwiki lint` CLI to confirm `.llmwiki/last-lint.json`
+ * is written after a completed run, even when lint exits non-zero for findings,
+ * and that the file lands at the documented path with the documented shape.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { rm, readFile, stat } from "fs/promises";
+import path from "path";
+import { runCLI, expectCLIExit, expectCLIFailure } from "./fixtures/run-cli.js";
+import { makeLintTempRoot } from "./fixtures/lint-temp-root.js";
+import type { LintTempRoot } from "./fixtures/lint-temp-root.js";
+import { LAST_LINT_FILE } from "../src/utils/constants.js";
+
+const ISO_8601_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+let fx: LintTempRoot;
+
+beforeEach(async () => {
+  fx = await makeLintTempRoot("lint-cache-int");
+});
+
+afterEach(async () => {
+  await rm(fx.root, { recursive: true, force: true });
+});
+
+async function readCache(): Promise<Record<string, unknown>> {
+  const raw = await readFile(path.join(fx.root, LAST_LINT_FILE), "utf-8");
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+async function cacheExists(): Promise<boolean> {
+  try {
+    await stat(path.join(fx.root, LAST_LINT_FILE));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("`llmwiki lint` cache side effect", () => {
+  it("writes the cache on a clean wiki and exits 0", async () => {
+    const longBody = "This sentence is long enough to clear the empty-page threshold by a comfortable margin.";
+    await fx.writeConceptPage("clean", `---\ntitle: Clean\nsummary: All good.\n---\n${longBody}`);
+
+    const result = await runCLI(["lint"], fx.root);
+    expectCLIExit(result, 0);
+
+    const cached = await readCache();
+    expect(cached.errors).toBe(0);
+    expect(cached.warnings).toBe(0);
+    expect(cached.at).toMatch(ISO_8601_PATTERN);
+  }, 30_000);
+
+  it("writes the cache before exiting non-zero when lint finds errors", async () => {
+    await fx.writeConceptPage(
+      "broken",
+      "---\ntitle: Broken\nsummary: Broken link.\n---\nSee [[Ghost Page]] for details, which is plenty long.",
+    );
+
+    const result = await runCLI(["lint"], fx.root);
+    expectCLIFailure(result);
+
+    expect(await cacheExists()).toBe(true);
+    const cached = await readCache();
+    expect((cached.errors as number) >= 1).toBe(true);
+    expect(cached.at).toMatch(ISO_8601_PATTERN);
+  }, 30_000);
+
+  it("creates .llmwiki/ recursively even when it did not exist", async () => {
+    const result = await runCLI(["lint"], fx.root);
+    expectCLIExit(result, 0);
+    expect(await cacheExists()).toBe(true);
+  }, 30_000);
+});

--- a/test/lint-cache.test.ts
+++ b/test/lint-cache.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for the lint cache (`.llmwiki/last-lint.json`).
+ *
+ * Covers both the writer (called by `llmwiki lint` after every completed run)
+ * and the reader (consumed by the upcoming viewer's /api/health endpoint).
+ * Verifies the on-disk shape, ISO-timestamp contract, missing-cache handling,
+ * and malformed-cache rejection so consumers never see partial counts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, rm, readFile, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
+import { writeLintCache, readLintCache } from "../src/linter/cache.js";
+import type { LintCacheEntry } from "../src/linter/cache.js";
+import { LAST_LINT_FILE, LLMWIKI_DIR } from "../src/utils/constants.js";
+import type { LintSummary } from "../src/linter/types.js";
+
+const ISO_8601_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(path.join(os.tmpdir(), "lint-cache-"));
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+function makeSummary(errors: number, warnings: number): LintSummary {
+  return { errors, warnings, info: 0, results: [] };
+}
+
+async function readRawCache(): Promise<string> {
+  return readFile(path.join(tmpDir, LAST_LINT_FILE), "utf-8");
+}
+
+async function writeRawCache(contents: string): Promise<void> {
+  await mkdir(path.join(tmpDir, LLMWIKI_DIR), { recursive: true });
+  await writeFile(path.join(tmpDir, LAST_LINT_FILE), contents, "utf-8");
+}
+
+describe("writeLintCache", () => {
+  it("creates .llmwiki/ recursively when the directory does not exist", async () => {
+    await writeLintCache(tmpDir, makeSummary(0, 0));
+    expect((await readRawCache()).length).toBeGreaterThan(0);
+  });
+
+  it("persists warnings, errors, and an ISO-8601 timestamp", async () => {
+    await writeLintCache(tmpDir, makeSummary(3, 5));
+    const parsed = JSON.parse(await readRawCache()) as Record<string, unknown>;
+    expect(parsed.errors).toBe(3);
+    expect(parsed.warnings).toBe(5);
+    expect(parsed.at).toMatch(ISO_8601_PATTERN);
+  });
+
+  it("overwrites a prior cache so zero-issue runs are reflected", async () => {
+    await writeLintCache(tmpDir, makeSummary(5, 5));
+    await writeLintCache(tmpDir, makeSummary(0, 0));
+    const parsed = JSON.parse(await readRawCache()) as Record<string, unknown>;
+    expect(parsed.errors).toBe(0);
+    expect(parsed.warnings).toBe(0);
+  });
+});
+
+describe("readLintCache", () => {
+  it("returns null when no cache file exists yet", async () => {
+    expect(await readLintCache(tmpDir)).toBeNull();
+  });
+
+  it("round-trips a freshly written cache", async () => {
+    await writeLintCache(tmpDir, makeSummary(2, 4));
+    const entry: LintCacheEntry | null = await readLintCache(tmpDir);
+    expect(entry?.errors).toBe(2);
+    expect(entry?.warnings).toBe(4);
+    expect(entry?.at).toMatch(ISO_8601_PATTERN);
+  });
+
+  it("returns null when the cache file is not valid JSON", async () => {
+    await writeRawCache("{not json");
+    expect(await readLintCache(tmpDir)).toBeNull();
+  });
+
+  it("returns null when required fields have the wrong type", async () => {
+    const bad = JSON.stringify({ warnings: "many", errors: 0, at: "2026-01-01T00:00:00.000Z" });
+    await writeRawCache(bad);
+    expect(await readLintCache(tmpDir)).toBeNull();
+  });
+
+  it("returns null when required fields are missing", async () => {
+    await writeRawCache(JSON.stringify({ warnings: 1, errors: 1 }));
+    expect(await readLintCache(tmpDir)).toBeNull();
+  });
+});

--- a/test/lint-cache.test.ts
+++ b/test/lint-cache.test.ts
@@ -11,12 +11,14 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtemp, mkdir, rm, readFile, writeFile } from "fs/promises";
 import os from "os";
 import path from "path";
-import { writeLintCache, readLintCache } from "../src/linter/cache.js";
+import {
+  writeLintCache,
+  readLintCache,
+  LINT_CACHE_TIMESTAMP_PATTERN,
+} from "../src/linter/cache.js";
 import type { LintCacheEntry } from "../src/linter/cache.js";
 import { LAST_LINT_FILE, LLMWIKI_DIR } from "../src/utils/constants.js";
 import type { LintSummary } from "../src/linter/types.js";
-
-const ISO_8601_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
 let tmpDir: string;
 
@@ -52,7 +54,7 @@ describe("writeLintCache", () => {
     const parsed = JSON.parse(await readRawCache()) as Record<string, unknown>;
     expect(parsed.errors).toBe(3);
     expect(parsed.warnings).toBe(5);
-    expect(parsed.at).toMatch(ISO_8601_PATTERN);
+    expect(parsed.at).toMatch(LINT_CACHE_TIMESTAMP_PATTERN);
   });
 
   it("overwrites a prior cache so zero-issue runs are reflected", async () => {
@@ -74,7 +76,7 @@ describe("readLintCache", () => {
     const entry: LintCacheEntry | null = await readLintCache(tmpDir);
     expect(entry?.errors).toBe(2);
     expect(entry?.warnings).toBe(4);
-    expect(entry?.at).toMatch(ISO_8601_PATTERN);
+    expect(entry?.at).toMatch(LINT_CACHE_TIMESTAMP_PATTERN);
   });
 
   it("returns null when the cache file is not valid JSON", async () => {
@@ -90,6 +92,31 @@ describe("readLintCache", () => {
 
   it("returns null when required fields are missing", async () => {
     await writeRawCache(JSON.stringify({ warnings: 1, errors: 1 }));
+    expect(await readLintCache(tmpDir)).toBeNull();
+  });
+
+  it("rejects negative warning or error counts", async () => {
+    const validAt = "2026-05-11T00:00:00.000Z";
+    await writeRawCache(JSON.stringify({ warnings: -1, errors: 0, at: validAt }));
+    expect(await readLintCache(tmpDir)).toBeNull();
+    await writeRawCache(JSON.stringify({ warnings: 0, errors: -5, at: validAt }));
+    expect(await readLintCache(tmpDir)).toBeNull();
+  });
+
+  it("rejects fractional counts", async () => {
+    const validAt = "2026-05-11T00:00:00.000Z";
+    await writeRawCache(JSON.stringify({ warnings: 1.5, errors: 0, at: validAt }));
+    expect(await readLintCache(tmpDir)).toBeNull();
+    await writeRawCache(JSON.stringify({ warnings: 0, errors: 0.1, at: validAt }));
+    expect(await readLintCache(tmpDir)).toBeNull();
+  });
+
+  it("rejects timestamps that do not match the ISO-8601 contract", async () => {
+    await writeRawCache(JSON.stringify({ warnings: 0, errors: 0, at: "2026-05-11" }));
+    expect(await readLintCache(tmpDir)).toBeNull();
+    await writeRawCache(JSON.stringify({ warnings: 0, errors: 0, at: "" }));
+    expect(await readLintCache(tmpDir)).toBeNull();
+    await writeRawCache(JSON.stringify({ warnings: 0, errors: 0, at: "2026-05-11T00:00:00Z" }));
     expect(await readLintCache(tmpDir)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Adds a side effect to `llmwiki lint` that writes `.llmwiki/last-lint.json` after every completed run — warning count, error count, and ISO-8601 completion timestamp.
- Lands as the prerequisite for the upcoming viewer's `/api/health` endpoint so that surface can report lint counts without re-running lint per request.
- Writes after the lint orchestrator completes successfully and before any non-zero exit for findings; crashed or partial runs leave any prior cache untouched.

## Cache contract

- File path: `.llmwiki/last-lint.json` (recursive mkdir if the directory is missing).
- Shape: `{ "warnings": number, "errors": number, "at": string }` where counts are finite non-negative integers and `at` matches `/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/`.
- `readLintCache(root)` returns `null` for any missing, malformed, or out-of-contract file so consumers never see garbage counts.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [x] `npm test` — 654 passed, 3 skipped
- [x] `npx fallow` — no dead code, no duplication, maintainability 91.8
- [x] Targeted unit tests: write/read round-trip, missing cache, malformed JSON, wrong-type fields, missing fields, negative counts, fractional counts, non-ISO timestamps
- [x] Subprocess integration tests: clean wiki exits 0 with cache written, error-finding wiki exits non-zero with cache written, recursive `.llmwiki/` creation on a fresh project
