### PR TITLE
Fix broken wikilink detection for pipe alias syntax (`[[slug|Display Text]]`)

### DIFF
--- a/src/linter/rules.ts
+++ b/src/linter/rules.ts
@@ -119,7 +119,8 @@ export async function checkBrokenWikilinks(root: string): Promise<LintResult[]> 
 
   for (const page of pages) {
     for (const { captured, line } of findMatchesInContent(page.content, WIKILINK_PATTERN)) {
-      const linkSlug = slugify(captured);
+      const linkTarget = captured.split("|")[0].trim();
+      const linkSlug = slugify(linkTarget);
       if (!existingSlugs.has(linkSlug)) {
         results.push({
           rule: "broken-wikilink",

--- a/test/lint.test.ts
+++ b/test/lint.test.ts
@@ -69,6 +69,23 @@ describe("checkBrokenWikilinks", () => {
     expect(results).toHaveLength(1);
     expect(results[0].line).toBe(6);
   });
+
+  it("resolves wikilinks using pipe alias syntax [[slug|Display Text]]", async () => {
+    await writeConcept("target-page", "---\ntitle: Target Page\n---\nTarget content.");
+    await writeConcept("source-page", "---\ntitle: Source Page\n---\nSee [[target-page|Custom Label]] for details.");
+
+    const results = await checkBrokenWikilinks(tmpDir);
+    expect(results).toHaveLength(0);
+  });
+
+  it("reports broken wikilink when pipe alias target does not exist", async () => {
+    await writeConcept("source-page", "---\ntitle: Source Page\n---\nSee [[missing-page|Custom Label]] for details.");
+
+    const results = await checkBrokenWikilinks(tmpDir);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe("broken-wikilink");
+    expect(results[0].message).toContain("missing-page|Custom Label");
+  });
 });
 
 describe("checkOrphanedPages", () => {


### PR DESCRIPTION
## What

The linter incorrectly flagged wikilinks using pipe alias syntax as broken. A link like `[[time-complexity|Time Complexity]]` was passing the full string `time-complexity|Time Complexity` to `slugify()`, which stripped the `|` and concatenated both sides into `time-complexitytime-complexity` — a slug that never matches any file.

The fix extracts only the target portion (before the `|`) before slugifying, matching how the syntax is intended to work.

## Why

Pipe alias syntax is standard wikilink convention for showing a display label different from the page slug. The linter should resolve the link target, not the label.

## Changes

- `src/linter/rules.ts`: split on `|` and slugify only the target before checking against existing page slugs
- `test/lint.test.ts`: two new cases in `checkBrokenWikilinks` — valid pipe alias resolves without error; broken pipe alias reports the full original wikilink in the error message

## How to test

```bash
llmwiki lint
```

Before this fix, any wiki with `[[slug|Display Text]]` wikilinks would produce false positive broken-wikilink errors even when the target page exists (see screenshot). After the fix, those links resolve correctly.

<img width="1364" height="946" alt="before-fix-lint-output" src="https://github.com/user-attachments/assets/f797ac1e-8bfd-46d4-b69a-3504b83d48d2" />

## Test plan

- `npx tsc --noEmit` — clean ✓
- `npm run build` — clean ✓
- `npm test` — 852 passed, 3 pre-existing skips, 0 failed ✓
- `npx fallow` — exit 0, no dead code, no duplication ✓
