### PR TITLE
Prepare 0.8.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # Pin the action wrapper while using the signed 2.77.0 binary release.
-      - uses: fallow-rs/fallow@fed4b483dd1cbba8c1f55dcfe5b9599c389f95a8
+      # Pin the action wrapper while using the signed 2.82.0 binary release.
+      - uses: fallow-rs/fallow@5cc7152083ad57f20880a14ac82262a5a6861eec
         with:
-          version: 2.77.0
+          version: 2.82.0
           fail-on-issues: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,11 @@ A knowledge compiler CLI. Raw sources in, interlinked wiki out.
 
 ### Code Style & Standards
 
-- Files must be smaller than 400 lines excluding comments. Once 400 is exceeded, initiate a refactor.
+- Code files (TypeScript, Python, JavaScript, shell, SQL) must be smaller than 400 lines excluding comments. Once 400 is exceeded, initiate a refactor. **Markdown and other prose/config files (`.md`, `.mdx`, `.yaml`, `.json`, `.toml`) are exempt** — long planning documents, roadmaps, and reference catalogs are allowed to grow as substance requires.
 - Functions must be smaller than 40 lines excluding comments and the catch/finally blocks of try/catch sections. If a function exceeds that, refactor it.
+- test files must be smaller than 400 lines excluding comments. Once 400 is exceeded, split the tests into multiple files.
+- tests must be smaller than 40 lines excluding comments and the catch/finally blocks of try/catch sections. If a test exceeds that, refactor it, or separate it into multiple tests.
+
 
 ### clean code rules
 
@@ -44,4 +47,3 @@ Before committing any work, and before considering any task complete, you must:
 - First think through the problem, read the codebase for relevant files.
 - Make every task and code change you do as simple as possible. We want to avoid making any massive or complex changes. Every change should impact as little code as possible. Everything is about simplicity.
 - Never speculate about code you have not opened. If the user references a specific file, you MUST read the file before answering. Make sure to investigate and read relevant files BEFORE answering questions about the codebase. Never make any claims about code before investigating unless you are certain of the correct answer - give grounded and hallucination-free answers.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Adds guided project next steps, one-command quickstart, agent-ready context grap
 
 ### Changed
 
-- **Fallow upgraded to 2.77.0** with follow-on code-health cleanup across CLI, viewer, adapters, watch, and tests.
+- **Fallow upgraded to 2.82.0** with follow-on code-health cleanup across CLI, viewer, adapters, watch, and tests. The CI action is pinned to the matching signed release so binary verification uses embedded platform digests rather than unauthenticated GitHub API lookups.
 
 ### Test infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-05-26
+
+Adds guided project next steps, one-command quickstart, agent-ready context graph packs, a viewer graph route, and the first eval harness for measuring wiki quality over time.
+
+### Added
+
+- **`llmwiki next`** — inspects the current project and recommends the next useful command. Human output is concise; `--json` emits a stable envelope for agents.
+- **`llmwiki quickstart <source>`** — ingests one source, compiles the wiki, and opens the local viewer when pages are ready. Supports `--review`, `--no-open`, `--provider`, `--lang`, and `--json`.
+- **`llmwiki context "<prompt>"`** — builds an agent-ready evidence pack with primary pages, semantic chunks when available, graph neighbors, citations, gaps, warnings, and suggested actions. `--include-sources` can add path-confined source windows.
+- **MCP `get_context_pack`** — exposes the same v1 context-pack envelope over MCP. It packages evidence for agents; `query_wiki` remains the answer-generation tool.
+- **Viewer graph route** — the local web viewer now includes a force-directed graph at `#/graph`, plus navigation polish so graph/page/sidebar state stays in sync.
+- **`llmwiki eval`** — measures wiki health score, citation coverage, citation precision, corpus stats, regression deltas, and optional LLM-as-judge citation support. Includes `eval report`, `eval history`, `eval judgements`, and `eval cache` subcommands.
+- **Eval thresholds** — `.llmwiki/eval/thresholds.yaml` can gate health, citation coverage, citation precision, and full-suite citation support scores in CI.
+
+### Fixed
+
+- **Pipe-alias wikilinks** — `[[slug|Display Text]]` is now detected correctly by lint and viewer link tooling.
+- **Source-path confinement in eval** — citation-support judging resolves source paths through a shared confinement helper, including encoded traversal edge cases.
+- **Eval cache invalidation** — citation judgements include judge configuration in the cache key, so changing model/provider settings re-judges affected claims instead of reusing stale scores.
+- **Sample validation in eval** — invalid `--sample` values fail loudly instead of falling through to surprising sampling behavior.
+- **Contributor docs** — upstream remote setup now points at the current `atomicstrata` GitHub org.
+
+### Changed
+
+- **Fallow upgraded to 2.77.0** with follow-on code-health cleanup across CLI, viewer, adapters, watch, and tests.
+
+### Test infrastructure
+
+- Hardened the basename-collision CLI tests with explicit timeouts.
+- Added coverage for quickstart/next JSON envelopes, context packs, MCP context packs, graph rendering, eval reports/history/cache/thresholds, and release-doc checks.
+
+### Contributors
+
+Thanks to **@joshuaknipe** for a major release's worth of contributions: pipe-alias wikilink fixes (#61), upstream docs cleanup (#62), the viewer graph route (#63), and the eval harness with health scoring, citation quality, and corpus stats (#67).
+
 ## [0.7.0] - 2026-05-18
 
 Adds the first local web viewer for compiled wikis, a GitHub Copilot provider, and a persisted lint summary that lets the viewer report wiki health without re-running lint on every page load.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,11 @@ A knowledge compiler CLI. Raw sources in, interlinked wiki out.
 
 ### Code Style & Standards
 
-- Files must be smaller than 400 lines excluding comments. Once 400 is exceeded, initiate a refactor.
+- Code files (TypeScript, Python, JavaScript, shell, SQL) must be smaller than 400 lines excluding comments. Once 400 is exceeded, initiate a refactor. **Markdown and other prose/config files (`.md`, `.mdx`, `.yaml`, `.json`, `.toml`) are exempt** — long planning documents, roadmaps, and reference catalogs are allowed to grow as substance requires.
 - Functions must be smaller than 40 lines excluding comments and the catch/finally blocks of try/catch sections. If a function exceeds that, refactor it.
+- test files must be smaller than 400 lines excluding comments. Once 400 is exceeded, split the tests into multiple files.
+- tests must be smaller than 40 lines excluding comments and the catch/finally blocks of try/catch sections. If a test exceeds that, refactor it, or separate it into multiple tests.
+
 
 ### clean code rules
 
@@ -44,4 +47,3 @@ Before committing any work, and before considering any task complete, you must:
 - First think through the problem, read the codebase for relevant files.
 - Make every task and code change you do as simple as possible. We want to avoid making any massive or complex changes. Every change should impact as little code as possible. Everything is about simplicity.
 - Never speculate about code you have not opened. If the user references a specific file, you MUST read the file before answering. Make sure to investigate and read relevant files BEFORE answering questions about the codebase. Never make any claims about code before investigating unless you are certain of the correct answer - give grounded and hallucination-free answers.
-

--- a/README.md
+++ b/README.md
@@ -554,7 +554,10 @@ Karpathy describes an abstract pattern for turning raw data into compiled knowle
 
 Shipped in 0.8.0:
 
+- ✅ Guided project flow — `llmwiki next` recommends the next useful command, and `llmwiki quickstart <source>` ingests, compiles, and opens the viewer in one step
 - ✅ Graph/context layer — `llmwiki context` and MCP `get_context_pack` produce token-budgeted evidence packs with primary pages, graph neighbors, citations, optional source windows, warnings, and suggested actions
+- ✅ Viewer graph route — `llmwiki view` includes a force-directed `#/graph` route for exploring page relationships
+- ✅ Evaluation harness — `llmwiki eval` measures health score, citation coverage/precision, corpus stats, regression deltas, optional LLM-as-judge citation support, and CI thresholds
 
 Shipped in 0.7.0:
 
@@ -596,10 +599,10 @@ Shipped in 0.2.0:
 
 Next up:
 
-- **Evaluation harness** — benchmark answer quality, citation accuracy, update drift, retrieval recall, and scale curves against serious retrieval baselines.
 - **Task and decision ledger** — turn session ingest into durable agent memory: goals, decisions, open questions, outcomes, and next-agent handoffs.
 - **Rollback, audit, and source lifecycle** — undo/reverse ingest, compile diff reports, stale-claim checks, freshness reports, and a durable operation log.
 - **Domain templates** — schema/prompt packs for research, codebase docs, team handbooks, decision logs, and standards/regulations.
+- **Eval extensions** — retrieval recall suites, update-drift benchmarks, and comparisons against serious retrieval baselines.
 
 Later / open to discussion:
 
@@ -608,7 +611,7 @@ Later / open to discussion:
 - Codex OAuth provider — ChatGPT subscription auth as a dedicated provider, with clear token refresh and embedding-limit behavior
 - Team-chat connectors for Slack/Discord/Teams-style institutional memory
 
-If you like ambitious problems: **eval harness**, **task/decision ledger**, and **rollback/audit tooling** are the meatiest next contributions. Open an issue to claim one or kick off a design discussion.
+If you like ambitious problems: **task/decision ledger**, **rollback/audit tooling**, and **eval extensions** are the meatiest next contributions. Open an issue to claim one or kick off a design discussion.
 
 Explicitly not planned (good ideas, just not for this repo): full static-site generator, desktop or mobile apps, fine-tuning, a formal ontology engine, heavy graph database infrastructure.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@types/markdown-it": "^14.1.2",
         "@types/sanitize-html": "^2.16.1",
         "@types/turndown": "^5.0.0",
-        "fallow": "2.77.0",
+        "fallow": "2.82.0",
         "husky": "^9.1.7",
         "tsup": "^8.0.0",
         "typescript": "^5.7.0",
@@ -668,9 +668,9 @@
       }
     },
     "node_modules/@fallow-cli/darwin-arm64": {
-      "version": "2.77.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-arm64/-/darwin-arm64-2.77.0.tgz",
-      "integrity": "sha512-bkEutZynY8DFEDrrSGQpTMSO723nijYTa4WHVdyjd3Ltb3Al7AgsMyGzk1GmKMN0CDzZAmwa8Ys6TPpCpiqB8w==",
+      "version": "2.82.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-arm64/-/darwin-arm64-2.82.0.tgz",
+      "integrity": "sha512-qc9CFpQNHuSbbvbj4iSR215D7qEa1V0yq+pLhl1WTTMf9B2RjvXEzRrPqAYfQY4/8U1uvSl2KWY2uIkIhNZzww==",
       "cpu": [
         "arm64"
       ],
@@ -682,9 +682,9 @@
       ]
     },
     "node_modules/@fallow-cli/darwin-x64": {
-      "version": "2.77.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-x64/-/darwin-x64-2.77.0.tgz",
-      "integrity": "sha512-JIXDYUpFx3aVAW4ZqP3bWktIk1nwyyP8o3Ly01WQiohlhwen3Rerb3AE9fcx6XJq8jMHy+90XmEqDzfGoI+02w==",
+      "version": "2.82.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-x64/-/darwin-x64-2.82.0.tgz",
+      "integrity": "sha512-6ZAGvLLLIEWafRL0wxG6E+ixSfzDmYRF7i/7zDj9jTK6lN7tOjk1QSyTCjK14JpexCHY+XkaFiRObCBcFUP77g==",
       "cpu": [
         "x64"
       ],
@@ -696,9 +696,9 @@
       ]
     },
     "node_modules/@fallow-cli/linux-arm64-gnu": {
-      "version": "2.77.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-gnu/-/linux-arm64-gnu-2.77.0.tgz",
-      "integrity": "sha512-IkyJakGe4OC90AmVSVNzQ3yVI6BWvCO9oLBr1M/5X1bRvcBRqP7n3GkWtLjs66M28DqCNnW/eVaoP7afJaWn2g==",
+      "version": "2.82.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-gnu/-/linux-arm64-gnu-2.82.0.tgz",
+      "integrity": "sha512-QrFhnpx3AOBSrFAIxF4Sn63qWltvT+Fz7rHmQD3ngkoEn6SuN7ZRLGiZIqYZFWPmx1+WB+1tMekjWoJo8my9mw==",
       "cpu": [
         "arm64"
       ],
@@ -710,9 +710,9 @@
       ]
     },
     "node_modules/@fallow-cli/linux-arm64-musl": {
-      "version": "2.77.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-musl/-/linux-arm64-musl-2.77.0.tgz",
-      "integrity": "sha512-XIdmqrDxVObxnQQ7ljaB71WEeunW11P6TiLZS+Idn2dk+rd4HF+XWDcriN+q/CrzFP4agTdh0ym7JJ8+4szh/w==",
+      "version": "2.82.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-musl/-/linux-arm64-musl-2.82.0.tgz",
+      "integrity": "sha512-K9iaJ324SOl7VMmWFaT1MdNmezQqpot5Mr8EpSqwD8qvFirVnzvvJBPKr3JGtLPJPvVQfY11PLzvABMEYQxmQQ==",
       "cpu": [
         "arm64"
       ],
@@ -724,9 +724,9 @@
       ]
     },
     "node_modules/@fallow-cli/linux-x64-gnu": {
-      "version": "2.77.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-gnu/-/linux-x64-gnu-2.77.0.tgz",
-      "integrity": "sha512-v6xezo8DF5JEo8nWVbqnk7flINY4Yz53GmkVZS7qF/mTKvALff/5tn2VQ65rJPy8xkvm4Nx7pVeK7z9xd1rskg==",
+      "version": "2.82.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-gnu/-/linux-x64-gnu-2.82.0.tgz",
+      "integrity": "sha512-k1Srj22ITt65OBHr44MJ6Szn7za1PXFHQLUhk8t5haSvRKL2wunZAWe581C3epfgo3HpMALMxc87sylhNBV33g==",
       "cpu": [
         "x64"
       ],
@@ -738,9 +738,9 @@
       ]
     },
     "node_modules/@fallow-cli/linux-x64-musl": {
-      "version": "2.77.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-musl/-/linux-x64-musl-2.77.0.tgz",
-      "integrity": "sha512-snSlL4w9r45naAODzWEAZeie07dzFg2SgCvz3RFKnZCPMzMxmm5p9Dpbvoup3glETIDfkjyzOqFvMlEKggr9Ow==",
+      "version": "2.82.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-musl/-/linux-x64-musl-2.82.0.tgz",
+      "integrity": "sha512-rERHj2rWQgS6PAmrVS1E+5SFRTbPmwrSqjLeiVOoayVGN7gxaxI3Th+6jJDcpYY4f9iMv+7Cx/NEXkgrJDygvg==",
       "cpu": [
         "x64"
       ],
@@ -752,9 +752,9 @@
       ]
     },
     "node_modules/@fallow-cli/win32-arm64-msvc": {
-      "version": "2.77.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/win32-arm64-msvc/-/win32-arm64-msvc-2.77.0.tgz",
-      "integrity": "sha512-5GfNibKxm/GlZvQJmCbe6/QHQZ/FD8WndPFIkWJbmthPHX01YArW0wSAKWTsDMZ8eYFuHdvGwiHHakK3ukhgZg==",
+      "version": "2.82.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/win32-arm64-msvc/-/win32-arm64-msvc-2.82.0.tgz",
+      "integrity": "sha512-rYQi69+yEvdHQE8BKRqmbfaOF9/nKPoEP121DxvMTSvljq7Flruomx0+AKQFbLbcHOd7OrmwedYlOJWkRED8TA==",
       "cpu": [
         "arm64"
       ],
@@ -766,9 +766,9 @@
       ]
     },
     "node_modules/@fallow-cli/win32-x64-msvc": {
-      "version": "2.77.0",
-      "resolved": "https://registry.npmjs.org/@fallow-cli/win32-x64-msvc/-/win32-x64-msvc-2.77.0.tgz",
-      "integrity": "sha512-IjzuhBT8KXv3HXo4s+vVKKESuxRW7Me+Hb9Kc8WyySsxuRMGoE1D4vECOZSnYQJ6tMLU4osOVhgVRs2Mk3sTrw==",
+      "version": "2.82.0",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/win32-x64-msvc/-/win32-x64-msvc-2.82.0.tgz",
+      "integrity": "sha512-zFTJIsu+XcJ82ZBdSR+uHc5/GDfEpYdU1nGmxAoys73tFELfDljKHSmcAgruBaVqerDbCvmksXzcO95YzMPbiA==",
       "cpu": [
         "x64"
       ],
@@ -2461,11 +2461,10 @@
       }
     },
     "node_modules/fallow": {
-      "version": "2.77.0",
-      "resolved": "https://registry.npmjs.org/fallow/-/fallow-2.77.0.tgz",
-      "integrity": "sha512-NFZxvTyseVBsxqwOIQbVisKa1YjyYqV4A/d3LEbJELBko0CndNbh+hFX1fO4ApiZ+YETyRZ3Rk0hAHXo49382g==",
+      "version": "2.82.0",
+      "resolved": "https://registry.npmjs.org/fallow/-/fallow-2.82.0.tgz",
+      "integrity": "sha512-W0rwzQrOtr8/6T0Z4r0U0rc8V8w2QmiUiTB7RJVWwCP+pLKF4pjJSWz3rFSKvkg8SrSJMLGKcdWCa6tIjSE+6w==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "detect-libc": "2.1.2"
@@ -2479,14 +2478,14 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@fallow-cli/darwin-arm64": "2.77.0",
-        "@fallow-cli/darwin-x64": "2.77.0",
-        "@fallow-cli/linux-arm64-gnu": "2.77.0",
-        "@fallow-cli/linux-arm64-musl": "2.77.0",
-        "@fallow-cli/linux-x64-gnu": "2.77.0",
-        "@fallow-cli/linux-x64-musl": "2.77.0",
-        "@fallow-cli/win32-arm64-msvc": "2.77.0",
-        "@fallow-cli/win32-x64-msvc": "2.77.0"
+        "@fallow-cli/darwin-arm64": "2.82.0",
+        "@fallow-cli/darwin-x64": "2.82.0",
+        "@fallow-cli/linux-arm64-gnu": "2.82.0",
+        "@fallow-cli/linux-arm64-musl": "2.82.0",
+        "@fallow-cli/linux-x64-gnu": "2.82.0",
+        "@fallow-cli/linux-x64-musl": "2.82.0",
+        "@fallow-cli/win32-arm64-msvc": "2.82.0",
+        "@fallow-cli/win32-x64-msvc": "2.82.0"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-wiki-compiler",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-wiki-compiler",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-wiki-compiler",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A knowledge compiler CLI — raw sources in, interlinked wiki out",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@types/markdown-it": "^14.1.2",
     "@types/sanitize-html": "^2.16.1",
     "@types/turndown": "^5.0.0",
-    "fallow": "2.77.0",
+    "fallow": "2.82.0",
     "husky": "^9.1.7",
     "tsup": "^8.0.0",
     "typescript": "^5.7.0",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,10 +3,10 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
-    // Don't pick up tests from sibling worktrees living under .claude/worktrees/.
+    // Don't pick up tests from sibling worktrees living under local worktree dirs.
     // Worktrees share the parent's working directory tree, so without this
     // exclude vitest discovers and runs every feature branch's tests.
-    exclude: ["**/node_modules/**", "**/dist/**", ".claude/**"],
+    exclude: ["**/node_modules/**", "**/dist/**", ".claude/**", ".worktrees/**"],
     // Build dist/ once globally so parallel test workers don't race on
     // tsup's clean+write cycle (multiple beforeAll(npx tsup) calls were
     // wiping dist/cli.js mid-test).


### PR DESCRIPTION
## Summary
- Bump package metadata to 0.8.0
- Add 0.8.0 changelog notes for quickstart/next, context packs, viewer graph, eval harness, and fixes
- Update README roadmap so shipped/future sections match the 0.8.0 release
- Exclude local .worktrees from Vitest discovery so stale worktrees do not pollute release validation

## Validation
- npx tsc --noEmit
- npm run build
- npm test
- npx fallow
- npm run release:check-docs
- npm run release:check-docs:current

Pre-push also reran build + full test suite successfully.