### PR TITLE
Add JSON export bridge contract for downstream importers

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Pages include source attribution in frontmatter. Paragraphs are annotated with `
 | `llmwiki schema show` | Print the resolved schema for the current project |
 | `llmwiki query "question"` | Ask questions against your compiled wiki |
 | `llmwiki query "question" --save` | Answer and save the result as a wiki page |
-| `llmwiki export [--target <name>]` | Export the wiki to portable formats — `llms.txt`, `llms-full.txt`, JSON, JSON-LD, GraphML, Marp slides |
+| `llmwiki export [--target <name>] [--project-id <id>]` | Export the wiki to portable formats — `llms.txt`, `llms-full.txt`, JSON, JSON-LD, GraphML, Marp slides. `--project-id` pins a stable identifier inside the JSON envelope so downstream importers (e.g. [`@atomicmemory/llmwiki`](https://github.com/atomicstrata/atomicmemory/tree/main/packages/llmwiki)) can derive deterministic external IDs |
 | `llmwiki view [--open]` | Start a read-only local web viewer for browsing, searching, and inspecting the compiled wiki |
 | `llmwiki next [--json]` | Show the recommended next action for this project (read-only); `--json` emits a stable envelope for agents |
 | `llmwiki context "<prompt>" [--json]` | Build an agent-ready evidence pack (primary pages, citations, neighbors, suggested actions) — same v1 envelope as MCP `get_context_pack` |
@@ -529,13 +529,14 @@ Tools that need an LLM (`compile_wiki`, `query_wiki`, `search_pages`) check for 
 
 ## Companion: Atomic Memory
 
-[Atomic Memory](https://github.com/atomicstrata/atomicmemory) is a separate runtime memory layer for AI applications — semantic retrieval, mutation, and provenance over a long-lived store. It is **valuable on its own** and remains so whether or not llmwiki is in the picture.
+llmwiki and [Atomic Memory](https://github.com/atomicstrata/atomicmemory) are complementary layers of open context infrastructure, both maintained by [Atomic Strata](https://github.com/atomicstrata):
 
-`@atomicmemory/llmwiki` (in the Atomic Memory monorepo) is a one-way bridge: it imports an `llmwiki export --target json` envelope as one verbatim Atomic Memory record per wiki page, with all advisory metadata (kind, citations, confidence, provenance state, contradictions, aliases, freshness) preserved under `memory.metadata.llmwiki.*`.
+- **llmwiki** gives you a persistent **knowledge base** — durable markdown compiled from your sources, inspectable on disk.
+- **Atomic Memory** gives your agents persistent **working memory** — runtime context that's searchable, correctable, scoped, and inspectable over time.
 
-The bridge does NOT replace llmwiki. llmwiki's local-first markdown output remains independently useful as a notebook, RAG index, CI-checked knowledge base, or domain pack source. The bridge just lets you layer runtime semantic recall on top of compiled knowledge when that is the task at hand.
+Use them independently or together. Each remains valuable on its own — llmwiki as a notebook, RAG index, CI-checked knowledge base, or domain pack source; Atomic Memory as a runtime memory layer for any agent or app.
 
-See the cookbook at `packages/llmwiki/docs/cookbook.md` in the Atomic Memory monorepo for the full compile → export → import → package workflow.
+The [`@atomicmemory/llmwiki`](https://github.com/atomicstrata/atomicmemory/tree/main/packages/llmwiki) bridge ingests `llmwiki export --target json --project-id <id>` envelopes as one verbatim Atomic Memory record per wiki page, preserving all advisory metadata (kind, citations, confidence, provenance state, contradictions, aliases, freshness) under `memory.metadata.llmwiki.*`. See the [bridge cookbook](https://github.com/atomicstrata/atomicmemory/blob/main/packages/llmwiki/docs/cookbook.md) for the full compile → export → import → package workflow.
 
 ## Limitations
 
@@ -561,6 +562,10 @@ Karpathy describes an abstract pattern for turning raw data into compiled knowle
 | Fine-tuning | — | Not yet implemented |
 
 ## Roadmap
+
+Shipped in 0.9.0:
+
+- ✅ JSON export bridge contract — `llmwiki export --target json --project-id <id>` adds per-page `path`, `kind`, advisory confidence/provenance, flattened citations, aliases, and freshness so downstream importers (e.g. [`@atomicmemory/llmwiki`](https://github.com/atomicstrata/atomicmemory/tree/main/packages/llmwiki)) can ingest pages as durable memory records
 
 Shipped in 0.8.0:
 
@@ -628,6 +633,10 @@ Explicitly not planned (good ideas, just not for this repo): full static-site ge
 ## Requirements
 
 Node.js >= 24, plus provider credentials (for Anthropic: `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN`).
+
+## About
+
+llmwiki is maintained by [Atomic Strata](https://github.com/atomicstrata), the team behind [Atomic Memory](https://github.com/atomicstrata/atomicmemory). Atomic Strata builds open context infrastructure: durable compiled knowledge with llmwiki, runtime memory with Atomic Memory.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -527,6 +527,16 @@ Tools that need an LLM (`compile_wiki`, `query_wiki`, `search_pages`) check for 
 <br>
 
 
+## Companion: Atomic Memory
+
+[Atomic Memory](https://github.com/atomicstrata/atomicmemory) is a separate runtime memory layer for AI applications — semantic retrieval, mutation, and provenance over a long-lived store. It is **valuable on its own** and remains so whether or not llmwiki is in the picture.
+
+`@atomicmemory/llmwiki` (in the Atomic Memory monorepo) is a one-way bridge: it imports an `llmwiki export --target json` envelope as one verbatim Atomic Memory record per wiki page, with all advisory metadata (kind, citations, confidence, provenance state, contradictions, aliases, freshness) preserved under `memory.metadata.llmwiki.*`.
+
+The bridge does NOT replace llmwiki. llmwiki's local-first markdown output remains independently useful as a notebook, RAG index, CI-checked knowledge base, or domain pack source. The bridge just lets you layer runtime semantic recall on top of compiled knowledge when that is the task at hand.
+
+See the cookbook at `packages/llmwiki/docs/cookbook.md` in the Atomic Memory monorepo for the full compile → export → import → package workflow.
+
 ## Limitations
 
 Early software. Best for small, high-signal corpora (a few dozen sources). Query routing is index-based.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -312,7 +312,11 @@ program
     "--source <kind>",
     "For marp target: which pages to include — concepts, queries, or all (default: all)",
   )
-  .action(async (options: { target?: string; source?: string }) => {
+  .option(
+    "--project-id <id>",
+    "Bridge identifier embedded in the JSON export envelope. Must match /^[a-z0-9][a-z0-9-]{0,62}$/.",
+  )
+  .action(async (options: { target?: string; source?: string; projectId?: string }) => {
     try {
       await exportCommand(process.cwd(), options);
     } catch (err) {

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -21,6 +21,7 @@ import * as output from "../utils/output.js";
 import { collectExportPages } from "../export/collect.js";
 import { buildLlmsTxt, buildLlmsFullTxt } from "../export/llms-txt.js";
 import { buildJsonExport } from "../export/json-export.js";
+import { validateProjectId } from "../export/project-id.js";
 import { buildJsonLd } from "../export/json-ld.js";
 import { buildGraphml } from "../export/graphml.js";
 import { buildMarp } from "../export/marp.js";
@@ -51,6 +52,13 @@ export interface ExportOptions {
    * Accepts "concepts", "queries", or "all" (default when absent).
    */
   source?: string;
+  /**
+   * Optional bridge identifier embedded in the JSON export envelope.
+   * Validated against the bridge contract regex
+   * (`/^[a-z0-9][a-z0-9-]{0,62}$/`); invalid values throw before any
+   * file is written.
+   */
+  projectId?: string;
 }
 
 /** Result returned by runExport for testing and MCP consumers. */
@@ -92,20 +100,26 @@ function resolveMarpSource(rawSource: string | undefined): MarpSource {
   return rawSource;
 }
 
+/** Inputs to {@link buildContent}. Grouped to keep the argument list short. */
+interface BuildContentInputs {
+  target: ExportTarget;
+  pages: ExportPage[];
+  projectTitle: string;
+  marpSource: MarpSource;
+  /** Optional bridge identifier; only consumed by the json target. */
+  projectId?: string;
+}
+
 /** Build the content string for a single target. */
-function buildContent(
-  target: ExportTarget,
-  pages: ReturnType<typeof collectExportPages> extends Promise<infer T> ? T : never,
-  projectTitle: string,
-  marpSource: MarpSource,
-): string {
+function buildContent(inputs: BuildContentInputs): string {
+  const { target, pages, projectTitle, marpSource, projectId } = inputs;
   switch (target) {
     case "llms-txt":
       return buildLlmsTxt(pages, projectTitle);
     case "llms-full-txt":
       return buildLlmsFullTxt(pages, projectTitle);
     case "json":
-      return buildJsonExport(pages);
+      return buildJsonExport(pages, projectId !== undefined ? { projectId } : {});
     case "json-ld":
       return buildJsonLd(pages);
     case "graphml":
@@ -140,6 +154,8 @@ function computeReportedPageCount(
  * @returns Paths written and page count.
  */
 export async function runExport(root: string, options: ExportOptions = {}): Promise<ExportResult> {
+  const projectId =
+    options.projectId !== undefined ? validateProjectId(options.projectId) : undefined;
   const pages = await collectExportPages(root);
   const projectTitle = resolveProjectTitle(root);
 
@@ -148,7 +164,7 @@ export async function runExport(root: string, options: ExportOptions = {}): Prom
   const written: string[] = [];
 
   for (const target of targets) {
-    const content = buildContent(target, pages, projectTitle, marpSource);
+    const content = buildContent({ target, pages, projectTitle, marpSource, projectId });
     const outPath = path.join(root, EXPORT_DIR, TARGET_FILENAMES[target]);
     await atomicWrite(outPath, content);
     written.push(outPath);

--- a/src/context/provenance.ts
+++ b/src/context/provenance.ts
@@ -40,12 +40,13 @@ export const MAX_LINES_PER_WINDOW = 30;
 const CITATION_KEY_SEPARATOR = " <#> ";
 
 /**
- * Flat citation shape consumed by `ContextPrimary.citations[]`. Mirrors
- * the inline anonymous type in `src/context/types.ts`; kept private so
- * the ranker reaches it via structural inference rather than a named
- * cross-module import.
+ * Flat citation shape consumed by `ContextPrimary.citations[]` AND by
+ * the JSON export's `ExportPage.citations[]`. Exported so both
+ * surfaces share one normalized shape rather than drifting — consumers
+ * can reuse the same flattening rule across `llmwiki context` and
+ * `llmwiki export`.
  */
-interface FlatCitation {
+export interface FlatCitation {
   file: string;
   start?: number;
   end?: number;

--- a/src/export/collect.ts
+++ b/src/export/collect.ts
@@ -9,34 +9,102 @@
  * export and viewer callers share one source.
  */
 
+import path from "path";
 import { collectRawWikiPages, extractWikilinkSlugs } from "../wiki/collect.js";
 import type { RawWikiPage } from "../wiki/collect.js";
-import type { ExportPage } from "./types.js";
+import { extractClaimCitations } from "../utils/markdown.js";
+import { flattenCitations } from "../context/provenance.js";
+import type { PageKind } from "../schema/types.js";
+import type { ProvenanceState, ContradictionRef } from "../utils/types.js";
+import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
+import type { ExportPage, PageDirectory } from "./types.js";
 
 export { extractWikilinkSlugs };
+
+/** Resolve the project-relative path for a wiki page (e.g. `wiki/concepts/retrieval.md`). */
+function buildPagePath(pageDirectory: PageDirectory, slug: string): string {
+  const dir = pageDirectory === "concepts" ? CONCEPTS_DIR : QUERIES_DIR;
+  return path.posix.join(dir, `${slug}.md`);
+}
+
+/** Pull a typed string array out of frontmatter or return `[]` for missing/malformed input. */
+function readStringArray(meta: Record<string, unknown>, field: string): string[] {
+  const value = meta[field];
+  if (!Array.isArray(value)) return [];
+  return (value as unknown[]).filter((s): s is string => typeof s === "string");
+}
+
+/** Read a numeric confidence value if present and in the [0, 1] range. */
+function readAdvisoryConfidence(meta: Record<string, unknown>): number | undefined {
+  const value = meta.confidence;
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  if (value < 0 || value > 1) return undefined;
+  return value;
+}
+
+/** Validate and return a ProvenanceState from frontmatter, or undefined. */
+function readProvenanceState(meta: Record<string, unknown>): ProvenanceState | undefined {
+  const value = meta.provenanceState;
+  if (value === "extracted" || value === "merged" || value === "inferred" || value === "ambiguous") {
+    return value;
+  }
+  return undefined;
+}
+
+/** Filter ContradictionRef entries to the documented `{ slug, reason? }` shape. */
+function readContradictedBy(meta: Record<string, unknown>): ContradictionRef[] | undefined {
+  const raw = meta.contradictedBy;
+  if (!Array.isArray(raw)) return undefined;
+  const refs: ContradictionRef[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const candidate = entry as Record<string, unknown>;
+    if (typeof candidate.slug !== "string" || candidate.slug.length === 0) continue;
+    const ref: ContradictionRef = { slug: candidate.slug };
+    if (typeof candidate.reason === "string") ref.reason = candidate.reason;
+    refs.push(ref);
+  }
+  return refs.length > 0 ? refs : undefined;
+}
+
+/** Validate and return PageKind from frontmatter, or undefined. */
+function readPageKind(meta: Record<string, unknown>): PageKind | undefined {
+  const value = meta.kind;
+  if (value === "concept" || value === "entity" || value === "comparison" || value === "overview") {
+    return value;
+  }
+  return undefined;
+}
 
 /**
  * Normalize a kept page into the shape every export writer consumes.
  * Caller is responsible for filtering out records that fail the export
- * gate (orphaned, untitled, unreadable).
+ * gate (orphaned, untitled, unreadable). The bridge contract additions
+ * (path, kind, advisory*, citations, aliases) are populated here so
+ * every export format gets the same enriched payload.
  */
 function toExportPage(raw: RawWikiPage): ExportPage {
   const meta = raw.frontmatter;
+  const aliases = readStringArray(meta, "aliases");
   return {
     title: raw.title as string,
     slug: raw.slug,
     pageDirectory: raw.pageDirectory,
+    path: buildPagePath(raw.pageDirectory, raw.slug),
     summary: typeof meta.summary === "string" ? meta.summary : "",
-    sources: Array.isArray(meta.sources)
-      ? (meta.sources as unknown[]).filter((s): s is string => typeof s === "string")
-      : [],
-    tags: Array.isArray(meta.tags)
-      ? (meta.tags as unknown[]).filter((t): t is string => typeof t === "string")
-      : [],
+    sources: readStringArray(meta, "sources"),
+    tags: readStringArray(meta, "tags"),
     createdAt: typeof meta.createdAt === "string" ? meta.createdAt : new Date().toISOString(),
     updatedAt: typeof meta.updatedAt === "string" ? meta.updatedAt : new Date().toISOString(),
     links: extractWikilinkSlugs(raw.body),
     body: raw.body,
+    kind: readPageKind(meta),
+    advisoryConfidence: readAdvisoryConfidence(meta),
+    provenanceState: readProvenanceState(meta),
+    contradictedBy: readContradictedBy(meta),
+    citations: flattenCitations(extractClaimCitations(raw.body)),
+    ...(aliases.length > 0 ? { aliases } : {}),
+    advisoryFreshnessStatus: "unverified",
   };
 }
 

--- a/src/export/json-export.ts
+++ b/src/export/json-export.ts
@@ -7,28 +7,53 @@
  * additional transformation.
  *
  * Schema:
- *   { exportedAt, pageCount, pages: ExportPage[] }
+ *   { exportedAt, pageCount, projectId?, pages: ExportPage[] }
+ *
+ * `projectId` is the optional bridge identifier. When present it pins the
+ * on-disk export to a stable identity that downstream consumers (the
+ * Atomic Memory adapter especially) use to derive deterministic external
+ * IDs. Validation happens at the CLI/programmatic boundary, not here —
+ * by the time we serialize, the value has been checked.
  */
 
+import { validateProjectId } from "./project-id.js";
 import type { ExportPage } from "./types.js";
 
 /** Top-level shape of the JSON export file. */
 interface JsonExportDocument {
   exportedAt: string;
   pageCount: number;
+  /** Optional bridge identifier. See `src/export/project-id.ts` for the validation rule. */
+  projectId?: string;
   pages: ExportPage[];
+}
+
+/** Options accepted by {@link buildJsonExport}. */
+export interface BuildJsonExportOptions {
+  /**
+   * Optional project identifier. Validated against the bridge contract
+   * regex; throws if invalid so a malformed value never reaches disk.
+   */
+  projectId?: string;
 }
 
 /**
  * Build the JSON export document from a list of export pages.
  * @param pages - Sorted array of export pages.
+ * @param options - Optional bridge envelope fields (e.g. `projectId`).
  * @returns Pretty-printed JSON string.
  */
-export function buildJsonExport(pages: ExportPage[]): string {
+export function buildJsonExport(
+  pages: ExportPage[],
+  options: BuildJsonExportOptions = {},
+): string {
   const doc: JsonExportDocument = {
     exportedAt: new Date().toISOString(),
     pageCount: pages.length,
     pages,
   };
+  if (options.projectId !== undefined) {
+    doc.projectId = validateProjectId(options.projectId);
+  }
   return JSON.stringify(doc, null, 2);
 }

--- a/src/export/project-id.ts
+++ b/src/export/project-id.ts
@@ -1,0 +1,55 @@
+/**
+ * Project ID validation for the JSON export contract.
+ *
+ * The regex `PROJECT_ID_PATTERN` is mirrored byte-for-byte in
+ * `@atomicmemory/llmwiki`'s importer-side `project-id.ts`. When you
+ * change either, change both.
+ *
+ * `projectId` participates in the deterministic external IDs
+ * (`llmwiki/<projectId>/<pageDirectory>/<slug>`) used by downstream
+ * importers and the Atomic Memory namespace scope. It is therefore a
+ * **security boundary**, not just a dedup aid: two projects supplying
+ * the same `projectId` collide and silently overwrite each other
+ * through any upsert primitive.
+ *
+ * Three guards apply:
+ *
+ *   1. Strict regex at the boundary (export side here; import side
+ *      mirrors).
+ *   2. The Atomic Memory write scope must authorize the namespace
+ *      (enforced server-side by the adapter; out of scope for the
+ *      exporter).
+ *   3. Collision detection on import when an existing record's
+ *      `source` field differs (also import side).
+ *
+ * The regex below pins the on-wire format: lowercase letters, digits,
+ * and hyphens; must begin with letter or digit; 1..63 characters. The
+ * length cap matches DNS-label conventions and keeps external IDs
+ * fitting comfortably inside Atomic Memory's metadata indexing limits.
+ */
+
+/** Regex pinning the on-wire `projectId` format. Mirrored on the importer side. */
+export const PROJECT_ID_PATTERN = /^[a-z0-9][a-z0-9-]{0,62}$/;
+
+/**
+ * Validate a candidate `projectId`. Returns the input string when the
+ * input is valid; throws `Error` with a clear, actionable message
+ * otherwise. The thrown message names the rejected value verbatim so
+ * shell users see what they typed.
+ */
+export function validateProjectId(candidate: unknown): string {
+  if (typeof candidate !== "string") {
+    throw new Error(`projectId must be a string; received ${typeof candidate}`);
+  }
+  if (candidate.length === 0) {
+    throw new Error("projectId must not be empty");
+  }
+  if (!PROJECT_ID_PATTERN.test(candidate)) {
+    throw new Error(
+      `Invalid projectId "${candidate}". ` +
+        `Must match /^[a-z0-9][a-z0-9-]{0,62}$/ (lowercase letters, digits, hyphens; ` +
+        `starts with letter or digit; max 63 characters).`,
+    );
+  }
+  return candidate;
+}

--- a/src/export/types.ts
+++ b/src/export/types.ts
@@ -4,7 +4,34 @@
  * ExportPage is the normalised in-memory representation of a wiki page used
  * by every export format. It is derived from the page's YAML frontmatter plus
  * the wikilink graph extracted from the body.
+ *
+ * Trust-adjacent fields (`advisoryConfidence`, `provenanceState`,
+ * `contradictedBy`) are surfaced as **advisory metadata only** — once the
+ * export crosses into any downstream storage (Atomic Memory or otherwise),
+ * those fields become mutable and lose their cryptographic tie to this
+ * export. Consumers should treat them as the compiler's estimate at
+ * export time, not as runtime guarantees.
  */
+
+import type { PageKind } from "../schema/types.js";
+import type { ProvenanceState, ContradictionRef } from "../utils/types.js";
+import type { FlatCitation } from "../context/provenance.js";
+
+/**
+ * Flat citation shape exported alongside each page. Identical to the
+ * normalized `FlatCitation` used by `llmwiki context` so adapters that
+ * consume both surfaces share one shape. Paragraph-only citations omit
+ * `start` and `end`; claim-level citations carry the parsed line range.
+ */
+export type ExportCitation = FlatCitation;
+
+/**
+ * Per-page freshness label. Always `"unverified"` in v1 — the bridge
+ * cannot assert freshness relative to changed sources until the
+ * source-freshness feature (roadmap P0) lands. Renamed from "unknown"
+ * because consumers must act on stale data, not ignore it.
+ */
+export type AdvisoryFreshnessStatus = "unverified";
 
 /**
  * Which wiki/ subdirectory a page lives in.
@@ -24,6 +51,12 @@ export interface ExportPage {
   slug: string;
   /** Whether this page came from wiki/concepts or wiki/queries. */
   pageDirectory: PageDirectory;
+  /**
+   * Project-relative path to the source markdown file, e.g.
+   * `wiki/concepts/retrieval.md`. Surfaced for the bridge so downstream
+   * adapters can deep-link without reconstructing the path themselves.
+   */
+  path: string;
   /** One-line page summary (from frontmatter). */
   summary: string;
   /** Source filenames cited in the page body. */
@@ -38,6 +71,41 @@ export interface ExportPage {
   links: string[];
   /** Full markdown body (without frontmatter). */
   body: string;
+  /**
+   * Optional typed page kind from frontmatter. Defaults to "concept" in
+   * downstream consumers when absent — the export omits the field if no
+   * `kind` was set on the wiki page rather than fabricating a default.
+   */
+  kind?: PageKind;
+  /**
+   * Compiler's confidence estimate at export time. Advisory only —
+   * once imported into any downstream store this field is mutable and
+   * not cryptographically bound to the export.
+   */
+  advisoryConfidence?: number;
+  /** Lifecycle state from the compiler's provenance metadata. Advisory only. */
+  provenanceState?: ProvenanceState;
+  /** Other pages flagged as contradicting this one. Advisory only. */
+  contradictedBy?: ContradictionRef[];
+  /**
+   * Claim citations from the page body, flattened to the shared bridge
+   * shape. One entry per `^[file:start-end]` span. Multi-source markers
+   * (`^[a.md, b.md]`) expand into multiple entries. Paragraph-only
+   * citations carry no line range.
+   */
+  citations: ExportCitation[];
+  /**
+   * Prior external IDs this page was known by (e.g. before a slug
+   * rename). Downstream importers treat any matching alias as an
+   * upsert target so renamed pages do not orphan their prior memory
+   * record.
+   */
+  aliases?: string[];
+  /**
+   * Per-page freshness status. Always `"unverified"` in v1 — the bridge
+   * cannot assert source-freshness until that feature ships.
+   */
+  advisoryFreshnessStatus: AdvisoryFreshnessStatus;
 }
 
 /**

--- a/test/bridge-export-contract-cli.test.ts
+++ b/test/bridge-export-contract-cli.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Subprocess-level integration tests for the bridge contract additions
+ * to `llmwiki export --target json`.
+ *
+ * Coverage:
+ *
+ *  - `--project-id <id>` lands in the JSON envelope.
+ *  - Invalid `--project-id` values cause a non-zero exit with a clear
+ *    error message and DO NOT write `wiki.json`.
+ *  - Default export (no flag) still produces a valid envelope without
+ *    `projectId`.
+ *
+ * `dist/cli.js` is built once via vitest globalSetup; see
+ * test/global-setup.ts.
+ */
+
+import { describe, it, expect } from "vitest";
+import path from "path";
+import { rm, readFile, access } from "fs/promises";
+import { runCLI, expectCLIExit, expectCLIFailure } from "./fixtures/run-cli.js";
+import { writePage } from "./fixtures/write-page.js";
+import { makeTempRoot } from "./fixtures/temp-root.js";
+
+const EXPORT_DIR = "dist/exports";
+
+interface BridgeEnvelope {
+  exportedAt: string;
+  pageCount: number;
+  projectId?: string;
+  pages: { slug: string; path: string; advisoryFreshnessStatus: string }[];
+}
+
+async function makeWiki(suffix: string): Promise<string> {
+  const root = await makeTempRoot(`bridge-cli-${suffix}`);
+  await writePage(
+    path.join(root, "wiki/concepts"),
+    "retrieval",
+    { title: "Retrieval", summary: "x", kind: "concept" },
+    "Retrieval is selective lookup.\n",
+  );
+  return root;
+}
+
+async function readJsonExport(root: string): Promise<BridgeEnvelope> {
+  const raw = await readFile(path.join(root, EXPORT_DIR, "wiki.json"), "utf-8");
+  return JSON.parse(raw) as BridgeEnvelope;
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("llmwiki export --target json (bridge contract CLI)", () => {
+  it("embeds --project-id in the JSON envelope", async () => {
+    const root = await makeWiki("ok");
+    try {
+      const result = await runCLI(
+        ["export", "--target", "json", "--project-id", "my-kb"],
+        root,
+      );
+      expectCLIExit(result, 0);
+      const env = await readJsonExport(root);
+      expect(env.projectId).toBe("my-kb");
+      expect(env.pages[0].path).toBe("wiki/concepts/retrieval.md");
+      expect(env.pages[0].advisoryFreshnessStatus).toBe("unverified");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("omits projectId when the flag is not supplied", async () => {
+    const root = await makeWiki("default");
+    try {
+      const result = await runCLI(["export", "--target", "json"], root);
+      expectCLIExit(result, 0);
+      const env = await readJsonExport(root);
+      expect(env.projectId).toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a path-traversal projectId and writes nothing", async () => {
+    const root = await makeWiki("traversal");
+    try {
+      const result = await runCLI(
+        ["export", "--target", "json", "--project-id", "../escape"],
+        root,
+      );
+      expectCLIFailure(result);
+      expect(result.stderr + result.stdout).toMatch(/Invalid projectId/);
+      const wrote = await fileExists(path.join(root, EXPORT_DIR, "wiki.json"));
+      expect(wrote).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an oversize projectId at the CLI boundary", async () => {
+    const root = await makeWiki("oversize");
+    try {
+      const result = await runCLI(
+        ["export", "--target", "json", "--project-id", "a".repeat(64)],
+        root,
+      );
+      expectCLIFailure(result);
+      expect(result.stderr + result.stdout).toMatch(/Invalid projectId/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/bridge-export-contract.test.ts
+++ b/test/bridge-export-contract.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Unit tests for the JSON export's bridge contract additions.
+ *
+ * Verifies the in-process behavior of `collectExportPages`,
+ * `buildJsonExport`, and `validateProjectId`:
+ *
+ *  - Every new `ExportPage` field round-trips from frontmatter through
+ *    the JSON envelope (path, kind, advisoryConfidence, provenanceState,
+ *    contradictedBy, citations, aliases, advisoryFreshnessStatus).
+ *  - `projectId` is embedded only when supplied; regex enforcement
+ *    rejects malformed values at the validator boundary.
+ *
+ * Subprocess-level coverage of the CLI flag lives in
+ * `bridge-export-contract-cli.test.ts` to keep file size under control.
+ */
+
+import { describe, it, expect } from "vitest";
+import path from "path";
+import { writePage } from "./fixtures/write-page.js";
+import { makeTempRoot } from "./fixtures/temp-root.js";
+import { collectExportPages } from "../src/export/collect.js";
+import { buildJsonExport } from "../src/export/json-export.js";
+import {
+  PROJECT_ID_PATTERN,
+  validateProjectId,
+} from "../src/export/project-id.js";
+
+interface BridgeExportPage {
+  title: string;
+  slug: string;
+  pageDirectory: "concepts" | "queries";
+  path: string;
+  kind?: string;
+  advisoryConfidence?: number;
+  provenanceState?: string;
+  contradictedBy?: { slug: string; reason?: string }[];
+  citations: { file: string; start?: number; end?: number }[];
+  aliases?: string[];
+  advisoryFreshnessStatus: string;
+}
+
+interface BridgeExportEnvelope {
+  exportedAt: string;
+  pageCount: number;
+  projectId?: string;
+  pages: BridgeExportPage[];
+}
+
+function findPage(envelope: BridgeExportEnvelope, slug: string): BridgeExportPage {
+  const page = envelope.pages.find((p) => p.slug === slug);
+  if (!page) throw new Error(`expected to find page with slug "${slug}" in export`);
+  return page;
+}
+
+describe("bridge export contract — collectExportPages + buildJsonExport", () => {
+  it("populates path, kind, citations, and advisoryFreshnessStatus for a basic concept", async () => {
+    const root = await makeTempRoot("basic");
+    await writePage(
+      path.join(root, "wiki/concepts"),
+      "retrieval",
+      { title: "Retrieval", summary: "x", kind: "concept" },
+      "Retrieval is selective lookup. ^[paper.md:10-15]\n",
+    );
+
+    const pages = await collectExportPages(root);
+    const env = JSON.parse(buildJsonExport(pages)) as BridgeExportEnvelope;
+    const page = findPage(env, "retrieval");
+
+    expect(page.path).toBe("wiki/concepts/retrieval.md");
+    expect(page.kind).toBe("concept");
+    expect(page.advisoryFreshnessStatus).toBe("unverified");
+    expect(page.citations).toEqual([{ file: "paper.md", start: 10, end: 15 }]);
+  });
+
+  it("round-trips advisoryConfidence, provenanceState, contradictedBy, aliases", async () => {
+    const root = await makeTempRoot("trust");
+    await writePage(
+      path.join(root, "wiki/concepts"),
+      "embeddings",
+      {
+        title: "Embeddings",
+        summary: "vectors",
+        kind: "concept",
+        confidence: 0.82,
+        provenanceState: "extracted",
+        contradictedBy: [{ slug: "sparse-retrieval", reason: "different paradigm" }],
+        aliases: ["llmwiki/old-proj/concepts/vectors"],
+      },
+      "Body.\n",
+    );
+
+    const pages = await collectExportPages(root);
+    const env = JSON.parse(buildJsonExport(pages)) as BridgeExportEnvelope;
+    const page = findPage(env, "embeddings");
+
+    expect(page.advisoryConfidence).toBe(0.82);
+    expect(page.provenanceState).toBe("extracted");
+    expect(page.contradictedBy).toEqual([
+      { slug: "sparse-retrieval", reason: "different paradigm" },
+    ]);
+    expect(page.aliases).toEqual(["llmwiki/old-proj/concepts/vectors"]);
+  });
+
+  it("omits aliases when none are declared and rejects out-of-range confidence", async () => {
+    const root = await makeTempRoot("omit");
+    await writePage(
+      path.join(root, "wiki/concepts"),
+      "vector-search",
+      { title: "Vector Search", summary: "v", kind: "concept", confidence: 1.5 },
+      "Body.\n",
+    );
+
+    const pages = await collectExportPages(root);
+    const env = JSON.parse(buildJsonExport(pages)) as BridgeExportEnvelope;
+    const page = findPage(env, "vector-search");
+
+    expect(page.aliases).toBeUndefined();
+    expect(page.advisoryConfidence).toBeUndefined();
+  });
+
+  it("flattens citations and de-dupes by (file,start,end)", async () => {
+    const root = await makeTempRoot("citations");
+    await writePage(
+      path.join(root, "wiki/concepts"),
+      "chunking",
+      { title: "Chunking", summary: "s", kind: "concept" },
+      "Claim one. ^[paper.md:10-15]\n\nClaim two. ^[paper.md:10-15, other.md:5-8]\n",
+    );
+
+    const pages = await collectExportPages(root);
+    const env = JSON.parse(buildJsonExport(pages)) as BridgeExportEnvelope;
+    const page = findPage(env, "chunking");
+
+    expect(page.citations).toEqual([
+      { file: "paper.md", start: 10, end: 15 },
+      { file: "other.md", start: 5, end: 8 },
+    ]);
+  });
+});
+
+describe("bridge export contract — projectId envelope field", () => {
+  it("omits projectId from the envelope when none is supplied", async () => {
+    const root = await makeTempRoot("noproj");
+    await writePage(
+      path.join(root, "wiki/concepts"),
+      "p",
+      { title: "P", summary: "s" },
+      "Body.\n",
+    );
+    const env = JSON.parse(buildJsonExport(await collectExportPages(root))) as BridgeExportEnvelope;
+    expect(env.projectId).toBeUndefined();
+  });
+
+  it("embeds a valid projectId in the envelope", async () => {
+    const root = await makeTempRoot("proj");
+    await writePage(
+      path.join(root, "wiki/concepts"),
+      "p",
+      { title: "P", summary: "s" },
+      "Body.\n",
+    );
+    const pages = await collectExportPages(root);
+    const env = JSON.parse(buildJsonExport(pages, { projectId: "my-kb" })) as BridgeExportEnvelope;
+    expect(env.projectId).toBe("my-kb");
+  });
+});
+
+describe("bridge export contract — validateProjectId", () => {
+  it("accepts canonical kebab-case identifiers", () => {
+    for (const id of ["a", "kb", "my-kb", "team-foo-2024", "abc123"]) {
+      expect(validateProjectId(id)).toBe(id);
+      expect(PROJECT_ID_PATTERN.test(id)).toBe(true);
+    }
+  });
+
+  it("rejects path-traversal, uppercase, leading hyphen, and oversize values", () => {
+    const bad = ["../escape", "Foo", "-leading", "with space", "a".repeat(64)];
+    for (const id of bad) {
+      expect(() => validateProjectId(id)).toThrow(/Invalid projectId/);
+    }
+  });
+
+  it("rejects non-string and empty inputs with a clear message", () => {
+    expect(() => validateProjectId(undefined)).toThrow(/must be a string/);
+    expect(() => validateProjectId(123)).toThrow(/must be a string/);
+    expect(() => validateProjectId("")).toThrow(/must not be empty/);
+  });
+});


### PR DESCRIPTION
## Summary

Extends `llmwiki export --target json` with the fields downstream importers need to ingest wiki pages as durable memory records, and adds a `--project-id` flag for deterministic external-ID derivation.

### What changed

- **Per-page bridge fields** added to `ExportPage`: `path`, `kind`, `advisoryConfidence`, `provenanceState`, `contradictedBy`, flattened `citations`, optional `aliases`, and `advisoryFreshnessStatus` (always `"unverified"` in v1).
- **Envelope `projectId`** + `--project-id` CLI flag, validated by a strict `/^[a-z0-9][a-z0-9-]{0,62}$/` regex at both the CLI boundary and inside `buildJsonExport`. Path-traversal, uppercase, leading-hyphen, and oversize values are rejected before any file is written.
- **`FlatCitation` promoted to a public type** so the `llmwiki context` and `llmwiki export` surfaces share one normalized citation shape rather than drifting.
- **README companion section** documenting the relationship with Atomic Memory as a one-way import path. Framed so llmwiki remains independently useful in either direction.

### Why

The export envelope was missing the metadata downstream importers need for deterministic upsert and source-traceable memory records. `projectId` is treated as a **security boundary** (not a dedup aid): two projects supplying the same id collide and silently overwrite each other through any upsert primitive, so the regex is enforced on both sides of the bridge.

## Test plan

- [ ] `npm test` — full suite (1187 passing, 3 skipped)
- [ ] `npx tsc --noEmit` — type-check clean
- [ ] `npm run build` — build succeeds
- [ ] `llmwiki export --target json --project-id <id>` writes `dist/exports/wiki.json` with the new fields populated
- [ ] `llmwiki export --target json --project-id "../escape"` exits non-zero with `Invalid projectId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
