### PR TITLE
chore: gitignore local demo wiki workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ localdocs/
 .worktrees/
 .sisyphus/
 .claude/
+# Local demo/test wiki workspaces (e.g. my-wiki/). The product output dirs
+# /wiki/ and /sources/ above are root-anchored, so a nested workspace's
+# my-wiki/wiki/ and my-wiki/sources/ would otherwise be tracked.
+*-wiki/


### PR DESCRIPTION
Ignores nested demo/test workspaces like `my-wiki/` (containing `my-wiki/wiki/` and `my-wiki/sources/`). The existing `/wiki/` and `/sources/` ignores are root-anchored, so nested workspace copies were being tracked.