### PR TITLE
Add Claude Agent SDK provider (local Claude Code login)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ instead of the raw Messages API. It authenticates with your **local Claude Code
 login** (OAuth/subscription), so **no `ANTHROPIC_API_KEY` is required** — if you
 can run `claude` in your terminal, this provider works.
 
+> **Terms of use.** This provider drives your Claude Code / Agent SDK session
+> programmatically to compile wikis. That is not automatically appropriate for
+> every account type, plan, or environment. Before using it, review Anthropic's
+> current [Claude Code](https://www.anthropic.com/legal/consumer-terms) and
+> [Agent SDK](https://docs.anthropic.com/en/api/agent-sdk/overview) terms and
+> usage policies, and make sure your intended use complies with them.
+
 ```bash
 export LLMWIKI_PROVIDER=claude-agent
 export LLMWIKI_MODEL=claude-sonnet-4-5  # optional; this is the default

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Inspired by Karpathy's [LLM Wiki](https://gist.github.com/karpathy/442a6bf555914
 - **Eval harness.** `llmwiki eval` measures health score (0–100), citation coverage and precision, optional LLM-as-judge support scoring, regression deltas, and CI-gateable thresholds.
 - **MCP server.** `llmwiki serve` exposes the full pipeline to Claude Desktop, Cursor, Claude Code, and any MCP-compatible agent — including `get_context_pack` for budgeted, citation-aware evidence packs.
 - **Bridge to runtime memory.** `llmwiki export --target json --project-id <id>` produces a typed envelope that [`@atomicmemory/llmwiki`](https://github.com/atomicstrata/atomicmemory/tree/main/packages/llmwiki) imports as one verbatim Atomic Memory record per page, preserving all advisory metadata.
-- **Provider-portable.** Anthropic, OpenAI-compatible (incl. local llama.cpp / vLLM), Ollama, GitHub Copilot.
+- **Provider-portable.** Anthropic, Claude Agent SDK (local Claude Code login, no API key), OpenAI-compatible (incl. local llama.cpp / vLLM), Ollama, GitHub Copilot.
 
 ## Who this is for
 
@@ -88,6 +88,36 @@ Example with zero exports (Claude Code already configured):
 ```bash
 llmwiki compile
 ```
+
+### Claude Agent SDK (local Claude Code login)
+
+The `claude-agent` provider routes calls through the
+[Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-typescript)
+instead of the raw Messages API. It authenticates with your **local Claude Code
+login** (OAuth/subscription), so **no `ANTHROPIC_API_KEY` is required** — if you
+can run `claude` in your terminal, this provider works.
+
+```bash
+export LLMWIKI_PROVIDER=claude-agent
+export LLMWIKI_MODEL=claude-sonnet-4-5  # optional; this is the default
+llmwiki compile
+```
+
+Notes:
+
+- Generation (`compile`) and structured extraction work off the local login with
+  no extra credentials.
+- Semantic search (`llmwiki query`) still needs embeddings, which Claude does not
+  provide. Set `VOYAGE_API_KEY` to enable them (same as the `anthropic`
+  provider); otherwise `query` falls back to lexical ranking.
+- To see what the SDK is doing, set `LLMWIKI_DEBUG=1` for a concise one-line trace
+  per SDK message (`[claude-agent] system:init`, `… assistant`, `… result:success`)
+  plus any `claude` subprocess errors. Use `LLMWIKI_DEBUG=verbose` to additionally
+  enable the SDK's full verbose logging.
+
+  ```bash
+  LLMWIKI_DEBUG=1 LLMWIKI_PROVIDER=claude-agent llmwiki compile
+  ```
 
 ### OpenAI-Compatible Local Servers
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.39.0",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.163",
+        "@anthropic-ai/sdk": "^0.100.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@mozilla/readability": "^0.5.0",
         "chokidar": "^4.0.0",
@@ -24,7 +25,7 @@
         "sanitize-html": "^2.17.3",
         "turndown": "^7.2.0",
         "youtube-transcript": "^1.3.1",
-        "zod": "^3.25.76"
+        "zod": "^4.4.3"
       },
       "bin": {
         "llmwiki": "dist/cli.js"
@@ -46,35 +47,166 @@
         "node": ">=24"
       }
     },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.163",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.163.tgz",
+      "integrity": "sha512-JGWfcrQhV5EZggvHb1tfet8JimJci7+4vOgKpQATUxKeE+5rVWH85w9IIND2/R/+qq90mDoMHGM2sYzJYvJXTg==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.163",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.163",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.163",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.163",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.163",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.163",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.163",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.163"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.163",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.163.tgz",
+      "integrity": "sha512-2veSQriv2OR1msX3C5ThYVwQUOLBzEXvdGzmkt9y47DTLHPqS6wy7MBWcNVHj7GDKrkPXnH7zz7DbKYM5yKXjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.163",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.163.tgz",
+      "integrity": "sha512-0n/vjdW12RQuuvJsy6bettU57a7hi7GTGDZxaAWVKpRr+U9A51GPvmUvnTENqogZ3PqpKCYEDv2he4qkA5zCmw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.163",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.163.tgz",
+      "integrity": "sha512-bDwKqn8XT5f9JOcOLaGi0XY6Ndzh3dkCzsub67igXCVYf3i19ElsR9p0LF1vWeQWDnHyCVvCnSfQfmtD3MsHJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.163",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.163.tgz",
+      "integrity": "sha512-kY39TQiXvniq1902IV4H5VSTwkwav6OkXqcr0T7rN04qXzASMpJ9UYlNhwDICBhIxKwcMlz9rjmg9nCDdeBQjQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.163",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.163.tgz",
+      "integrity": "sha512-vYPKM5Nfm4yh3jFDqb17iwY7Y59unuZu9JSYEM45POT5idgZMSC5E9O9jqGIt9GF2Ug7sNRdFMEkUZgIXsZIBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.163",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.163.tgz",
+      "integrity": "sha512-OmvQgIX3X5TZ8wXROOHi90iSmGoVNCREYSP5YR+7o8swR59TjBPhlbaCh22yFX5dc2brftCqwF9WklYMrhaDHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.163",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.163.tgz",
+      "integrity": "sha512-yQFXwSfD1FQfcCVJoxmVNc9KJGtwzwwrQ5sR3xALmVq7N6yjXy6sU6xqowjx+S98Dgiz7fKBrWVZyKLWWxLyRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.163",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.163.tgz",
+      "integrity": "sha512-Fe/zfbh3PK5jDO/yoU5BtY6U2vfMN8GdcrvWggzfe20OAqQjdfbxo31SiD9Rg5gTItE28ns3mcP8toohPkmUwA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.39.0.tgz",
-      "integrity": "sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==",
+      "version": "0.100.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.100.1.tgz",
+      "integrity": "sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
-    },
-    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
@@ -87,6 +219,15 @@
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@copilotkit/aimock": {
@@ -1419,6 +1560,12 @@
         "win32"
       ]
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2494,6 +2641,12 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -3013,6 +3166,19 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -4001,6 +4167,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -4213,6 +4389,12 @@
       "bin": {
         "tree-kill": "cli.js"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
@@ -4696,9 +4878,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "js-yaml": "^4.1.1",
         "jsdom": "^25.0.0",
         "markdown-it": "^14.1.1",
-        "openai": "^4.0.0",
+        "openai": "^6.42.0",
         "p-limit": "^6.0.0",
         "pdf-parse": "^2.4.5",
         "sanitize-html": "^2.17.3",
@@ -1639,19 +1639,10 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/sanitize-html": {
@@ -1793,18 +1784,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1838,18 +1817,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -2506,15 +2473,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -2730,12 +2688,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "license": "MIT"
-    },
     "node_modules/form-data/node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -2755,19 +2707,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
       }
     },
     "node_modules/forwarded": {
@@ -2996,15 +2935,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
       }
     },
     "node_modules/husky": {
@@ -3403,68 +3333,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/nwsapi": {
       "version": "2.2.23",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
@@ -3514,25 +3382,13 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.104.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
-      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
+      "version": "6.42.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.42.0.tgz",
+      "integrity": "sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      },
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
-        "zod": "^3.23.8"
+        "zod": "^3.25 || ^4.0"
       },
       "peerDependenciesMeta": {
         "ws": {
@@ -3542,21 +3398,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/openai/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "6.2.0",
@@ -4514,6 +4355,7 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -4715,15 +4557,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "js-yaml": "^4.1.1",
     "jsdom": "^25.0.0",
     "markdown-it": "^14.1.1",
-    "openai": "^4.0.0",
+    "openai": "^6.42.0",
     "p-limit": "^6.0.0",
     "pdf-parse": "^2.4.5",
     "sanitize-html": "^2.17.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "node": ">=24"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.39.0",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.163",
+    "@anthropic-ai/sdk": "^0.100.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@mozilla/readability": "^0.5.0",
     "chokidar": "^4.0.0",
@@ -61,7 +62,7 @@
     "sanitize-html": "^2.17.3",
     "turndown": "^7.2.0",
     "youtube-transcript": "^1.3.1",
-    "zod": "^3.25.76"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@copilotkit/aimock": "^1.15.1",

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -7,9 +7,7 @@
 
 import Anthropic, { type ClientOptions } from "@anthropic-ai/sdk";
 import type { LLMProvider, LLMMessage, LLMTool } from "../utils/provider.js";
-import { EMBEDDING_MODELS } from "../utils/constants.js";
-
-const VOYAGE_EMBEDDINGS_URL = "https://api.voyageai.com/v1/embeddings";
+import { voyageEmbed } from "./voyage-embed.js";
 
 /**
  * Builds the client options for the Anthropic SDK.
@@ -139,32 +137,6 @@ export class AnthropicProvider implements LLMProvider {
    * to Voyage (their recommended partner). Requires VOYAGE_API_KEY.
    */
   async embed(text: string): Promise<number[]> {
-    const apiKey = process.env.VOYAGE_API_KEY?.trim();
-    if (!apiKey) {
-      throw new Error(
-        "VOYAGE_API_KEY is not set. Anthropic embeddings use Voyage — set VOYAGE_API_KEY to enable semantic search.",
-      );
-    }
-
-    const response = await fetch(VOYAGE_EMBEDDINGS_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({ input: text, model: EMBEDDING_MODELS.anthropic }),
-    });
-
-    if (!response.ok) {
-      const detail = await response.text();
-      throw new Error(`Voyage embeddings request failed (${response.status}): ${detail}`);
-    }
-
-    const json = (await response.json()) as { data?: Array<{ embedding?: number[] }> };
-    const vector = json.data?.[0]?.embedding;
-    if (!Array.isArray(vector)) {
-      throw new Error("Voyage embeddings response did not include a vector.");
-    }
-    return vector;
+    return voyageEmbed(text);
   }
 }

--- a/src/providers/claude-agent.ts
+++ b/src/providers/claude-agent.ts
@@ -92,6 +92,17 @@ function accumulateText(blocks: AssistantBlock[], onToken?: (text: string) => vo
   return text;
 }
 
+/**
+ * Extract the text of a success result, or throw on any error result subtype
+ * (auth failure, max turns, execution failure, …). Failing loudly here keeps a
+ * bad SDK run from silently producing empty or partial wiki output.
+ */
+function resultText(message: { subtype?: string; result?: string; errors?: string[] }): string {
+  if (message.subtype === "success") return message.result ?? "";
+  const detail = message.errors?.join("; ") || message.subtype || "unknown error";
+  throw new Error(`Claude Agent SDK returned an error result: ${detail}`);
+}
+
 /** Return the input of the first matching `tool_use` block, or undefined. */
 function findToolInput(
   blocks: AssistantBlock[],
@@ -140,6 +151,7 @@ export class ClaudeAgentProvider implements LLMProvider {
         systemPrompt: `${system}\n\n${OUTPUT_ONLY_DIRECTIVE}`,
         model: this.model,
         maxTurns: MAX_TURNS,
+        tools: [],
         allowedTools: [],
         ...debugOptions(),
       },
@@ -151,8 +163,8 @@ export class ClaudeAgentProvider implements LLMProvider {
       traceMessage(message);
       if (message.type === "assistant") {
         streamed += accumulateText(message.message.content as AssistantBlock[], onToken);
-      } else if (message.type === "result" && message.subtype === "success") {
-        finalText = message.result;
+      } else if (message.type === "result") {
+        finalText = resultText(message);
       }
     }
     return finalText || streamed;
@@ -185,6 +197,8 @@ export class ClaudeAgentProvider implements LLMProvider {
         model: this.model,
         maxTurns: MAX_TURNS,
         mcpServers: { [TOOL_SERVER_NAME]: mcpServer },
+        // Disable every built-in tool; only the in-process MCP tool is reachable.
+        tools: [],
         allowedTools: [qualifiedName],
         permissionMode: "bypassPermissions",
         allowDangerouslySkipPermissions: true,
@@ -200,26 +214,39 @@ export class ClaudeAgentProvider implements LLMProvider {
   }
 }
 
-/** An assistant message carrying content blocks (other SDK messages are ignored). */
-interface AssistantMessage {
+/** An SDK message: assistant content, or a result whose error subtype must throw. */
+interface StreamMessage {
   type: string;
+  subtype?: string;
+  result?: string;
+  errors?: string[];
   message?: { content: AssistantBlock[] };
 }
 
-/** Read the first matching `tool_use` input from a query stream as JSON. */
+/**
+ * Read the first matching `tool_use` input from a query stream as JSON. Throws
+ * on an SDK error result, and throws if the model never called the tool (prose
+ * or empty output) — callers expect JSON, so a silent fallback would degrade
+ * into zero extracted concepts or broken eval output.
+ */
 async function collectToolInput(
   response: AsyncIterable<unknown>,
   toolName: string,
   qualifiedName: string,
 ): Promise<string> {
-  let fallbackText = "";
+  let prose = "";
   for await (const raw of response) {
     traceMessage(raw);
-    const message = raw as AssistantMessage;
+    const message = raw as StreamMessage;
+    if (message.type === "result") {
+      resultText(message); // throws on any error result; success is ignored here
+      continue;
+    }
     if (message.type !== "assistant" || !message.message) continue;
     const input = findToolInput(message.message.content, toolName, qualifiedName);
     if (input !== undefined) return JSON.stringify(input);
-    fallbackText += accumulateText(message.message.content);
+    prose += accumulateText(message.message.content);
   }
-  return fallbackText;
+  const suffix = prose ? `; it responded with prose instead: ${prose.slice(0, 200)}` : ".";
+  throw new Error(`Claude Agent SDK did not call the "${toolName}" tool${suffix}`);
 }

--- a/src/providers/claude-agent.ts
+++ b/src/providers/claude-agent.ts
@@ -1,0 +1,225 @@
+/**
+ * Claude Agent SDK LLM provider implementation.
+ *
+ * Wraps `@anthropic-ai/claude-agent-sdk`'s `query()` to implement the
+ * LLMProvider interface. Unlike the `anthropic` provider (which calls the raw
+ * Messages API), this backend routes through the Agent SDK and therefore
+ * authenticates with the user's local Claude Code login (OAuth/subscription) —
+ * no standalone ANTHROPIC_API_KEY is required.
+ *
+ * Generation runs in single-shot mode (one turn, no agentic file tools) so it
+ * behaves like a plain completion. Structured output (`toolCall`) is handled
+ * faithfully by registering the requested tool as an in-process SDK MCP tool
+ * and capturing the model's `tool_use` input. Embeddings delegate to Voyage,
+ * mirroring the `anthropic` provider.
+ */
+
+import { query, createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
+import type { LLMProvider, LLMMessage, LLMTool } from "../utils/provider.js";
+import { voyageEmbed } from "./voyage-embed.js";
+import { jsonSchemaToZodShape } from "./json-schema-to-zod.js";
+
+/** Name for the throwaway in-process MCP server used to host a tool. */
+const TOOL_SERVER_NAME = "llmwiki";
+
+/**
+ * Turn ceiling for a single-shot request. The SDK reports an error result when
+ * this ceiling is *reached*, so it must sit above the one turn a clean
+ * completion or forced tool call actually consumes — `1` errors on every call.
+ */
+const MAX_TURNS = 4;
+
+/**
+ * Appended to text-generation prompts. The Agent SDK runs an agentic model that
+ * otherwise prefixes answers with conversational scaffolding ("I'll write…");
+ * this keeps the output to the requested document, matching the raw API path.
+ */
+const OUTPUT_ONLY_DIRECTIVE =
+  "Respond with only the requested content — no preamble, explanation, or sign-off.";
+
+/** A content block on an assistant message (text or tool_use). */
+interface AssistantBlock {
+  type: string;
+  text?: string;
+  name?: string;
+  input?: unknown;
+}
+
+/** Join the user-role message contents into a single prompt string. */
+function buildPrompt(messages: LLMMessage[]): string {
+  return messages.map((message) => message.content).join("\n\n");
+}
+
+/** High-frequency SDK message types/subtypes that add noise without insight. */
+const NOISY_MESSAGES = new Set(["thinking_tokens", "rate_limit_event"]);
+
+/** Resolve the LLMWIKI_DEBUG level: off, a concise trace, or the full SDK firehose. */
+function debugLevel(): "off" | "on" | "verbose" {
+  const value = process.env.LLMWIKI_DEBUG?.trim().toLowerCase();
+  if (!value) return "off";
+  return value === "verbose" || value === "2" ? "verbose" : "on";
+}
+
+/**
+ * Extra query options that surface what the Agent SDK is doing. Always streams
+ * the `claude` subprocess stderr when debugging; the full SDK verbose logs are
+ * added only at the `verbose` level. Empty object unless LLMWIKI_DEBUG is set.
+ */
+function debugOptions(): { debug?: boolean; stderr?: (data: string) => void } {
+  const level = debugLevel();
+  if (level === "off") return {};
+  return { debug: level === "verbose", stderr: (data) => process.stderr.write(data) };
+}
+
+/** Print a one-line trace of a meaningful SDK message (type and subtype). */
+function traceMessage(raw: unknown): void {
+  if (debugLevel() === "off") return;
+  const message = raw as { type?: string; subtype?: string };
+  if (NOISY_MESSAGES.has(message.subtype ?? "") || NOISY_MESSAGES.has(message.type ?? "")) return;
+  const subtype = message.subtype ? `:${message.subtype}` : "";
+  process.stderr.write(`[claude-agent] ${message.type ?? "?"}${subtype}\n`);
+}
+
+/** Accumulate text from assistant content blocks, optionally emitting each chunk. */
+function accumulateText(blocks: AssistantBlock[], onToken?: (text: string) => void): string {
+  let text = "";
+  for (const block of blocks) {
+    if (block.type === "text" && block.text) {
+      text += block.text;
+      onToken?.(block.text);
+    }
+  }
+  return text;
+}
+
+/** Return the input of the first matching `tool_use` block, or undefined. */
+function findToolInput(
+  blocks: AssistantBlock[],
+  toolName: string,
+  qualifiedName: string,
+): unknown {
+  const match = blocks.find(
+    (block) =>
+      block.type === "tool_use" && (block.name === toolName || block.name === qualifiedName),
+  );
+  return match?.input;
+}
+
+/** Claude Agent SDK-backed LLM provider using the local Claude Code login. */
+export class ClaudeAgentProvider implements LLMProvider {
+  private readonly model: string;
+
+  constructor(model: string) {
+    this.model = model;
+  }
+
+  /** Send a single non-streaming completion request. */
+  async complete(system: string, messages: LLMMessage[], _maxTokens: number): Promise<string> {
+    return this.runText(system, buildPrompt(messages));
+  }
+
+  /** Stream a completion, invoking onToken for each text chunk. */
+  async stream(
+    system: string,
+    messages: LLMMessage[],
+    _maxTokens: number,
+    onToken?: (text: string) => void,
+  ): Promise<string> {
+    return this.runText(system, buildPrompt(messages), onToken);
+  }
+
+  /** Run a single-shot, tool-free query and accumulate the assistant's text. */
+  private async runText(
+    system: string,
+    prompt: string,
+    onToken?: (text: string) => void,
+  ): Promise<string> {
+    const response = query({
+      prompt,
+      options: {
+        systemPrompt: `${system}\n\n${OUTPUT_ONLY_DIRECTIVE}`,
+        model: this.model,
+        maxTurns: MAX_TURNS,
+        allowedTools: [],
+        ...debugOptions(),
+      },
+    });
+
+    let streamed = "";
+    let finalText = "";
+    for await (const message of response) {
+      traceMessage(message);
+      if (message.type === "assistant") {
+        streamed += accumulateText(message.message.content as AssistantBlock[], onToken);
+      } else if (message.type === "result" && message.subtype === "success") {
+        finalText = message.result;
+      }
+    }
+    return finalText || streamed;
+  }
+
+  /**
+   * Force a single structured tool call and return its input as a JSON string,
+   * matching the shape callers parse from the other providers.
+   */
+  async toolCall(
+    system: string,
+    messages: LLMMessage[],
+    tools: LLMTool[],
+    _maxTokens: number,
+  ): Promise<string> {
+    const requested = tools[0];
+    const qualifiedName = `mcp__${TOOL_SERVER_NAME}__${requested.name}`;
+    const sdkTool = tool(
+      requested.name,
+      requested.description,
+      jsonSchemaToZodShape(requested.input_schema),
+      async () => ({ content: [{ type: "text", text: "ok" }] }),
+    );
+    const mcpServer = createSdkMcpServer({ name: TOOL_SERVER_NAME, tools: [sdkTool] });
+
+    const response = query({
+      prompt: buildPrompt(messages),
+      options: {
+        systemPrompt: `${system}\n\nRespond by calling the \`${requested.name}\` tool.`,
+        model: this.model,
+        maxTurns: MAX_TURNS,
+        mcpServers: { [TOOL_SERVER_NAME]: mcpServer },
+        allowedTools: [qualifiedName],
+        permissionMode: "bypassPermissions",
+        allowDangerouslySkipPermissions: true,
+        ...debugOptions(),
+      },
+    });
+    return collectToolInput(response, requested.name, qualifiedName);
+  }
+
+  /** Produce a single embedding vector via Voyage (Anthropic has no endpoint). */
+  async embed(text: string): Promise<number[]> {
+    return voyageEmbed(text);
+  }
+}
+
+/** An assistant message carrying content blocks (other SDK messages are ignored). */
+interface AssistantMessage {
+  type: string;
+  message?: { content: AssistantBlock[] };
+}
+
+/** Read the first matching `tool_use` input from a query stream as JSON. */
+async function collectToolInput(
+  response: AsyncIterable<unknown>,
+  toolName: string,
+  qualifiedName: string,
+): Promise<string> {
+  let fallbackText = "";
+  for await (const raw of response) {
+    traceMessage(raw);
+    const message = raw as AssistantMessage;
+    if (message.type !== "assistant" || !message.message) continue;
+    const input = findToolInput(message.message.content, toolName, qualifiedName);
+    if (input !== undefined) return JSON.stringify(input);
+    fallbackText += accumulateText(message.message.content);
+  }
+  return fallbackText;
+}

--- a/src/providers/json-schema-to-zod.ts
+++ b/src/providers/json-schema-to-zod.ts
@@ -1,0 +1,65 @@
+/**
+ * Minimal JSON-Schema → Zod converter for the Claude Agent SDK.
+ *
+ * The Agent SDK's `tool()` helper takes a Zod *raw shape* (a record of Zod
+ * types keyed by property name), but llmwiki declares its tools as JSON Schema
+ * (`LLMTool.input_schema`). This converts the subset of JSON Schema that every
+ * llmwiki tool uses — object / array / string / number / boolean / enum, with
+ * a `required` list — into the raw shape the SDK expects. It is intentionally
+ * narrow: unsupported nodes fall back to `z.unknown()` rather than throwing.
+ */
+
+import { z, type ZodType } from "zod";
+
+/** The slice of JSON Schema this converter understands. */
+interface JsonSchemaNode {
+  type?: string;
+  properties?: Record<string, JsonSchemaNode>;
+  required?: string[];
+  items?: JsonSchemaNode;
+  enum?: unknown[];
+}
+
+/** Builders for primitive JSON Schema types, keyed by `type`. */
+const SCALAR_BUILDERS: Record<string, () => ZodType> = {
+  string: () => z.string(),
+  number: () => z.number(),
+  integer: () => z.number(),
+  boolean: () => z.boolean(),
+};
+
+/** Convert a single JSON Schema node into a Zod type. */
+function nodeToZod(node: JsonSchemaNode): ZodType {
+  if (Array.isArray(node.enum) && node.enum.length > 0) {
+    return z.enum(node.enum.map(String) as [string, ...string[]]);
+  }
+  const scalar = node.type ? SCALAR_BUILDERS[node.type] : undefined;
+  if (scalar) return scalar();
+  if (node.type === "array") {
+    return z.array(node.items ? nodeToZod(node.items) : z.unknown());
+  }
+  if (node.type === "object") return z.object(shapeFromProperties(node));
+  return z.unknown();
+}
+
+/** Build a Zod raw shape from an object schema's properties + required list. */
+function shapeFromProperties(schema: JsonSchemaNode): Record<string, ZodType> {
+  const properties = schema.properties ?? {};
+  const required = new Set(schema.required ?? []);
+  const shape: Record<string, ZodType> = {};
+  for (const [key, value] of Object.entries(properties)) {
+    const zodType = nodeToZod(value);
+    shape[key] = required.has(key) ? zodType : zodType.optional();
+  }
+  return shape;
+}
+
+/**
+ * Convert an Anthropic-style tool `input_schema` (a JSON Schema object) into
+ * the Zod raw shape accepted by the Agent SDK's `tool()` helper.
+ */
+export function jsonSchemaToZodShape(
+  inputSchema: Record<string, unknown>,
+): Record<string, ZodType> {
+  return shapeFromProperties(inputSchema as JsonSchemaNode);
+}

--- a/src/providers/json-schema-to-zod.ts
+++ b/src/providers/json-schema-to-zod.ts
@@ -7,6 +7,10 @@
  * llmwiki tool uses — object / array / string / number / boolean / enum, with
  * a `required` list — into the raw shape the SDK expects. It is intentionally
  * narrow: unsupported nodes fall back to `z.unknown()` rather than throwing.
+ *
+ * Two contract details are preserved so the SDK path matches the raw API path:
+ * numeric/boolean enums keep their literal types (e.g. eval scores `0 | 1 | 2`,
+ * not `"0" | "1" | "2"`), and field `description`s carry through via `.describe`.
  */
 
 import { z, type ZodType } from "zod";
@@ -18,6 +22,7 @@ interface JsonSchemaNode {
   required?: string[];
   items?: JsonSchemaNode;
   enum?: unknown[];
+  description?: string;
 }
 
 /** Builders for primitive JSON Schema types, keyed by `type`. */
@@ -28,11 +33,20 @@ const SCALAR_BUILDERS: Record<string, () => ZodType> = {
   boolean: () => z.boolean(),
 };
 
-/** Convert a single JSON Schema node into a Zod type. */
-function nodeToZod(node: JsonSchemaNode): ZodType {
-  if (Array.isArray(node.enum) && node.enum.length > 0) {
-    return z.enum(node.enum.map(String) as [string, ...string[]]);
+/** Build a Zod type for an enum, keeping numeric/boolean values as literals. */
+function enumToZod(values: unknown[]): ZodType {
+  if (values.every((value) => typeof value === "string")) {
+    return z.enum(values as [string, ...string[]]);
   }
+  const literals = values.map((value) => z.literal(value as string | number | boolean));
+  return literals.length === 1
+    ? literals[0]
+    : z.union(literals as unknown as [ZodType, ZodType, ...ZodType[]]);
+}
+
+/** Map a JSON Schema node to a Zod type, ignoring any field description. */
+function baseType(node: JsonSchemaNode): ZodType {
+  if (Array.isArray(node.enum) && node.enum.length > 0) return enumToZod(node.enum);
   const scalar = node.type ? SCALAR_BUILDERS[node.type] : undefined;
   if (scalar) return scalar();
   if (node.type === "array") {
@@ -40,6 +54,12 @@ function nodeToZod(node: JsonSchemaNode): ZodType {
   }
   if (node.type === "object") return z.object(shapeFromProperties(node));
   return z.unknown();
+}
+
+/** Convert a node to a Zod type, carrying its description through via .describe(). */
+function nodeToZod(node: JsonSchemaNode): ZodType {
+  const zodType = baseType(node);
+  return node.description ? zodType.describe(node.description) : zodType;
 }
 
 /** Build a Zod raw shape from an object schema's properties + required list. */

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -9,6 +9,9 @@ import OpenAI from "openai";
 import type { LLMProvider, LLMMessage, LLMTool } from "../utils/provider.js";
 import { EMBEDDING_MODELS, OPENAI_DEFAULT_TIMEOUT_MS } from "../utils/constants.js";
 
+/** Placeholder key so client construction succeeds when no real key is set yet. */
+const PLACEHOLDER_API_KEY = "llmwiki-unset";
+
 /** Construction options for an OpenAI-compatible provider. */
 interface OpenAIProviderOptions {
   baseURL?: string;
@@ -66,9 +69,11 @@ export class OpenAIProvider implements LLMProvider {
   constructor(model: string, options: OpenAIProviderOptions = {}) {
     this.model = model;
     this.configuredEmbeddingModel = options.embeddingModel;
-    // The OpenAI SDK validates OPENAI_API_KEY at construction time.
-    // Pass the key explicitly so the provider controls when validation happens.
-    const resolvedKey = options.apiKey ?? process.env.OPENAI_API_KEY ?? "";
+    // The OpenAI SDK (v6+) throws on a missing/empty key at construction time.
+    // Real credential validation is owned by ensureProviderAvailable (the provider
+    // guard), so pass a placeholder when unset to defer the check; local servers
+    // that ignore auth accept any value anyway.
+    const resolvedKey = options.apiKey ?? process.env.OPENAI_API_KEY ?? PLACEHOLDER_API_KEY;
     const timeout = options.timeoutMs ?? resolveOpenAITimeoutMs() ?? OPENAI_DEFAULT_TIMEOUT_MS;
     this.client = new OpenAI({
       apiKey: resolvedKey,
@@ -134,9 +139,9 @@ export class OpenAIProvider implements LLMProvider {
       tool_choice: "required",
     });
 
-    const toolCalls = response.choices[0]?.message?.tool_calls;
-    if (toolCalls && toolCalls.length > 0) {
-      return toolCalls[0].function.arguments;
+    const toolCall = response.choices[0]?.message?.tool_calls?.[0];
+    if (toolCall?.type === "function") {
+      return toolCall.function.arguments;
     }
 
     return response.choices[0]?.message?.content ?? "";

--- a/src/providers/voyage-embed.ts
+++ b/src/providers/voyage-embed.ts
@@ -1,0 +1,53 @@
+/**
+ * Voyage embeddings helper.
+ *
+ * Anthropic ships no first-party embeddings endpoint, so the Claude-backed
+ * providers (`anthropic` and `claude-agent`) delegate embeddings to Voyage —
+ * Anthropic's recommended partner. Shared here so both providers reuse the
+ * exact same request logic. Requires the VOYAGE_API_KEY environment variable.
+ */
+
+import { EMBEDDING_MODELS } from "../utils/constants.js";
+
+const VOYAGE_EMBEDDINGS_URL = "https://api.voyageai.com/v1/embeddings";
+
+/**
+ * Produce a single embedding vector for the given text via the Voyage API.
+ *
+ * @param text - The text to embed.
+ * @param model - Voyage model name; defaults to the Anthropic embedding model.
+ * @returns The embedding vector.
+ * @throws If VOYAGE_API_KEY is unset or the Voyage request fails.
+ */
+export async function voyageEmbed(
+  text: string,
+  model: string = EMBEDDING_MODELS.anthropic,
+): Promise<number[]> {
+  const apiKey = process.env.VOYAGE_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error(
+      "VOYAGE_API_KEY is not set. Anthropic embeddings use Voyage — set VOYAGE_API_KEY to enable semantic search.",
+    );
+  }
+
+  const response = await fetch(VOYAGE_EMBEDDINGS_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ input: text, model }),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(`Voyage embeddings request failed (${response.status}): ${detail}`);
+  }
+
+  const json = (await response.json()) as { data?: Array<{ embedding?: number[] }> };
+  const vector = json.data?.[0]?.embedding;
+  if (!Array.isArray(vector)) {
+    throw new Error("Voyage embeddings response did not include a vector.");
+  }
+  return vector;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -45,6 +45,7 @@ export const DEFAULT_PROVIDER = "anthropic";
 /** Default model per provider. */
 export const PROVIDER_MODELS: Record<string, string> = {
   anthropic: "claude-sonnet-4-20250514",
+  "claude-agent": "claude-sonnet-4-5",
   openai: "gpt-4o",
   ollama: "llama3.1",
   minimax: "MiniMax-M2.7",
@@ -123,6 +124,7 @@ export const MAX_INFERRED_PARAGRAPHS_WITHOUT_CITATIONS = 2;
 /** Embedding model to use per provider. */
 export const EMBEDDING_MODELS: Record<string, string> = {
   anthropic: "voyage-3-lite",
+  "claude-agent": "voyage-3-lite",
   openai: "text-embedding-3-small",
   ollama: "nomic-embed-text",
 };

--- a/src/utils/provider-guard.ts
+++ b/src/utils/provider-guard.ts
@@ -23,6 +23,7 @@ import { resolveAnthropicAuthFromEnv } from "./claude-settings.js";
 /** Map of provider name to the env var that satisfies it. Null = no key needed. */
 const PROVIDER_KEY_VARS: Record<string, string | null> = {
   anthropic: "ANTHROPIC_API_KEY",
+  "claude-agent": null,
   openai: "OPENAI_API_KEY",
   ollama: null,
   minimax: "MINIMAX_API_KEY",

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -12,6 +12,7 @@ import { OpenAIProvider } from "../providers/openai.js";
 import { OllamaProvider } from "../providers/ollama.js";
 import { MiniMaxProvider } from "../providers/minimax.js";
 import { CopilotProvider } from "../providers/copilot.js";
+import { ClaudeAgentProvider } from "../providers/claude-agent.js";
 import {
   resolveAnthropicAuthFromEnv,
   resolveAnthropicBaseURLFromEnv,
@@ -50,7 +51,7 @@ export interface LLMProvider {
   embed(text: string): Promise<number[]>;
 }
 
-const SUPPORTED_PROVIDERS: ReadonlySet<string> = new Set(["anthropic", "openai", "ollama", "minimax", "copilot"]);
+const SUPPORTED_PROVIDERS: ReadonlySet<string> = new Set(["anthropic", "claude-agent", "openai", "ollama", "minimax", "copilot"]);
 
 /**
  * Factory that returns the appropriate LLMProvider based on env vars.
@@ -65,6 +66,8 @@ export function getProvider(): LLMProvider {
   switch (providerName) {
     case "anthropic":
       return getAnthropicProvider();
+    case "claude-agent":
+      return getClaudeAgentProvider();
     case "openai":
       return new OpenAIProvider(getModelForProvider("openai"), {
         baseURL: readOptionalEnv("OPENAI_BASE_URL"),
@@ -128,6 +131,16 @@ function getAnthropicProvider(): AnthropicProvider {
     baseURL,
     ...auth,
   });
+}
+
+/**
+ * Build the Claude Agent SDK provider. Auth is handled by the local Claude Code
+ * login, so no API key is read here; LLMWIKI_MODEL (or the Claude settings
+ * model) still overrides the default model.
+ */
+function getClaudeAgentProvider(): ClaudeAgentProvider {
+  const model = resolveAnthropicModelFromEnv() ?? PROVIDER_MODELS["claude-agent"];
+  return new ClaudeAgentProvider(model);
 }
 
 function getProviderName(): string {

--- a/test/json-schema-to-zod.test.ts
+++ b/test/json-schema-to-zod.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for the JSON-Schema → Zod bridge used by the Claude Agent SDK provider.
+ *
+ * The shape is wrapped in `z.object()` and exercised with `safeParse`, which
+ * verifies the observable behaviour callers depend on: required vs optional
+ * keys, enums, nested objects/arrays, and the unknown-type fallback.
+ */
+
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { jsonSchemaToZodShape } from "../src/providers/json-schema-to-zod.js";
+
+/** Build a validator from a JSON Schema object, mirroring the SDK tool() usage. */
+function validator(schema: Record<string, unknown>) {
+  return z.object(jsonSchemaToZodShape(schema));
+}
+
+describe("jsonSchemaToZodShape", () => {
+  it("treats listed keys as required and the rest as optional", () => {
+    const check = validator({
+      type: "object",
+      properties: { a: { type: "string" }, b: { type: "number" } },
+      required: ["a"],
+    });
+    expect(check.safeParse({ a: "x" }).success).toBe(true);
+    expect(check.safeParse({ b: 1 }).success).toBe(false);
+  });
+
+  it("enforces enum values", () => {
+    const check = validator({
+      type: "object",
+      properties: { state: { enum: ["extracted", "merged"] } },
+      required: ["state"],
+    });
+    expect(check.safeParse({ state: "merged" }).success).toBe(true);
+    expect(check.safeParse({ state: "other" }).success).toBe(false);
+  });
+
+  it("validates nested object and array properties", () => {
+    const check = validator({
+      type: "object",
+      properties: {
+        items: { type: "array", items: { type: "object", properties: { n: { type: "number" } }, required: ["n"] } },
+      },
+      required: ["items"],
+    });
+    expect(check.safeParse({ items: [{ n: 1 }] }).success).toBe(true);
+    expect(check.safeParse({ items: [{ n: "no" }] }).success).toBe(false);
+  });
+
+  it("falls back to an accept-anything type for unknown schemas", () => {
+    const check = validator({ type: "object", properties: { x: { type: "weird" } }, required: ["x"] });
+    expect(check.safeParse({ x: { anything: true } }).success).toBe(true);
+  });
+});

--- a/test/json-schema-to-zod.test.ts
+++ b/test/json-schema-to-zod.test.ts
@@ -52,4 +52,20 @@ describe("jsonSchemaToZodShape", () => {
     const check = validator({ type: "object", properties: { x: { type: "weird" } }, required: ["x"] });
     expect(check.safeParse({ x: { anything: true } }).success).toBe(true);
   });
+
+  it("preserves numeric enums as number literals, not strings", () => {
+    const check = validator({ type: "object", properties: { score: { enum: [0, 1, 2] } }, required: ["score"] });
+    expect(check.safeParse({ score: 2 }).success).toBe(true);
+    expect(check.safeParse({ score: "2" }).success).toBe(false);
+    expect(check.safeParse({ score: 3 }).success).toBe(false);
+  });
+
+  it("carries field descriptions through via .describe()", () => {
+    const shape = jsonSchemaToZodShape({
+      type: "object",
+      properties: { note: { type: "string", description: "why it matters" } },
+      required: ["note"],
+    });
+    expect(shape.note.description).toBe("why it matters");
+  });
 });

--- a/test/provider-claude-agent.test.ts
+++ b/test/provider-claude-agent.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for the Claude Agent SDK LLM provider.
+ *
+ * The Agent SDK's `query()` is mocked so the tests stay offline: they verify
+ * that complete/stream accumulate assistant text, that toolCall captures a
+ * `tool_use` input as JSON, that embed delegates to Voyage, and that the
+ * factory resolves the provider without requiring an API key.
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+const query = vi.fn();
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (...args: unknown[]) => query(...args),
+  createSdkMcpServer: vi.fn(() => ({ type: "sdk", name: "llmwiki" })),
+  tool: vi.fn((name: string) => ({ name })),
+}));
+
+const { ClaudeAgentProvider } = await import("../src/providers/claude-agent.js");
+const { getProvider } = await import("../src/utils/provider.js");
+const { PROVIDER_MODELS } = await import("../src/utils/constants.js");
+
+/** Wrap messages in an async generator, mimicking the SDK's query() return. */
+async function* messageStream(messages: unknown[]): AsyncGenerator<unknown> {
+  for (const message of messages) yield message;
+}
+
+function assistantText(text: string): unknown {
+  return { type: "assistant", message: { content: [{ type: "text", text }] } };
+}
+
+afterEach(() => {
+  query.mockReset();
+  delete process.env.LLMWIKI_PROVIDER;
+  delete process.env.LLMWIKI_MODEL;
+  delete process.env.VOYAGE_API_KEY;
+});
+
+describe("ClaudeAgentProvider generation", () => {
+  it("accumulates assistant text for complete()", async () => {
+    query.mockReturnValue(messageStream([assistantText("Hello "), assistantText("world")]));
+    const result = await new ClaudeAgentProvider("m").complete("sys", [{ role: "user", content: "hi" }], 100);
+    expect(result).toBe("Hello world");
+  });
+
+  it("prefers the final result text over intermediate assistant turns", async () => {
+    query.mockReturnValue(
+      messageStream([
+        assistantText("I'll write the page: "),
+        { type: "result", subtype: "success", result: "# Clean Page" },
+      ]),
+    );
+    const result = await new ClaudeAgentProvider("m").complete("sys", [{ role: "user", content: "hi" }], 100);
+    expect(result).toBe("# Clean Page");
+  });
+
+  it("emits text chunks via onToken for stream()", async () => {
+    query.mockReturnValue(messageStream([assistantText("a"), assistantText("b")]));
+    const chunks: string[] = [];
+    const result = await new ClaudeAgentProvider("m").stream(
+      "sys",
+      [{ role: "user", content: "hi" }],
+      100,
+      (t) => chunks.push(t),
+    );
+    expect(chunks).toEqual(["a", "b"]);
+    expect(result).toBe("ab");
+  });
+
+  it("captures tool_use input as JSON for toolCall()", async () => {
+    const input = { concepts: [{ concept: "X" }] };
+    query.mockReturnValue(
+      messageStream([
+        { type: "assistant", message: { content: [{ type: "tool_use", name: "mcp__llmwiki__extract_concepts", input }] } },
+      ]),
+    );
+    const tools = [{ name: "extract_concepts", description: "d", input_schema: { type: "object", properties: {} } }];
+    const result = await new ClaudeAgentProvider("m").toolCall("sys", [{ role: "user", content: "hi" }], tools, 100);
+    expect(JSON.parse(result)).toEqual(input);
+  });
+});
+
+describe("ClaudeAgentProvider embeddings", () => {
+  it("delegates embed() to Voyage and throws without VOYAGE_API_KEY", async () => {
+    delete process.env.VOYAGE_API_KEY;
+    await expect(new ClaudeAgentProvider("m").embed("hi")).rejects.toThrow("VOYAGE_API_KEY");
+  });
+});
+
+describe("getProvider with claude-agent", () => {
+  it("resolves ClaudeAgentProvider with no API key required", () => {
+    process.env.LLMWIKI_PROVIDER = "claude-agent";
+    const provider = getProvider();
+    expect(provider).toBeInstanceOf(ClaudeAgentProvider);
+    expect(Reflect.get(provider, "model")).toBe(PROVIDER_MODELS["claude-agent"]);
+  });
+
+  it("respects LLMWIKI_MODEL override", () => {
+    process.env.LLMWIKI_PROVIDER = "claude-agent";
+    process.env.LLMWIKI_MODEL = "claude-opus-4-1";
+    expect(Reflect.get(getProvider(), "model")).toBe("claude-opus-4-1");
+  });
+});

--- a/test/provider-claude-agent.test.ts
+++ b/test/provider-claude-agent.test.ts
@@ -80,6 +80,35 @@ describe("ClaudeAgentProvider generation", () => {
   });
 });
 
+describe("ClaudeAgentProvider failure handling", () => {
+  const TOOLS = [
+    { name: "extract_concepts", description: "d", input_schema: { type: "object", properties: {} } },
+  ];
+
+  it("throws on an SDK error result instead of returning partial text", async () => {
+    query.mockReturnValue(
+      messageStream([{ type: "result", subtype: "error_during_execution", errors: ["auth failed"] }]),
+    );
+    await expect(
+      new ClaudeAgentProvider("m").complete("sys", [{ role: "user", content: "hi" }], 100),
+    ).rejects.toThrow("error result: auth failed");
+  });
+
+  it("throws when the model never calls the tool", async () => {
+    query.mockReturnValue(messageStream([{ type: "result", subtype: "success", result: "done" }]));
+    await expect(
+      new ClaudeAgentProvider("m").toolCall("sys", [{ role: "user", content: "hi" }], TOOLS, 100),
+    ).rejects.toThrow('did not call the "extract_concepts" tool');
+  });
+
+  it("throws and surfaces prose when the model answers in text instead", async () => {
+    query.mockReturnValue(messageStream([assistantText("I think the answer is 42.")]));
+    await expect(
+      new ClaudeAgentProvider("m").toolCall("sys", [{ role: "user", content: "hi" }], TOOLS, 100),
+    ).rejects.toThrow("prose instead");
+  });
+});
+
 describe("ClaudeAgentProvider embeddings", () => {
   it("delegates embed() to Voyage and throws without VOYAGE_API_KEY", async () => {
     delete process.env.VOYAGE_API_KEY;


### PR DESCRIPTION
## What & why

Adds a new provider, **`LLMWIKI_PROVIDER=claude-agent`**, that routes LLM calls through [`@anthropic-ai/claude-agent-sdk`](https://github.com/anthropics/claude-agent-sdk-typescript)'s `query()` instead of the raw Messages API. It authenticates via the user's **local Claude Code login** (OAuth/subscription), so **no `ANTHROPIC_API_KEY` is required**.

Why do we want this - because Claude Agent SDK usage tokens comes bundled with Claude personal plans. See here - https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan

This fills a real gap: the existing `anthropic` provider's "zero exports" path only works if a literal key/token is present in `~/.claude/settings.json`'s `env` block — it can't use the Claude Code OAuth session. `claude-agent` works purely off the logged-in CLI.

The change is additive and slots into the existing provider pattern (`LLMProvider` interface, `getProvider()` factory, `PROVIDER_MODELS`, `provider-guard`). No pipeline, prompt, or CLI changes; all other providers are untouched.

## How it works

- **`complete` / `stream`** — single-shot generation (`MAX_TURNS` ceiling; note `maxTurns: 1` makes the SDK return an error result on *every* call, so the ceiling sits above the one turn a clean completion uses). Returns the SDK's final `result` text and appends an output-only directive to suppress agentic preamble, matching raw-API output.
- **`toolCall`** — used by compile (`CONCEPT_EXTRACTION_TOOL`), query (`PAGE_SELECTION_TOOL`), and eval (`JUDGE_TOOL`). Implemented faithfully: registers the requested tool as an in-process SDK MCP tool (`createSdkMcpServer`/`tool`) and captures the real `tool_use` input as JSON. A small JSON-Schema→Zod bridge adapts llmwiki's JSON-Schema tool definitions to the SDK's Zod-raw-shape `tool()` helper.
- **`embed`** — delegates to Voyage (Claude has no embeddings endpoint), extracted into a shared `voyage-embed` helper reused by the `anthropic` provider so there's no duplication. Compile gracefully skips embeddings when `VOYAGE_API_KEY` is unset.
- **Default model** `claude-sonnet-4-5`, overridable via `LLMWIKI_MODEL` (reuses the existing Anthropic model-resolution chain).
- **`LLMWIKI_DEBUG=1`** prints a concise per-message SDK trace (`[claude-agent] system:init`, `… assistant`, `… result:success`); `=verbose` adds the SDK's full logging. Off by default.

## Dependency bumps (forced by the SDK's peers)

- `@anthropic-ai/sdk` `^0.39` → `^0.100`
- `zod` `^3` → `^4` (zod is used in a single file with primitive types — low blast radius)

Both verified safe: the full suite passes.

## Testing

- New `test/provider-claude-agent.test.ts` — `complete`/`stream`/`toolCall`/`embed`, factory resolution (no API key required), model override, and final-result preference (mocks the SDK's `query`).
- New `test/json-schema-to-zod.test.ts` — the schema bridge: required-vs-optional, enum, nested object/array, fallback.
- `npx tsc --noEmit`, `npm run build`, `npm test` (**1215 passed**, 3 skipped), and `fallow` (0 above threshold) all green.
- **Verified end-to-end live** against a real Claude Code login (no API key): ingest → compile produces interlinked wiki pages with citations; embeddings gracefully skipped without `VOYAGE_API_KEY`.

## Reviewer notes

- `toolCall` relies on `permissionMode: 'bypassPermissions'` with `allowedTools` restricted to the single registered tool, so no file/agentic tools are reachable.
- Page generation may use up to `MAX_TURNS` (4) agent turns vs. the raw `anthropic` provider's single call; in practice a clean page is one turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)