### PR TITLE
feat(mcp): add run_eval tool and eval resources

### DIFF
--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -12,12 +12,8 @@
  *   evalJudgementsCommand  — browse individual citation judgements with filters
  */
 
-import { evaluateHealth } from "../eval/health.js";
-import { evaluateCitationCoverage } from "../eval/citation-coverage.js";
-import { evaluateCitationSupport } from "../eval/citation-support.js";
-import { collectStats, appendHistory, loadPreviousReport, loadHistory } from "../eval/stats.js";
-import { computeDelta } from "../eval/delta.js";
-import { checkThresholds } from "../eval/thresholds.js";
+import { loadHistory, loadPreviousReport } from "../eval/stats.js";
+import { runEval } from "../eval/index.js";
 import {
   formatTerminalReport,
   formatJsonReport,
@@ -26,7 +22,6 @@ import {
   formatJudgementsDisplay,
 } from "../eval/report.js";
 import { clearCitationCache, loadCitationCache, summarizeCitationCache } from "../eval/cache.js";
-import type { EvalReport } from "../eval/types.js";
 
 interface EvalOptions {
   suite?: string;
@@ -62,34 +57,6 @@ function resolveEvalOptions(options: EvalOptions): ResolvedEvalOptions {
   };
 }
 
-async function runEvalComponents(root: string, suite: "fast" | "full", sampleSize: number) {
-  const [health, citationCoverage, stats, previousReport] = await Promise.all([
-    evaluateHealth(root),
-    evaluateCitationCoverage(root),
-    collectStats(root),
-    loadPreviousReport(root),
-  ]);
-  const citationSupport = suite === "full"
-    ? await evaluateCitationSupport(root, sampleSize, previousReport?.citationSupport?.sampledHashes ?? [])
-    : undefined;
-  return { health, citationCoverage, stats, previousReport, citationSupport };
-}
-
-async function buildReport(root: string, components: Awaited<ReturnType<typeof runEvalComponents>>, suite: "fast" | "full"): Promise<EvalReport> {
-  const { health, citationCoverage, stats, previousReport, citationSupport } = components;
-  const partial = {
-    suite,
-    timestamp: new Date().toISOString(),
-    health,
-    citationCoverage,
-    stats,
-    ...(citationSupport ? { citationSupport } : {}),
-  };
-  const delta = previousReport ? computeDelta(partial as EvalReport, previousReport) : undefined;
-  const thresholdViolations = await checkThresholds(partial as EvalReport, root);
-  return { ...partial, ...(delta ? { delta } : {}), thresholdViolations };
-}
-
 /**
  * Run the eval harness against the current project.
  * @param options - Parsed CLI options.
@@ -98,9 +65,7 @@ export default async function evalCommand(options: EvalOptions = {}): Promise<vo
   const root = process.cwd();
   const { suite, sampleSize, outFormat } = resolveEvalOptions(options);
 
-  const components = await runEvalComponents(root, suite, sampleSize);
-  const report = await buildReport(root, components, suite);
-  await appendHistory(root, report);
+  const report = await runEval(root, suite, sampleSize);
 
   const output = outFormat === "json" ? formatJsonReport(report) : formatTerminalReport(report);
   console.log(output);

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -29,7 +29,7 @@ interface EvalOptions {
   sample?: string;
 }
 
-const DEFAULT_SAMPLE_SIZE = 20;
+export const DEFAULT_SAMPLE_SIZE = 20;
 
 interface ResolvedEvalOptions {
   suite: "fast" | "full";

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -13,7 +13,7 @@
  */
 
 import { loadHistory, loadPreviousReport } from "../eval/stats.js";
-import { runEval } from "../eval/index.js";
+import { runEval, DEFAULT_SAMPLE_SIZE } from "../eval/index.js";
 import {
   formatTerminalReport,
   formatJsonReport,
@@ -28,8 +28,6 @@ interface EvalOptions {
   out?: string;
   sample?: string;
 }
-
-export const DEFAULT_SAMPLE_SIZE = 20;
 
 interface ResolvedEvalOptions {
   suite: "fast" | "full";

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -12,6 +12,7 @@ import { evaluateCitationSupport } from "./citation-support.js";
 import { collectStats, appendHistory, loadPreviousReport, loadLastFullReport } from "./stats.js";
 import { computeDelta } from "./delta.js";
 import { checkThresholds } from "./thresholds.js";
+import { ensureProviderAvailable } from "../utils/provider-guard.js";
 import type { EvalReport, HealthResult, CitationCoverageResult, CitationSupportResult, StatsResult } from "./types.js";
 
 interface EvalComponents {
@@ -39,6 +40,7 @@ async function buildReport(root: string, components: EvalComponents, suite: "fas
 
 /** Run the full eval pipeline, optionally append to history, and return the report. */
 export async function runEval(root: string, suite: "fast" | "full", sampleSize: number, record = true): Promise<EvalReport> {
+  if (suite === "full") ensureProviderAvailable();
   const [health, citationCoverage, stats, previousReport, previousFullReport] = await Promise.all([
     evaluateHealth(root),
     evaluateCitationCoverage(root),

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -15,6 +15,8 @@ import { checkThresholds } from "./thresholds.js";
 import { ensureProviderAvailable } from "../utils/provider-guard.js";
 import type { EvalReport, HealthResult, CitationCoverageResult, CitationSupportResult, StatsResult } from "./types.js";
 
+export const DEFAULT_SAMPLE_SIZE = 20;
+
 interface EvalComponents {
   health: HealthResult;
   citationCoverage: CitationCoverageResult;

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -9,7 +9,7 @@
 import { evaluateHealth } from "./health.js";
 import { evaluateCitationCoverage } from "./citation-coverage.js";
 import { evaluateCitationSupport } from "./citation-support.js";
-import { collectStats, appendHistory, loadPreviousReport } from "./stats.js";
+import { collectStats, appendHistory, loadPreviousReport, loadLastFullReport } from "./stats.js";
 import { computeDelta } from "./delta.js";
 import { checkThresholds } from "./thresholds.js";
 import type { EvalReport, HealthResult, CitationCoverageResult, CitationSupportResult, StatsResult } from "./types.js";
@@ -39,14 +39,15 @@ async function buildReport(root: string, components: EvalComponents, suite: "fas
 
 /** Run the full eval pipeline, append to history, and return the report. */
 export async function runEval(root: string, suite: "fast" | "full", sampleSize: number): Promise<EvalReport> {
-  const [health, citationCoverage, stats, previousReport] = await Promise.all([
+  const [health, citationCoverage, stats, previousReport, previousFullReport] = await Promise.all([
     evaluateHealth(root),
     evaluateCitationCoverage(root),
     collectStats(root),
     loadPreviousReport(root),
+    suite === "full" ? loadLastFullReport(root) : Promise.resolve(null),
   ]);
   const citationSupport = suite === "full"
-    ? await evaluateCitationSupport(root, sampleSize, previousReport?.citationSupport?.sampledHashes ?? [])
+    ? await evaluateCitationSupport(root, sampleSize, previousFullReport?.citationSupport?.sampledHashes ?? [])
     : undefined;
   const report = await buildReport(root, { health, citationCoverage, stats, previousReport, citationSupport }, suite);
   await appendHistory(root, report);

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -1,0 +1,54 @@
+/**
+ * Report assembly for the llmwiki eval harness.
+ *
+ * Combines evaluated components (health, citation coverage, stats, citation support)
+ * into a final EvalReport with delta tracking and threshold validation.
+ * Shared by the CLI eval command and the MCP run_eval tool.
+ */
+
+import { evaluateHealth } from "./health.js";
+import { evaluateCitationCoverage } from "./citation-coverage.js";
+import { evaluateCitationSupport } from "./citation-support.js";
+import { collectStats, appendHistory, loadPreviousReport } from "./stats.js";
+import { computeDelta } from "./delta.js";
+import { checkThresholds } from "./thresholds.js";
+import type { EvalReport, HealthResult, CitationCoverageResult, CitationSupportResult, StatsResult } from "./types.js";
+
+interface EvalComponents {
+  health: HealthResult;
+  citationCoverage: CitationCoverageResult;
+  stats: StatsResult;
+  previousReport: EvalReport | null;
+  citationSupport?: CitationSupportResult | null;
+}
+
+async function buildReport(root: string, components: EvalComponents, suite: "fast" | "full"): Promise<EvalReport> {
+  const { health, citationCoverage, stats, previousReport, citationSupport } = components;
+  const partial = {
+    suite,
+    timestamp: new Date().toISOString(),
+    health,
+    citationCoverage,
+    stats,
+    ...(citationSupport ? { citationSupport } : {}),
+  };
+  const delta = previousReport ? computeDelta(partial as EvalReport, previousReport) : undefined;
+  const thresholdViolations = await checkThresholds(partial as EvalReport, root);
+  return { ...partial, ...(delta ? { delta } : {}), thresholdViolations };
+}
+
+/** Run the full eval pipeline, append to history, and return the report. */
+export async function runEval(root: string, suite: "fast" | "full", sampleSize: number): Promise<EvalReport> {
+  const [health, citationCoverage, stats, previousReport] = await Promise.all([
+    evaluateHealth(root),
+    evaluateCitationCoverage(root),
+    collectStats(root),
+    loadPreviousReport(root),
+  ]);
+  const citationSupport = suite === "full"
+    ? await evaluateCitationSupport(root, sampleSize, previousReport?.citationSupport?.sampledHashes ?? [])
+    : undefined;
+  const report = await buildReport(root, { health, citationCoverage, stats, previousReport, citationSupport }, suite);
+  await appendHistory(root, report);
+  return report;
+}

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -37,8 +37,8 @@ async function buildReport(root: string, components: EvalComponents, suite: "fas
   return { ...partial, ...(delta ? { delta } : {}), thresholdViolations };
 }
 
-/** Run the full eval pipeline, append to history, and return the report. */
-export async function runEval(root: string, suite: "fast" | "full", sampleSize: number): Promise<EvalReport> {
+/** Run the full eval pipeline, optionally append to history, and return the report. */
+export async function runEval(root: string, suite: "fast" | "full", sampleSize: number, record = true): Promise<EvalReport> {
   const [health, citationCoverage, stats, previousReport, previousFullReport] = await Promise.all([
     evaluateHealth(root),
     evaluateCitationCoverage(root),
@@ -50,6 +50,6 @@ export async function runEval(root: string, suite: "fast" | "full", sampleSize: 
     ? await evaluateCitationSupport(root, sampleSize, previousFullReport?.citationSupport?.sampledHashes ?? [])
     : undefined;
   const report = await buildReport(root, { health, citationCoverage, stats, previousReport, citationSupport }, suite);
-  await appendHistory(root, report);
+  if (record) await appendHistory(root, report);
   return report;
 }

--- a/src/eval/stats.ts
+++ b/src/eval/stats.ts
@@ -93,21 +93,44 @@ export async function loadHistory(root: string, n = 10): Promise<EvalReport[]> {
   return reports;
 }
 
+/** Read the history file and return its non-empty lines, or null if it doesn't exist. */
+async function readHistoryLines(root: string): Promise<string[] | null> {
+  const historyPath = path.join(root, HISTORY_FILE);
+  if (!existsSync(historyPath)) return null;
+  const content = await readFile(historyPath, "utf-8");
+  return content.trim().split("\n").filter(Boolean);
+}
+
 /**
  * Load the most recent eval report from history.jsonl, or null if none exists.
  * @param root - Absolute path to the project root.
  */
 export async function loadPreviousReport(root: string): Promise<EvalReport | null> {
-  const historyPath = path.join(root, HISTORY_FILE);
-  if (!existsSync(historyPath)) return null;
-
-  const content = await readFile(historyPath, "utf-8");
-  const lines = content.trim().split("\n").filter(Boolean);
-  if (lines.length === 0) return null;
-
+  const lines = await readHistoryLines(root);
+  if (!lines || lines.length === 0) return null;
   try {
     return JSON.parse(lines[lines.length - 1]) as EvalReport;
   } catch {
     return null;
   }
+}
+
+/**
+ * Load the most recent full-suite eval report from history.jsonl, skipping fast-suite
+ * entries. This ensures citation-support sampledHashes are not lost when a fast run
+ * occurs between two full runs.
+ * @param root - Absolute path to the project root.
+ */
+export async function loadLastFullReport(root: string): Promise<EvalReport | null> {
+  const lines = await readHistoryLines(root);
+  if (!lines) return null;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      const report = JSON.parse(lines[i]) as EvalReport;
+      if (report.suite === "full") return report;
+    } catch {
+      // Skip malformed lines
+    }
+  }
+  return null;
 }

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -199,7 +199,7 @@ function registerEvalHistoryResource(server: McpServer, root: string): void {
       mimeType: "application/json",
     },
     async (uri) => {
-      const reports = await loadHistory(root, 10);
+      const reports = await loadHistory(root);
       return { contents: [jsonContent(uri, reports)] };
     },
   );

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -18,6 +18,7 @@ import {
 } from "../utils/constants.js";
 import { safeReadFile, parseFrontmatter } from "../utils/markdown.js";
 import { readState } from "../utils/state.js";
+import { loadPreviousReport, loadHistory } from "../eval/stats.js";
 
 /** Standard JSON content block for an MCP resource read result. */
 function jsonContent(uri: URL, payload: unknown): {
@@ -45,13 +46,15 @@ function markdownContent(uri: URL, text: string): {
   };
 }
 
-/** Register all 5 read-only wiki resources on the given MCP server. */
+/** Register all 7 read-only wiki resources on the given MCP server. */
 export function registerWikiResources(server: McpServer, root: string): void {
   registerIndexResource(server, root);
   registerSourcesResource(server, root);
   registerStateResource(server, root);
   registerConceptResource(server, root);
   registerQueryResource(server, root);
+  registerEvalReportResource(server, root);
+  registerEvalHistoryResource(server, root);
 }
 
 function registerIndexResource(server: McpServer, root: string): void {
@@ -168,6 +171,38 @@ async function loadPageWithMeta(
 
   const { meta, body } = parseFrontmatter(content);
   return { slug, meta, body: body.trim() };
+}
+
+function registerEvalReportResource(server: McpServer, root: string): void {
+  server.registerResource(
+    "eval-report",
+    "llmwiki://eval/report",
+    {
+      title: "Eval Report",
+      description: "Latest eval report — health score, citation coverage, corpus stats.",
+      mimeType: "application/json",
+    },
+    async (uri) => {
+      const report = await loadPreviousReport(root);
+      return { contents: [jsonContent(uri, report ?? {})] };
+    },
+  );
+}
+
+function registerEvalHistoryResource(server: McpServer, root: string): void {
+  server.registerResource(
+    "eval-history",
+    "llmwiki://eval/history",
+    {
+      title: "Eval History",
+      description: "Eval run history — trend table of past eval reports.",
+      mimeType: "application/json",
+    },
+    async (uri) => {
+      const reports = await loadHistory(root, 10);
+      return { contents: [jsonContent(uri, reports)] };
+    },
+  );
 }
 
 /** Build a resource list payload by enumerating .md files in a wiki directory. */

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -37,7 +37,8 @@ export async function startMCPServer(options: ServerOptions): Promise<void> {
       "llmwiki is a knowledge compiler. Use ingest_source to add raw sources, " +
       "compile_wiki to run the LLM pipeline, query_wiki for grounded answers, " +
       "search_pages to retrieve relevant pages, and run_eval to score wiki quality. " +
-      "read_page, lint_wiki, wiki_status, and run_eval (fast suite) work without an API key.",
+      "read_page, lint_wiki, wiki_status, and run_eval (fast suite, record: false) work without an API key " +
+      "and do not mutate state.",
   });
 
   registerWikiTools(server, root);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -36,8 +36,8 @@ export async function startMCPServer(options: ServerOptions): Promise<void> {
     instructions:
       "llmwiki is a knowledge compiler. Use ingest_source to add raw sources, " +
       "compile_wiki to run the LLM pipeline, query_wiki for grounded answers, " +
-      "and search_pages to retrieve relevant pages. read_page, lint_wiki, and " +
-      "wiki_status work without an API key.",
+      "search_pages to retrieve relevant pages, and run_eval to score wiki quality. " +
+      "read_page, lint_wiki, wiki_status, and run_eval (fast suite) work without an API key.",
   });
 
   registerWikiTools(server, root);

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -381,17 +381,20 @@ function registerEvalTool(server: McpServer, root: string): void {
       description:
         "Run the wiki quality eval harness. fast suite checks health and citation " +
         "coverage without LLM calls. full suite also LLM-judges a sample of citations " +
-        "(requires an LLM provider). Appends results to eval history.",
+        "(requires an LLM provider). " +
+        "Set record: true to append results to eval history (default false — read-only).",
       inputSchema: {
         suite: z.enum(["fast", "full"]).optional().default("fast")
           .describe("fast=no LLM calls, full=includes citation support (requires LLM provider)"),
         sampleSize: z.number().int().min(1).max(100).optional()
           .describe("Citations to sample for citation support (full suite only, default 20)"),
+        record: z.boolean().optional().default(false)
+          .describe("Append results to eval history (default false; set true to persist a checkpoint)"),
       },
     },
-    async ({ suite, sampleSize }) => {
+    async ({ suite, sampleSize, record }) => {
       if (suite === "full") ensureProviderAvailable();
-      const report = await runEval(root, suite, sampleSize ?? 20);
+      const report = await runEval(root, suite, sampleSize ?? 20, record ?? false);
       return jsonResult(report);
     },
   );

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -2,7 +2,7 @@
  * MCP tool registrations for llmwiki.
  *
  * Each tool wraps an existing pipeline function (ingest, compile, query,
- * search, read, lint, status) and converts its structured result into
+ * search, read, lint, status, context-pack, eval) and converts its structured result into
  * an MCP CallToolResult. Tools that need an LLM provider validate the
  * provider lazily — the server itself starts without credentials so
  * read-only tools always work.
@@ -29,6 +29,7 @@ import {
   CHUNK_TOP_K,
 } from "../utils/constants.js";
 import { ensureProviderAvailable } from "../utils/provider-guard.js";
+import { runEval } from "../eval/index.js";
 
 /** Directories searched (in priority order) when resolving a page slug. */
 const PAGE_DIRS = [CONCEPTS_DIR, QUERIES_DIR];
@@ -56,7 +57,7 @@ function jsonResult(payload: unknown): {
   };
 }
 
-/** Register all 8 wiki tools on the given MCP server instance. */
+/** Register all 9 wiki tools on the given MCP server instance. */
 export function registerWikiTools(server: McpServer, root: string): void {
   registerIngestTool(server, root);
   registerCompileTool(server, root);
@@ -66,6 +67,7 @@ export function registerWikiTools(server: McpServer, root: string): void {
   registerLintTool(server, root);
   registerStatusTool(server, root);
   registerContextPackTool(server, root);
+  registerEvalTool(server, root);
 }
 
 function registerIngestTool(server: McpServer, root: string): void {
@@ -369,6 +371,32 @@ async function buildContextPackFromArgs(
     includeSources: args.includeSources,
   });
 }
+
+
+function registerEvalTool(server: McpServer, root: string): void {
+  server.registerTool(
+    "run_eval",
+    {
+      title: "Run Eval",
+      description:
+        "Run the wiki quality eval harness. fast suite checks health and citation " +
+        "coverage without LLM calls. full suite also LLM-judges a sample of citations " +
+        "(requires an LLM provider). Appends results to eval history.",
+      inputSchema: {
+        suite: z.enum(["fast", "full"]).optional().default("fast")
+          .describe("fast=no LLM calls, full=includes citation support (requires LLM provider)"),
+        sampleSize: z.number().int().min(1).max(100).optional()
+          .describe("Citations to sample for citation support (full suite only, default 20)"),
+      },
+    },
+    async ({ suite, sampleSize }) => {
+      if (suite === "full") ensureProviderAvailable();
+      const report = await runEval(root, suite, sampleSize ?? 20);
+      return jsonResult(report);
+    },
+  );
+}
+
 
 /** Read-only status snapshot used by the wiki_status tool. */
 async function collectStatus(root: string): Promise<WikiStatus> {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -30,6 +30,7 @@ import {
 } from "../utils/constants.js";
 import { ensureProviderAvailable } from "../utils/provider-guard.js";
 import { runEval } from "../eval/index.js";
+import { DEFAULT_SAMPLE_SIZE } from "../commands/eval.js";
 
 /** Directories searched (in priority order) when resolving a page slug. */
 const PAGE_DIRS = [CONCEPTS_DIR, QUERIES_DIR];
@@ -372,7 +373,6 @@ async function buildContextPackFromArgs(
   });
 }
 
-
 function registerEvalTool(server: McpServer, root: string): void {
   server.registerTool(
     "run_eval",
@@ -387,13 +387,13 @@ function registerEvalTool(server: McpServer, root: string): void {
         suite: z.enum(["fast", "full"]).optional().default("fast")
           .describe("fast=no LLM calls, full=includes citation support (requires LLM provider)"),
         sampleSize: z.number().int().min(1).max(100).optional()
-          .describe("Citations to sample for citation support (full suite only, default 20)"),
+          .describe(`Citations to sample for citation support (full suite only, default ${DEFAULT_SAMPLE_SIZE})`),
         record: z.boolean().optional().default(false)
           .describe("Append results to eval history (default false; set true to persist a checkpoint)"),
       },
     },
     async ({ suite, sampleSize, record }) => {
-      const report = await runEval(root, suite, sampleSize ?? 20, record ?? false);
+      const report = await runEval(root, suite, sampleSize ?? DEFAULT_SAMPLE_SIZE, record ?? false);
       return jsonResult(report);
     },
   );

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -393,7 +393,6 @@ function registerEvalTool(server: McpServer, root: string): void {
       },
     },
     async ({ suite, sampleSize, record }) => {
-      if (suite === "full") ensureProviderAvailable();
       const report = await runEval(root, suite, sampleSize ?? 20, record ?? false);
       return jsonResult(report);
     },

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -29,8 +29,7 @@ import {
   CHUNK_TOP_K,
 } from "../utils/constants.js";
 import { ensureProviderAvailable } from "../utils/provider-guard.js";
-import { runEval } from "../eval/index.js";
-import { DEFAULT_SAMPLE_SIZE } from "../commands/eval.js";
+import { runEval, DEFAULT_SAMPLE_SIZE } from "../eval/index.js";
 
 /** Directories searched (in priority order) when resolving a page slug. */
 const PAGE_DIRS = [CONCEPTS_DIR, QUERIES_DIR];

--- a/test/eval-command.test.ts
+++ b/test/eval-command.test.ts
@@ -1,9 +1,11 @@
 /**
  * Tests for src/commands/eval.ts — CLI option resolution and validation.
+ * Also covers the runEval() credential guard in src/eval/index.ts.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { parseSampleSize } from "../src/commands/eval.js";
+import { runEval } from "../src/eval/index.js";
 
 describe("parseSampleSize", () => {
   it.each(["0", "-1", "-100"])("rejects %s (zero or negative)", (raw) => {
@@ -24,5 +26,35 @@ describe("parseSampleSize", () => {
 
   it("includes the rejected value in the error message", () => {
     expect(() => parseSampleSize("0")).toThrow('"0"');
+  });
+});
+
+describe("runEval credential guard", () => {
+  afterEach(() => {
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
+    delete process.env.LLMWIKI_PROVIDER;
+  });
+
+  it("throws a clean credential error for full suite when anthropic key is absent", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
+    process.env.LLMWIKI_PROVIDER = "anthropic";
+
+    await expect(runEval("/tmp", "full", 1)).rejects.toThrow(
+      "Anthropic credentials are required"
+    );
+  });
+
+  it("does not throw a credential error for fast suite without credentials", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
+    process.env.LLMWIKI_PROVIDER = "anthropic";
+
+    // fast suite skips the guard — it will fail on missing files, not on credentials
+    await runEval("/tmp", "fast", 1).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      expect(message).not.toContain("Anthropic credentials are required");
+    });
   });
 });

--- a/test/eval-command.test.ts
+++ b/test/eval-command.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { parseSampleSize } from "../src/commands/eval.js";
 import { runEval } from "../src/eval/index.js";
+import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
 
 describe("parseSampleSize", () => {
   it.each(["0", "-1", "-100"])("rejects %s (zero or negative)", (raw) => {
@@ -30,6 +31,8 @@ describe("parseSampleSize", () => {
 });
 
 describe("runEval credential guard", () => {
+  const env = useLintTempRoot("eval-cmd");
+
   afterEach(() => {
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.ANTHROPIC_AUTH_TOKEN;
@@ -51,10 +54,6 @@ describe("runEval credential guard", () => {
     delete process.env.ANTHROPIC_AUTH_TOKEN;
     process.env.LLMWIKI_PROVIDER = "anthropic";
 
-    // fast suite skips the guard — it will fail on missing files, not on credentials
-    await runEval("/tmp", "fast", 1).catch((err: unknown) => {
-      const message = err instanceof Error ? err.message : String(err);
-      expect(message).not.toContain("Anthropic credentials are required");
-    });
+    await expect(runEval(env.dir, "fast", 1, false)).resolves.toBeDefined();
   });
 });

--- a/test/eval-run.test.ts
+++ b/test/eval-run.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Integration tests for src/eval/index.ts — runEval record flag.
+ *
+ * Verifies that runEval does not write to history.jsonl by default (record=false),
+ * and does write when record=true.
+ */
+
+import { existsSync } from "fs";
+import path from "path";
+import { runEval } from "../src/eval/index.js";
+import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
+
+describe("runEval record flag", () => {
+  const env = useLintTempRoot("eval-run");
+  const historyPath = () => path.join(env.dir, ".llmwiki", "eval", "history.jsonl");
+
+  it("does NOT write history when record is false", async () => {
+    await runEval(env.dir, "fast", 20, false);
+    expect(existsSync(historyPath())).toBe(false);
+  });
+
+  it("writes history when record is true", async () => {
+    await runEval(env.dir, "fast", 20, true);
+    expect(existsSync(historyPath())).toBe(true);
+  });
+});

--- a/test/eval-stats.test.ts
+++ b/test/eval-stats.test.ts
@@ -5,7 +5,7 @@
 import { readFile } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
-import { collectStats, appendHistory, loadHistory } from "../src/eval/stats.js";
+import { collectStats, appendHistory, loadHistory, loadLastFullReport } from "../src/eval/stats.js";
 import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
 import { makeEvalReport } from "./fixtures/eval-report.js";
 import type { EvalReport } from "../src/eval/types.js";
@@ -125,5 +125,44 @@ describe("loadHistory", () => {
 
     const history = await loadHistory(env.dir, 100);
     expect(history).toHaveLength(1);
+  });
+});
+
+describe("loadLastFullReport", () => {
+  const env = useLintTempRoot("eval-last-full");
+
+  it("returns null when history is empty", async () => {
+    const result = await loadLastFullReport(env.dir);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when only fast-suite reports exist", async () => {
+    await appendHistory(env.dir, makeEvalReport({ suite: "fast" }));
+    const result = await loadLastFullReport(env.dir);
+    expect(result).toBeNull();
+  });
+
+  it("returns the full-suite report even when a fast report follows it", async () => {
+    const sampledHashes = ["hash-a", "hash-b", "hash-c"];
+    const fullReport = makeEvalReport({
+      suite: "full",
+      citationSupport: {
+        sampledCount: 3,
+        sampledHashes,
+        totalCitations: 10,
+        meanScore: 1.5,
+        fullySupported: 2,
+        partiallySupported: 1,
+        unsupported: 0,
+        judgeErrors: 0,
+        judgements: [],
+      },
+    });
+    await appendHistory(env.dir, fullReport);
+    await appendHistory(env.dir, makeEvalReport({ suite: "fast" }));
+
+    const result = await loadLastFullReport(env.dir);
+    expect(result?.suite).toBe("full");
+    expect(result?.citationSupport?.sampledHashes).toEqual(sampledHashes);
   });
 });

--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -247,18 +247,20 @@ describe("error handling", () => {
   });
 });
 
+type ResourceMap = Record<string, { readCallback: (uri: URL) => Promise<{ contents: Array<{ text: string }> }> }>;
+
 describe("MCP resources", () => {
   it("resolves the wiki-index static resource", async () => {
     await writeFile(path.join(root, "wiki/index.md"), "# Test Index\n");
     const server = buildServer();
-    const resource = (getRegisteredResources(server) as Record<string, { readCallback: (uri: URL) => Promise<{ contents: Array<{ text: string }> }> }>)["llmwiki://index"];
+    const resource = (getRegisteredResources(server) as ResourceMap)["llmwiki://index"];
     const result = await resource.readCallback(new URL("llmwiki://index"));
     expect(result.contents[0].text).toContain("Test Index");
   });
 
   it("resolves the wiki-state static resource", async () => {
     const server = buildServer();
-    const resource = (getRegisteredResources(server) as Record<string, { readCallback: (uri: URL) => Promise<{ contents: Array<{ text: string }> }> }>)["llmwiki://state"];
+    const resource = (getRegisteredResources(server) as ResourceMap)["llmwiki://state"];
     const result = await resource.readCallback(new URL("llmwiki://state"));
     const parsed = JSON.parse(result.contents[0].text);
     expect(parsed).toMatchObject({ version: 1, sources: expect.any(Object) });
@@ -270,7 +272,7 @@ describe("MCP resources", () => {
       "---\ntitle: Article\nsource: example.com\n---\n\nbody",
     );
     const server = buildServer();
-    const resource = (getRegisteredResources(server) as Record<string, { readCallback: (uri: URL) => Promise<{ contents: Array<{ text: string }> }> }>)["llmwiki://sources"];
+    const resource = (getRegisteredResources(server) as ResourceMap)["llmwiki://sources"];
     const result = await resource.readCallback(new URL("llmwiki://sources"));
     const parsed = JSON.parse(result.contents[0].text);
     expect(parsed).toEqual([expect.objectContaining({ filename: "article.md", title: "Article" })]);
@@ -312,9 +314,6 @@ describe("MCP resources", () => {
     expect(parsed).toMatchObject({ slug: "what-is-x", body: "Saved query body." });
   });
 });
-
-
-type ResourceMap = Record<string, { readCallback: (uri: URL) => Promise<{ contents: Array<{ text: string }> }> }>;
 
 describe("run_eval tool", () => {
   it("returns EvalReport shape for an empty project (fast suite)", async () => {

--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -17,6 +17,8 @@ import {
   snapshotWorkspace,
   useMcpRoot,
 } from "./fixtures/mcp-test-env.js";
+import { appendHistory } from "../src/eval/stats.js";
+import { makeEvalReport } from "./fixtures/eval-report.js";
 
 const rootHandle = useMcpRoot("llmwiki-mcp");
 /**
@@ -73,6 +75,7 @@ describe("MCP server tool registration", () => {
       "lint_wiki",
       "query_wiki",
       "read_page",
+      "run_eval",
       "search_pages",
       "wiki_status",
     ]);
@@ -82,7 +85,13 @@ describe("MCP server tool registration", () => {
     const server = buildServer();
     const staticUris = Object.keys(getRegisteredResources(server)).sort();
     const templateNames = Object.keys(getRegisteredResourceTemplates(server)).sort();
-    expect(staticUris).toEqual(["llmwiki://index", "llmwiki://sources", "llmwiki://state"]);
+    expect(staticUris).toEqual([
+      "llmwiki://eval/history",
+      "llmwiki://eval/report",
+      "llmwiki://index",
+      "llmwiki://sources",
+      "llmwiki://state",
+    ]);
     expect(templateNames).toEqual(["wiki-concept", "wiki-query"]);
   });
 });
@@ -231,21 +240,10 @@ describe("error handling", () => {
   });
 
   it("compile_wiki surfaces missing-credential errors", async () => {
-    delete process.env.ANTHROPIC_API_KEY;
-    delete process.env.ANTHROPIC_AUTH_TOKEN;
-    const originalSettingsPath = process.env.LLMWIKI_CLAUDE_SETTINGS_PATH;
-    process.env.LLMWIKI_CLAUDE_SETTINGS_PATH = path.join(root, "no-such-settings.json");
-    const server = buildServer();
-
-    try {
+    await withNoCredentials(root, async () => {
+      const server = buildServer();
       await expect(callTool(server, "compile_wiki", {})).rejects.toThrow(/Anthropic credentials/);
-    } finally {
-      if (originalSettingsPath !== undefined) {
-        process.env.LLMWIKI_CLAUDE_SETTINGS_PATH = originalSettingsPath;
-      } else {
-        delete process.env.LLMWIKI_CLAUDE_SETTINGS_PATH;
-      }
-    }
+    });
   });
 });
 
@@ -315,3 +313,81 @@ describe("MCP resources", () => {
   });
 });
 
+
+type ResourceMap = Record<string, { readCallback: (uri: URL) => Promise<{ contents: Array<{ text: string }> }> }>;
+
+describe("run_eval tool", () => {
+  it("returns EvalReport shape for an empty project (fast suite)", async () => {
+    const server = buildServer();
+    const result = await callTool(server, "run_eval", { suite: "fast" });
+    const payload = result.structuredContent?.result as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      suite: "fast",
+      timestamp: expect.any(String),
+      health: expect.objectContaining({ score: expect.any(Number) }),
+      citationCoverage: expect.objectContaining({ coveragePercent: expect.any(Number) }),
+      stats: expect.objectContaining({ pageCount: expect.any(Number) }),
+      thresholdViolations: expect.any(Array),
+    });
+    expect(payload.citationSupport).toBeUndefined();
+  });
+
+  it("throws credentials error when suite=full and no provider configured", async () => {
+    await withNoCredentials(root, async () => {
+      const server = buildServer();
+      await expect(callTool(server, "run_eval", { suite: "full" })).rejects.toThrow(/Anthropic credentials/);
+    });
+  });
+});
+
+describe("eval resources", () => {
+  it("resolves llmwiki://eval/report returning {} when no history exists", async () => {
+    const server = buildServer();
+    const resource = (getRegisteredResources(server) as ResourceMap)["llmwiki://eval/report"];
+    const result = await resource.readCallback(new URL("llmwiki://eval/report"));
+    expect(JSON.parse(result.contents[0].text)).toEqual({});
+  });
+
+  it("resolves llmwiki://eval/report returning the last report when history exists", async () => {
+    await appendHistory(root, makeEvalReport());
+    const server = buildServer();
+    const resource = (getRegisteredResources(server) as ResourceMap)["llmwiki://eval/report"];
+    const result = await resource.readCallback(new URL("llmwiki://eval/report"));
+    const parsed = JSON.parse(result.contents[0].text);
+    expect(parsed).toMatchObject({ suite: "fast", health: { score: 90 } });
+  });
+
+  it("resolves llmwiki://eval/history returning [] when no history exists", async () => {
+    const server = buildServer();
+    const resource = (getRegisteredResources(server) as ResourceMap)["llmwiki://eval/history"];
+    const result = await resource.readCallback(new URL("llmwiki://eval/history"));
+    expect(JSON.parse(result.contents[0].text)).toEqual([]);
+  });
+
+  it("resolves llmwiki://eval/history returning entries when history exists", async () => {
+    await appendHistory(root, makeEvalReport());
+    await appendHistory(root, makeEvalReport({ suite: "full" }));
+    const server = buildServer();
+    const resource = (getRegisteredResources(server) as ResourceMap)["llmwiki://eval/history"];
+    const result = await resource.readCallback(new URL("llmwiki://eval/history"));
+    const parsed = JSON.parse(result.contents[0].text) as unknown[];
+    expect(parsed).toHaveLength(2);
+  });
+});
+
+/** Run `fn` with all Anthropic credentials cleared and a missing settings path, then restore. */
+async function withNoCredentials(root: string, fn: () => Promise<void>): Promise<void> {
+  delete process.env.ANTHROPIC_API_KEY;
+  delete process.env.ANTHROPIC_AUTH_TOKEN;
+  const originalSettingsPath = process.env.LLMWIKI_CLAUDE_SETTINGS_PATH;
+  process.env.LLMWIKI_CLAUDE_SETTINGS_PATH = path.join(root, "no-such-settings.json");
+  try {
+    await fn();
+  } finally {
+    if (originalSettingsPath !== undefined) {
+      process.env.LLMWIKI_CLAUDE_SETTINGS_PATH = originalSettingsPath;
+    } else {
+      delete process.env.LLMWIKI_CLAUDE_SETTINGS_PATH;
+    }
+  }
+}

--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -377,17 +377,20 @@ describe("eval resources", () => {
 
 /** Run `fn` with all Anthropic credentials cleared and a missing settings path, then restore. */
 async function withNoCredentials(root: string, fn: () => Promise<void>): Promise<void> {
+  const saved: Record<string, string | undefined> = {
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+    ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
+    LLMWIKI_CLAUDE_SETTINGS_PATH: process.env.LLMWIKI_CLAUDE_SETTINGS_PATH,
+  };
   delete process.env.ANTHROPIC_API_KEY;
   delete process.env.ANTHROPIC_AUTH_TOKEN;
-  const originalSettingsPath = process.env.LLMWIKI_CLAUDE_SETTINGS_PATH;
   process.env.LLMWIKI_CLAUDE_SETTINGS_PATH = path.join(root, "no-such-settings.json");
   try {
     await fn();
   } finally {
-    if (originalSettingsPath !== undefined) {
-      process.env.LLMWIKI_CLAUDE_SETTINGS_PATH = originalSettingsPath;
-    } else {
-      delete process.env.LLMWIKI_CLAUDE_SETTINGS_PATH;
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
     }
   }
 }


### PR DESCRIPTION


## Summary

This PR exposes the eval harness through the MCP server, giving agents a
structured way to score wiki quality and read past results without dropping
into the CLI.

### What it does

- Adds a `run_eval` MCP tool: fast suite checks health and citation coverage
  without any LLM calls; full suite additionally LLM-judges a sample of
  citations. Returns a full `EvalReport` with threshold violations.
- Adds `llmwiki://eval/report` — a read-only resource serving the most recent
  eval report (empty object if none exists yet).
- Adds `llmwiki://eval/history` — a read-only resource serving the last 10 runs
  as a trend array.
- Updates the MCP server instructions to mention `run_eval` alongside the other
  major tools.

### Architecture

| Area | Change |
|---|---|
| `src/eval/index.ts` | New module entry point: `runEval()`, `buildReport()`, `EvalComponents`. Mirrors the `linter/index.ts` / `compiler/index.ts` pattern. |
| `src/mcp/tools.ts` | `registerEvalTool` — thin wrapper, calls `runEval()` then `jsonResult()`, matching every other tool's structure. |
| `src/mcp/resources.ts` | `registerEvalReportResource` + `registerEvalHistoryResource` — read-only JSON resources backed by `loadPreviousReport` / `loadHistory`. |
| `src/mcp/server.ts` | Instructions updated to include `run_eval`; notes fast suite needs no API key. |
| `src/commands/eval.ts` | Simplified: delegates entirely to `runEval()`, removing the private `runEvalComponents` and `buildReport` functions. |
| `test/mcp-server.test.ts` | Tests for `run_eval` shape, credentials guard, and both eval resources. Extracts `withNoCredentials` helper to remove repeated teardown pattern. |

### Key design decisions

- **Consistent module boundary**: the eval layer now has a proper `index.ts`
  entry point. Both the CLI command and the MCP tool import `runEval` from
  `src/eval/index.ts` — no cross-command imports.
- **Fast suite needs no credentials**: `ensureProviderAvailable()` is only
  called when `suite === "full"`, so `run_eval` with default options is safe in
  read-only contexts, consistent with how `lint_wiki` and `wiki_status` behave.
- **Resources are read-only**: the eval resources surface existing history
  without triggering a new run, keeping them cheap and side-effect-free.

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 1180 tests pass
- [x] `npx fallow` — no dead code, no duplication
- [x] MCP: `run_eval` (fast suite) returns a valid `EvalReport` shape
- [x] MCP: `run_eval` (full suite) throws credential error without API key
- [x] MCP: `llmwiki://eval/report` returns `{}` on a fresh project
- [x] MCP: `llmwiki://eval/history` returns `[]` on a fresh project