### PR TITLE
Harden viewer subprocess test timeouts

### DIFF
--- a/test/fixtures/run-cli-server.ts
+++ b/test/fixtures/run-cli-server.ts
@@ -25,7 +25,7 @@ const CLI = path.resolve("dist/cli.js");
 // Parses either `http://127.0.0.1:PORT` or the bracketed-IPv6 form
 // `http://[::1]:PORT` — group 1 captures the host without the brackets.
 const READINESS_RE = /Viewer ready at http:\/\/(?:\[([^\]]+)\]|([^\s:]+)):(\d+)/;
-const DEFAULT_READY_TIMEOUT_MS = 5000;
+const DEFAULT_READY_TIMEOUT_MS = 30_000;
 
 /** Handle returned by {@link startViewerCLI}. */
 export interface ViewerProcessHandle {

--- a/test/viewer-host.test.ts
+++ b/test/viewer-host.test.ts
@@ -29,6 +29,7 @@ import {
 
 const exec = promisify(execCb);
 const CLI = path.resolve("dist/cli.js");
+const CLI_REJECTION_TIMEOUT_MS = 30_000;
 
 let ipv6Available = false;
 
@@ -84,7 +85,10 @@ describe("CLI — wildcard host rejection", () => {
     const root = await makeTempRoot(`viewer-host-wildcard-${host.replace(/[:.*]/g, "-")}`);
     let stderr = "";
     try {
-      await exec(`node "${CLI}" view --port 0 --allow-lan --host "${host}"`, { cwd: root, timeout: 5000 });
+      await exec(`node "${CLI}" view --port 0 --allow-lan --host "${host}"`, {
+        cwd: root,
+        timeout: CLI_REJECTION_TIMEOUT_MS,
+      });
       throw new Error("expected CLI to exit non-zero for wildcard host");
     } catch (err) {
       stderr = String((err as { stderr?: string }).stderr ?? "");


### PR DESCRIPTION
## Summary
- raise the shared viewer/quickstart readiness timeout from 5s to 30s
- raise the viewer host rejection subprocess timeout from 5s to 30s
- keeps the local release/push path from failing when subprocess startup is slow under load

## Validation
- npm run build
- npx vitest run test/viewer-host.test.ts test/viewer-health.test.ts test/viewer-server-security.test.ts test/viewer-server.test.ts test/quickstart-integration.test.ts
- full pre-push build + npm test