### PR TITLE
[codex] Polish viewer graph navigation

### DIFF
--- a/src/viewer/assets/index.html
+++ b/src/viewer/assets/index.html
@@ -23,10 +23,10 @@
       </div>
       <a
         class="github-link"
-        href="https://github.com/atomicmemory/llm-wiki-compiler"
+        href="https://github.com/atomicstrata/llm-wiki-compiler"
         target="_blank"
         rel="noopener noreferrer"
-        aria-label="Open llm-wiki-compiler on GitHub"
+        aria-label="Open llm-wiki-compiler on GitHub, 1.3k stars"
       >
         <svg class="github-mark" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
           <path
@@ -34,6 +34,7 @@
           />
         </svg>
         <span>GitHub</span>
+        <span class="github-stars" aria-hidden="true">★ 1.3k</span>
       </a>
     </header>
     <div class="app-layout">

--- a/src/viewer/assets/viewer-sidebar.js
+++ b/src/viewer/assets/viewer-sidebar.js
@@ -1,9 +1,9 @@
 /**
  * llmwiki viewer — sidebar renderer.
  *
- * Renders concept pages grouped by frontmatter `kind` (defaulting to
- * "concept" when absent — spec line 347), then a "Saved Queries"
- * group, then the standing "Health" entry. Groups use native
+ * Renders the standing project links first, then concept pages grouped
+ * by frontmatter `kind` (defaulting to "concept" when absent — spec
+ * line 347), then a "Saved Queries" group. Groups use native
  * `<details><summary>` so keyboard users get Enter/Space collapse for
  * free without bespoke ARIA wiring.
  *
@@ -21,6 +21,7 @@ export function renderSidebar(pages) {
   const sidebar = document.querySelector(SIDEBAR_SELECTOR);
   if (!sidebar) return;
   sidebar.innerHTML = "";
+  sidebar.appendChild(buildProjectSection());
   const concepts = pages.filter((p) => p.pageDirectory === "concepts");
   const queries = pages.filter((p) => p.pageDirectory === "queries");
   const conceptGroups = groupConceptsByKind(concepts);
@@ -36,7 +37,6 @@ export function renderSidebar(pages) {
     empty.textContent = "No pages yet — run `llmwiki compile`.";
     sidebar.appendChild(empty);
   }
-  sidebar.appendChild(buildProjectSection());
   markActive();
 }
 

--- a/src/viewer/assets/viewer.css
+++ b/src/viewer/assets/viewer.css
@@ -104,7 +104,8 @@ a:hover, a:focus-visible { text-decoration: underline; }
   fill: currentColor;
 }
 .github-stars {
-  font-size: 1.05em;
+  font-size: 0.82rem;
+  font-weight: 500;
   font-variant-numeric: tabular-nums;
 }
 
@@ -314,7 +315,14 @@ a:hover, a:focus-visible { text-decoration: underline; }
 }
 
 /* Graph pane */
-.graph-pane { padding: 0; overflow: hidden; position: relative; }
+.graph-pane {
+  width: 100%;
+  height: calc(100vh - 3rem);
+  min-height: 32rem;
+  padding: 0;
+  overflow: hidden;
+  position: relative;
+}
 .graph-pane svg { display: block; width: 100%; height: 100%; }
 .graph-tooltip {
   position: absolute;

--- a/test/viewer-accessibility.test.ts
+++ b/test/viewer-accessibility.test.ts
@@ -78,10 +78,10 @@ describe("shell template — accessibility landmarks + skip link", () => {
     expect(skip!.getAttribute("href")).toBe("#main-pane");
     const github = doc.querySelector(".github-link") as HTMLAnchorElement | null;
     expect(github).not.toBeNull();
-    expect(github!.getAttribute("href")).toBe("https://github.com/atomicmemory/llm-wiki-compiler");
-    expect(github!.getAttribute("aria-label")).toBe("Open llm-wiki-compiler on GitHub");
+    expect(github!.getAttribute("href")).toBe("https://github.com/atomicstrata/llm-wiki-compiler");
+    expect(github!.getAttribute("aria-label")).toBe("Open llm-wiki-compiler on GitHub, 1.3k stars");
     expect(github!.textContent).toContain("GitHub");
-    expect(github!.textContent).not.toContain("1.1k");
+    expect(github!.textContent).toContain("1.3k");
   });
 
   it("stylesheet declares a universal `:focus-visible` outline so keyboard focus is visible", async () => {

--- a/test/viewer-rail.test.ts
+++ b/test/viewer-rail.test.ts
@@ -191,7 +191,8 @@ describe("sidebar — concept grouping by kind", () => {
     expect(kinds).toContain("concept");
     expect(kinds).toContain("entity");
     expect(kinds).toContain("query");
-    // The fallback "concept" kind appears first.
+    expect(dom.window.document.querySelector("[data-sidebar] section h2")?.textContent).toBe("Project");
+    // The fallback "concept" kind appears first among page groups.
     expect(kinds[0]).toBe("concept");
     // Two pages classified as concept (a + c with missing kind).
     const conceptGroup = Array.from(groups).find((d) => d.dataset.kind === "concept");


### PR DESCRIPTION
## Summary

Polishes the local viewer after the graph view landed:

- lets the graph pane fill the main content container instead of inheriting the markdown width cap
- moves the Project links above the growing concepts/query groups in the left nav
- shows the GitHub star count in the header with lighter/smaller styling
- updates the viewer GitHub link to the current atomicstrata org URL

## Validation

- `npx tsc --noEmit`
- `npm run build`
- `npm test -- test/viewer-shell.test.ts test/viewer-rail.test.ts test/viewer-accessibility.test.ts test/viewer-graph.test.ts test/viewer-server.test.ts test/viewer-pack.test.ts`
- `npm test -- test/ingest-basename-collision.test.ts`
- `npx fallow`

Note: local full `npm test` was attempted twice and reproduced the existing parallel-load timeout in `test/ingest-basename-collision.test.ts`; that file passes isolated. GitHub CI should be treated as the authoritative full-suite gate.
