### PR TITLE
feat(viewer): resolve wikilinks via page frontmatter aliases

### DIFF
--- a/src/viewer/collect.ts
+++ b/src/viewer/collect.ts
@@ -16,11 +16,17 @@
 
 import { collectRawWikiPages, extractWikilinkSlugs, extractWikilinkTargets } from "../wiki/collect.js";
 import type { RawWikiPage } from "../wiki/collect.js";
-import { extractClaimCitations } from "../utils/markdown.js";
+import { extractClaimCitations, slugify } from "../utils/markdown.js";
 import type { PageId, ViewerPage, ViewerWarning } from "./types.js";
 
 /** Minimal page shape `resolveBareSlug` needs to find a target. */
-type PageIndexEntry = { id: PageId; pageDirectory: ViewerPage["pageDirectory"]; slug: string };
+type PageIndexEntry = {
+  id: PageId;
+  pageDirectory: ViewerPage["pageDirectory"];
+  slug: string;
+  /** Declared frontmatter aliases, used as a resolution fallback after exact slug. */
+  aliases?: readonly string[];
+};
 
 /**
  * Build the decorated page list for a project root. Each `ViewerPage`
@@ -49,7 +55,19 @@ export function resolveBareSlug(
   if (concept) return concept.id;
   const query = pages.find((p) => p.pageDirectory === "queries" && p.slug === slug);
   if (query) return query.id;
+  // Alias fallback: a page whose declared aliases slugify to this target. An
+  // exact slug match always wins (above) so a real page is never shadowed by
+  // another page's alias; concepts still take precedence over queries.
+  const conceptAlias = pages.find((p) => p.pageDirectory === "concepts" && hasAliasSlug(p, slug));
+  if (conceptAlias) return conceptAlias.id;
+  const queryAlias = pages.find((p) => p.pageDirectory === "queries" && hasAliasSlug(p, slug));
+  if (queryAlias) return queryAlias.id;
   return null;
+}
+
+/** True when any of the page's declared aliases slugifies to `slug`. */
+function hasAliasSlug(page: PageIndexEntry, slug: string): boolean {
+  return (page.aliases ?? []).some((alias) => slugify(alias) === slug);
 }
 
 /**
@@ -124,10 +142,18 @@ function buildPageShell(page: RawWikiPage): ViewerPage {
     filePath: page.filePath,
     frontmatter: page.frontmatter,
     body: page.body,
+    aliases: readAliases(page.frontmatter),
     outgoingLinks: [],
     citations: extractClaimCitations(page.body),
     warnings: warningsFromParseStatus(page),
   };
+}
+
+/** Read the `aliases` frontmatter field as a string list (empty when absent/malformed). */
+function readAliases(frontmatter: Record<string, unknown>): string[] {
+  const raw = frontmatter.aliases;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((entry): entry is string => typeof entry === "string");
 }
 
 /**

--- a/src/viewer/types.ts
+++ b/src/viewer/types.ts
@@ -53,6 +53,8 @@ export interface ViewerPage {
   filePath: string;
   /** Raw frontmatter object (empty when missing or malformed). */
   frontmatter: Record<string, unknown>;
+  /** Declared frontmatter aliases; a wikilink whose slug matches one resolves here. */
+  aliases?: string[];
   /** Markdown body with the frontmatter block stripped. Needed by Slice 4. */
   body: string;
   /** Outgoing wikilink targets resolved to namespaced IDs. */

--- a/test/viewer-collect.test.ts
+++ b/test/viewer-collect.test.ts
@@ -120,3 +120,51 @@ describe("collectViewerPages — outgoing links and bare-slug resolution", () =>
     expect(resolveBareSlug("a", pages)).toBe("concepts/a");
   });
 });
+
+describe("collectViewerPages — alias resolution", () => {
+  it("resolves a wikilink whose slug matches a page's declared alias", async () => {
+    const root = await makeTempRoot("viewer-collect-alias");
+    await writePage(
+      path.join(root, "wiki/concepts"),
+      "computer-vision-and-nlp-integration",
+      { title: "CV/NLP Integration", aliases: ["Computer Vision", "NLP"] },
+      "B.",
+    );
+    const pages = await collectViewerPages(root);
+    // `[[computer vision]]` slugifies to "computer-vision" — no page has that
+    // exact slug, but a page declares it as an alias.
+    expect(resolveBareSlug("computer-vision", pages)).toBe("concepts/computer-vision-and-nlp-integration");
+    expect(resolveBareSlug("nlp", pages)).toBe("concepts/computer-vision-and-nlp-integration");
+  });
+
+  it("prefers an exact slug match over an alias match", async () => {
+    const root = await makeTempRoot("viewer-collect-alias-precedence");
+    await writePage(path.join(root, "wiki/concepts"), "vision", { title: "Vision" }, "B.");
+    await writePage(
+      path.join(root, "wiki/concepts"),
+      "other",
+      { title: "Other", aliases: ["Vision"] },
+      "B.",
+    );
+    expect(resolveBareSlug("vision", await collectViewerPages(root))).toBe("concepts/vision");
+  });
+
+  it("resolves outgoing links and clears danglingLinks via aliases end-to-end", async () => {
+    const root = await makeTempRoot("viewer-collect-alias-e2e");
+    await writePage(
+      path.join(root, "wiki/concepts"),
+      "deep-learning-foundations",
+      { title: "Deep Learning Foundations", aliases: ["deep learning"] },
+      "B.",
+    );
+    await writePage(
+      path.join(root, "wiki/concepts"),
+      "linker",
+      { title: "Linker" },
+      "See [[deep learning]].",
+    );
+    const linker = (await collectViewerPages(root)).find((p) => p.slug === "linker");
+    expect(linker?.outgoingLinks).toEqual(["concepts/deep-learning-foundations"]);
+    expect(linker?.danglingLinks ?? []).toEqual([]);
+  });
+});

--- a/test/viewer-render.test.ts
+++ b/test/viewer-render.test.ts
@@ -124,6 +124,13 @@ describe("renderPageHtml — wikilinks", () => {
     expect(html).toContain('data-missing="true"');
     expect(html).toContain("[[ghost]]");
   });
+
+  it("resolves [[X]] to a page that declares X as a frontmatter alias", () => {
+    const target = { ...buildPage("deep-learning-foundations", "Deep Learning Foundations"), aliases: ["deep learning"] };
+    const { html } = renderPageHtml("See [[deep learning]].", buildSnapshot([target]), { isLoopback: true });
+    expect(html).toContain('data-page-id="concepts/deep-learning-foundations"');
+    expect(html).not.toContain('data-missing="true"');
+  });
 });
 
 describe("renderPageHtml — citation chips", () => {


### PR DESCRIPTION
Resolves a `[[X]]` wikilink to a page that declares `X` among its `aliases` frontmatter, not just one whose slug is exactly `slugify(X)`. Exact slug matches still win and concepts keep precedence over queries, so no real page is shadowed by another page's alias. Both the rendered links and the collector's outgoing/dangling-link computation pick it up since they share `resolveBareSlug`.
