### PR TITLE
feat(freshness): page-level source freshness + stale-page lint

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -3,7 +3,7 @@
   "entry": [
     "src/viewer/assets/viewer.js",
     "scripts/copy-viewer-assets.mjs",
-    "src/freshness/types.ts"
+    "src/freshness/index.ts"
   ],
   "ignorePatterns": [
     "src/viewer/assets/index.html",

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -2,7 +2,8 @@
   "$schema": "https://fallow.tools/schema.json",
   "entry": [
     "src/viewer/assets/viewer.js",
-    "scripts/copy-viewer-assets.mjs"
+    "scripts/copy-viewer-assets.mjs",
+    "src/freshness/types.ts"
   ],
   "ignorePatterns": [
     "src/viewer/assets/index.html",

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -2,8 +2,7 @@
   "$schema": "https://fallow.tools/schema.json",
   "entry": [
     "src/viewer/assets/viewer.js",
-    "scripts/copy-viewer-assets.mjs",
-    "src/freshness/index.ts"
+    "scripts/copy-viewer-assets.mjs"
   ],
   "ignorePatterns": [
     "src/viewer/assets/index.html",

--- a/src/export/collect.ts
+++ b/src/export/collect.ts
@@ -12,6 +12,8 @@
 import path from "path";
 import { collectRawWikiPages, extractWikilinkSlugs } from "../wiki/collect.js";
 import type { RawWikiPage } from "../wiki/collect.js";
+import { buildFreshnessSnapshot, computeFreshness } from "../freshness/index.js";
+import type { FreshnessSnapshot } from "../freshness/types.js";
 import { extractClaimCitations } from "../utils/markdown.js";
 import { flattenCitations } from "../context/provenance.js";
 import type { PageKind } from "../schema/types.js";
@@ -83,9 +85,13 @@ function readPageKind(meta: Record<string, unknown>): PageKind | undefined {
  * (path, kind, advisory*, citations, aliases) are populated here so
  * every export format gets the same enriched payload.
  */
-function toExportPage(raw: RawWikiPage): ExportPage {
+function toExportPage(raw: RawWikiPage, snapshot: FreshnessSnapshot): ExportPage {
   const meta = raw.frontmatter;
   const aliases = readStringArray(meta, "aliases");
+  const freshness = computeFreshness(
+    { slug: raw.slug, pageDirectory: raw.pageDirectory, frontmatter: meta },
+    snapshot,
+  );
   return {
     title: raw.title as string,
     slug: raw.slug,
@@ -104,19 +110,26 @@ function toExportPage(raw: RawWikiPage): ExportPage {
     contradictedBy: readContradictedBy(meta),
     citations: flattenCitations(extractClaimCitations(raw.body)),
     ...(aliases.length > 0 ? { aliases } : {}),
-    advisoryFreshnessStatus: "unverified",
+    freshnessStatus: freshness.freshnessStatus,
+    contradicted: freshness.contradicted,
+    archived: freshness.archived,
   };
 }
 
 /**
  * Collect all exportable wiki pages from `wiki/concepts/` and `wiki/queries/`.
- * Drops orphaned and untitled records — those are diagnosed by the viewer,
- * not exported. Returns the surviving pages sorted by title.
+ * Drops untitled records, frontmatter-orphaned records, and computed-orphaned
+ * records (every owning source deleted) — those are diagnosed by lint/the
+ * viewer, not exported. The freshness snapshot is built once and shared across
+ * all pages. Returns the surviving pages sorted by title.
  */
 export async function collectExportPages(root: string): Promise<ExportPage[]> {
   const raw = await collectRawWikiPages(root);
+  const snapshot = await buildFreshnessSnapshot(root);
   const kept = raw.filter((page) => page.parseStatus.hasTitle && !page.parseStatus.orphaned);
-  const pages = kept.map(toExportPage);
+  const pages = kept
+    .map((page) => toExportPage(page, snapshot))
+    .filter((page) => page.freshnessStatus !== "orphaned");
   pages.sort((a, b) => a.title.localeCompare(b.title));
   return pages;
 }

--- a/src/export/types.ts
+++ b/src/export/types.ts
@@ -16,6 +16,7 @@
 import type { PageKind } from "../schema/types.js";
 import type { ProvenanceState, ContradictionRef } from "../utils/types.js";
 import type { FlatCitation } from "../context/provenance.js";
+import type { FreshnessStatus } from "../freshness/types.js";
 
 /**
  * Flat citation shape exported alongside each page. Identical to the
@@ -25,13 +26,6 @@ import type { FlatCitation } from "../context/provenance.js";
  */
 export type ExportCitation = FlatCitation;
 
-/**
- * Per-page freshness label. Always `"unverified"` in v1 — the bridge
- * cannot assert freshness relative to changed sources until the
- * source-freshness feature (roadmap P0) lands. Renamed from "unknown"
- * because consumers must act on stale data, not ignore it.
- */
-export type AdvisoryFreshnessStatus = "unverified";
 
 /**
  * Which wiki/ subdirectory a page lives in.
@@ -102,10 +96,17 @@ export interface ExportPage {
    */
   aliases?: string[];
   /**
-   * Per-page freshness status. Always `"unverified"` in v1 — the bridge
-   * cannot assert source-freshness until that feature ships.
+   * Advisory per-page source-freshness, computed at export time from
+   * `.llmwiki/state.json` + the current `sources/`. A snapshot, not a
+   * guarantee. The export is active-page-only, so this is `fresh`, `stale`,
+   * or `unverified` — never `orphaned` (orphaned pages are dropped from the
+   * export and surfaced by lint/the viewer instead).
    */
-  advisoryFreshnessStatus: AdvisoryFreshnessStatus;
+  freshnessStatus: FreshnessStatus;
+  /** True when the page is disputed by another page (`contradictedBy` non-empty). */
+  contradicted: boolean;
+  /** True when the page is explicitly archived (`archived: true` frontmatter). */
+  archived: boolean;
 }
 
 /**

--- a/src/freshness/index.ts
+++ b/src/freshness/index.ts
@@ -1,5 +1,5 @@
 /**
- * Computed source-freshness layer (radar P0).
+ * Computed source-freshness layer.
  *
  * Derives a page's freshness on demand from a FreshnessSnapshot (state.json
  * hashes + current source hashes). Pure — never reads or writes the filesystem

--- a/src/freshness/index.ts
+++ b/src/freshness/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Computed source-freshness layer (radar P0).
+ *
+ * Derives a page's freshness on demand from a FreshnessSnapshot (state.json
+ * hashes + current source hashes). Pure — never reads or writes the filesystem
+ * and never persists freshness. See localdocs/specs/2026-06-04-source-freshness-design.md.
+ */
+
+import type { FreshnessSnapshot, PageFreshness, PageFreshnessInput, FreshnessStatus } from "./types.js";
+
+/** Compute the three orthogonal freshness signals for one page. */
+export function computeFreshness(page: PageFreshnessInput, snapshot: FreshnessSnapshot): PageFreshness {
+  return {
+    freshnessStatus: classify(page, snapshot),
+    contradicted: Array.isArray(page.frontmatter.contradictedBy) && page.frontmatter.contradictedBy.length > 0,
+    archived: page.frontmatter.archived === true,
+  };
+}
+
+/** Source-derived freshness status, per the spec's ordered ownership algorithm. */
+function classify(page: PageFreshnessInput, snapshot: FreshnessSnapshot): FreshnessStatus {
+  if (snapshot.stateStatus !== "ok") return "unverified";
+  if (page.frontmatter.orphaned === true) return "orphaned";
+  if (page.pageDirectory === "queries") return "unverified";
+
+  const owners = ownersOf(page.slug, snapshot);
+  if (owners.length === 0) return "unverified";
+
+  const live = owners.filter((o) => o.exists);
+  if (live.length === 0) return "orphaned";
+  if (live.length < owners.length) return "stale";
+  if (live.some((o) => o.currentHash !== o.recordedHash)) return "stale";
+  return "fresh";
+}
+
+/** Sources whose recorded concept set includes this page's slug (state is authoritative). */
+function ownersOf(slug: string, snapshot: FreshnessSnapshot) {
+  return Object.values(snapshot.sources).filter((s) => s.concepts.includes(slug));
+}

--- a/src/freshness/index.ts
+++ b/src/freshness/index.ts
@@ -7,6 +7,11 @@
  */
 
 import type { FreshnessSnapshot, PageFreshness, PageFreshnessInput, FreshnessStatus } from "./types.js";
+import { existsSync } from "fs";
+import path from "path";
+import { readStateClassified } from "../utils/state.js";
+import { hashFile } from "../compiler/hasher.js";
+import { SOURCES_DIR } from "../utils/constants.js";
 
 /** Compute the three orthogonal freshness signals for one page. */
 export function computeFreshness(page: PageFreshnessInput, snapshot: FreshnessSnapshot): PageFreshness {
@@ -36,4 +41,26 @@ function classify(page: PageFreshnessInput, snapshot: FreshnessSnapshot): Freshn
 /** Sources whose recorded concept set includes this page's slug (state is authoritative). */
 function ownersOf(slug: string, snapshot: FreshnessSnapshot) {
   return Object.values(snapshot.sources).filter((s) => s.concepts.includes(slug));
+}
+
+/**
+ * Build the per-run freshness snapshot: one read-only state read + one hash
+ * pass over sources/. Shared by every freshness consumer so hashing happens once.
+ */
+export async function buildFreshnessSnapshot(root: string): Promise<FreshnessSnapshot> {
+  const { status, state } = await readStateClassified(root);
+  const sources: FreshnessSnapshot["sources"] = {};
+  if (status === "ok") {
+    for (const [file, entry] of Object.entries(state.sources)) {
+      const filePath = path.join(root, SOURCES_DIR, file);
+      const exists = existsSync(filePath);
+      sources[file] = {
+        recordedHash: entry.hash,
+        currentHash: exists ? await hashFile(filePath) : null,
+        exists,
+        concepts: entry.concepts,
+      };
+    }
+  }
+  return { stateStatus: status, sources };
 }

--- a/src/freshness/index.ts
+++ b/src/freshness/index.ts
@@ -25,8 +25,10 @@ export function computeFreshness(page: PageFreshnessInput, snapshot: FreshnessSn
 /** Source-derived freshness status, per the spec's ordered ownership algorithm. */
 function classify(page: PageFreshnessInput, snapshot: FreshnessSnapshot): FreshnessStatus {
   if (snapshot.stateStatus !== "ok") return "unverified";
-  if (page.frontmatter.orphaned === true) return "orphaned";
+  // Query pages are generated answers, not source projections — always unverified,
+  // never orphaned/fresh (they also never receive `orphaned` frontmatter).
   if (page.pageDirectory === "queries") return "unverified";
+  if (page.frontmatter.orphaned === true) return "orphaned";
 
   const owners = ownersOf(page.slug, snapshot);
   if (owners.length === 0) return "unverified";

--- a/src/freshness/types.ts
+++ b/src/freshness/types.ts
@@ -1,0 +1,43 @@
+/**
+ * Types for the computed source-freshness layer (radar P0).
+ *
+ * Freshness is derived on demand from the filesystem + state.json and is never
+ * persisted. `FreshnessSnapshot` is built once per command/viewer snapshot and
+ * shared by every consumer (lint, export, MCP, context, viewer).
+ */
+
+/** A page's computed freshness on the source-derived axis. */
+export type FreshnessStatus = "fresh" | "stale" | "orphaned" | "unverified";
+
+/** The minimal page shape `computeFreshness` needs; each surface adapts to it. */
+export interface PageFreshnessInput {
+  slug: string;
+  pageDirectory: "concepts" | "queries";
+  frontmatter: Record<string, unknown>;
+}
+
+/** One source's freshness inputs within a snapshot. */
+export interface SourceFreshness {
+  /** Hash recorded in state.json at last compile. */
+  recordedHash: string;
+  /** Hash of the source file on disk now, or null when the file is missing. */
+  currentHash: string | null;
+  /** Whether the source file still exists on disk. */
+  exists: boolean;
+  /** Concept slugs this source produced (state.json ownership map). */
+  concepts: string[];
+}
+
+/** Reusable, per-run snapshot of all freshness inputs. */
+export interface FreshnessSnapshot {
+  stateStatus: "ok" | "missing" | "corrupt";
+  /** Source filename -> its freshness inputs (empty unless stateStatus === "ok"). */
+  sources: Record<string, SourceFreshness>;
+}
+
+/** The three orthogonal signals exposed per page. */
+export interface PageFreshness {
+  freshnessStatus: FreshnessStatus;
+  contradicted: boolean;
+  archived: boolean;
+}

--- a/src/freshness/types.ts
+++ b/src/freshness/types.ts
@@ -1,5 +1,5 @@
 /**
- * Types for the computed source-freshness layer (radar P0).
+ * Types for the computed source-freshness layer.
  *
  * Freshness is derived on demand from the filesystem + state.json and is never
  * persisted. `FreshnessSnapshot` is built once per command/viewer snapshot and

--- a/src/linter/index.ts
+++ b/src/linter/index.ts
@@ -19,8 +19,11 @@ import {
   checkContradictedPages,
   checkInferredWithoutCitations,
   checkSchemaCrossLinks,
+  checkStalePages,
 } from "./rules.js";
 import { loadSchema } from "../schema/index.js";
+import { buildFreshnessSnapshot } from "../freshness/index.js";
+import type { FreshnessSnapshot } from "../freshness/types.js";
 
 /** Rule-only lint checks that don't depend on the schema layer. */
 const RULES_WITHOUT_SCHEMA: LintRule[] = [
@@ -38,6 +41,9 @@ const RULES_WITHOUT_SCHEMA: LintRule[] = [
 
 /** Lint rules that need the resolved schema to know per-kind expectations. */
 const RULES_WITH_SCHEMA: SchemaAwareLintRule[] = [checkSchemaCrossLinks];
+
+type FreshnessLintRule = (root: string, snapshot: FreshnessSnapshot) => Promise<LintResult[]>;
+const RULES_WITH_FRESHNESS: FreshnessLintRule[] = [checkStalePages];
 
 /**
  * Count occurrences of a specific severity level in the results.
@@ -58,12 +64,14 @@ function countBySeverity(
  */
 export async function lint(root: string): Promise<LintSummary> {
   const schema = await loadSchema(root);
-  const [plainResults, schemaResults] = await Promise.all([
+  const freshness = await buildFreshnessSnapshot(root);
+  const [plainResults, schemaResults, freshnessResults] = await Promise.all([
     Promise.all(RULES_WITHOUT_SCHEMA.map((rule) => rule(root))),
     Promise.all(RULES_WITH_SCHEMA.map((rule) => rule(root, schema))),
+    Promise.all(RULES_WITH_FRESHNESS.map((rule) => rule(root, freshness))),
   ]);
 
-  const results = [...plainResults.flat(), ...schemaResults.flat()];
+  const results = [...plainResults.flat(), ...schemaResults.flat(), ...freshnessResults.flat()];
 
   return {
     errors: countBySeverity(results, "error"),

--- a/src/linter/rules.ts
+++ b/src/linter/rules.ts
@@ -31,6 +31,8 @@ import {
   resolvePageKind,
   type SchemaConfig,
 } from "../schema/index.js";
+import { computeFreshness } from "../freshness/index.js";
+import type { FreshnessSnapshot } from "../freshness/types.js";
 
 /** Minimum body length (in characters) for a page to be considered non-empty. */
 const MIN_BODY_LENGTH = 50;
@@ -154,6 +156,30 @@ export async function checkOrphanedPages(root: string): Promise<LintResult[]> {
     }
   }
 
+  return results;
+}
+
+/**
+ * Report concept pages whose source content changed since the last compile.
+ * Receives the shared freshness snapshot so hashing happens once per lint run.
+ */
+export async function checkStalePages(root: string, snapshot: FreshnessSnapshot): Promise<LintResult[]> {
+  const pages = await collectAllPages(root);
+  const results: LintResult[] = [];
+  for (const page of pages) {
+    const { meta } = parseFrontmatter(page.content);
+    const slug = path.basename(page.filePath, ".md");
+    const pageDirectory = page.filePath.includes(QUERIES_DIR) ? "queries" : "concepts";
+    const { freshnessStatus } = computeFreshness({ slug, pageDirectory, frontmatter: meta }, snapshot);
+    if (freshnessStatus === "stale") {
+      results.push({
+        rule: "stale-page",
+        severity: "warning",
+        file: page.filePath,
+        message: `Page is stale — a source it was compiled from has changed since the last compile`,
+      });
+    }
+  }
   return results;
 }
 

--- a/src/linter/rules.ts
+++ b/src/linter/rules.ts
@@ -169,7 +169,7 @@ export async function checkStalePages(root: string, snapshot: FreshnessSnapshot)
   for (const page of pages) {
     const { meta } = parseFrontmatter(page.content);
     const slug = path.basename(page.filePath, ".md");
-    const pageDirectory = page.filePath.includes(QUERIES_DIR) ? "queries" : "concepts";
+    const pageDirectory = path.basename(path.dirname(page.filePath)) === "queries" ? "queries" : "concepts";
     const { freshnessStatus } = computeFreshness({ slug, pageDirectory, frontmatter: meta }, snapshot);
     if (freshnessStatus === "stale") {
       results.push({

--- a/src/linter/rules.ts
+++ b/src/linter/rules.ts
@@ -160,14 +160,21 @@ export async function checkOrphanedPages(root: string): Promise<LintResult[]> {
 }
 
 /**
- * Report concept pages whose source content changed since the last compile.
- * Receives the shared freshness snapshot so hashing happens once per lint run.
+ * Report pages whose computed freshness is actionable: `stale` (a source
+ * changed since compile) or `orphaned` (every source it derived from was
+ * deleted but no compile has cleaned the page up yet). Pages already flagged
+ * `orphaned: true` in frontmatter are left to {@link checkOrphanedPages} so the
+ * two rules never double-report. `fresh` and `unverified` are not findings —
+ * unverified covers legitimately unowned pages (query pages, hand-authored
+ * content) that should not warn. Receives the shared freshness snapshot so the
+ * source-hash pass happens once per lint run.
  */
 export async function checkStalePages(root: string, snapshot: FreshnessSnapshot): Promise<LintResult[]> {
   const pages = await collectAllPages(root);
   const results: LintResult[] = [];
   for (const page of pages) {
     const { meta } = parseFrontmatter(page.content);
+    if (meta.orphaned === true) continue;
     const slug = path.basename(page.filePath, ".md");
     const pageDirectory = path.basename(path.dirname(page.filePath)) === "queries" ? "queries" : "concepts";
     const { freshnessStatus } = computeFreshness({ slug, pageDirectory, frontmatter: meta }, snapshot);
@@ -177,6 +184,13 @@ export async function checkStalePages(root: string, snapshot: FreshnessSnapshot)
         severity: "warning",
         file: page.filePath,
         message: `Page is stale — a source it was compiled from has changed since the last compile`,
+      });
+    } else if (freshnessStatus === "orphaned") {
+      results.push({
+        rule: "orphaned-page",
+        severity: "warning",
+        file: page.filePath,
+        message: `Page is orphaned — every source it was compiled from has been deleted; recompile to clean it up`,
       });
     }
   }

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -17,23 +17,38 @@ function emptyState(): WikiState {
   return { version: 1, indexHash: "", sources: {} };
 }
 
-/** Read .llmwiki/state.json, recovering from corruption gracefully. */
-export async function readState(root: string): Promise<WikiState> {
+/** State file read outcome: ok = parsed, missing = no file, corrupt = unparseable. */
+export interface ClassifiedState {
+  status: "ok" | "missing" | "corrupt";
+  state: WikiState;
+}
+
+/**
+ * Read .llmwiki/state.json and classify the outcome WITHOUT side effects.
+ * Unlike readState(), this never writes a .bak on corrupt input, so read-only
+ * callers (freshness/lint/view/export) can safely use it.
+ */
+export async function readStateClassified(root: string): Promise<ClassifiedState> {
   const filePath = path.join(root, STATE_FILE);
-
-  if (!existsSync(filePath)) {
-    return emptyState();
-  }
-
+  if (!existsSync(filePath)) return { status: "missing", state: emptyState() };
   try {
     const raw = await readFile(filePath, "utf-8");
-    return JSON.parse(raw) as WikiState;
+    return { status: "ok", state: JSON.parse(raw) as WikiState };
   } catch {
+    return { status: "corrupt", state: emptyState() };
+  }
+}
+
+/** Read .llmwiki/state.json, recovering from corruption gracefully (writes a .bak). */
+export async function readState(root: string): Promise<WikiState> {
+  const classified = await readStateClassified(root);
+  if (classified.status === "corrupt") {
+    const filePath = path.join(root, STATE_FILE);
     const bakPath = filePath + ".bak";
     console.warn(`⚠ Corrupt state.json — backed up to ${bakPath}, starting fresh.`);
     await copyFile(filePath, bakPath);
-    return emptyState();
   }
+  return classified.state;
 }
 
 /** Atomically write state.json (write .tmp then rename). */

--- a/test/bridge-export-contract-cli.test.ts
+++ b/test/bridge-export-contract-cli.test.ts
@@ -27,7 +27,7 @@ interface BridgeEnvelope {
   exportedAt: string;
   pageCount: number;
   projectId?: string;
-  pages: { slug: string; path: string; advisoryFreshnessStatus: string }[];
+  pages: { slug: string; path: string; freshnessStatus: string }[];
 }
 
 async function makeWiki(suffix: string): Promise<string> {
@@ -67,7 +67,7 @@ describe("llmwiki export --target json (bridge contract CLI)", () => {
       const env = await readJsonExport(root);
       expect(env.projectId).toBe("my-kb");
       expect(env.pages[0].path).toBe("wiki/concepts/retrieval.md");
-      expect(env.pages[0].advisoryFreshnessStatus).toBe("unverified");
+      expect(env.pages[0].freshnessStatus).toBe("unverified");
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/test/bridge-export-contract.test.ts
+++ b/test/bridge-export-contract.test.ts
@@ -6,7 +6,7 @@
  *
  *  - Every new `ExportPage` field round-trips from frontmatter through
  *    the JSON envelope (path, kind, advisoryConfidence, provenanceState,
- *    contradictedBy, citations, aliases, advisoryFreshnessStatus).
+   contradictedBy, citations, aliases, freshnessStatus, contradicted, archived).
  *  - `projectId` is embedded only when supplied; regex enforcement
  *    rejects malformed values at the validator boundary.
  *
@@ -36,7 +36,9 @@ interface BridgeExportPage {
   contradictedBy?: { slug: string; reason?: string }[];
   citations: { file: string; start?: number; end?: number }[];
   aliases?: string[];
-  advisoryFreshnessStatus: string;
+  freshnessStatus: string;
+  contradicted: boolean;
+  archived: boolean;
 }
 
 interface BridgeExportEnvelope {
@@ -53,7 +55,7 @@ function findPage(envelope: BridgeExportEnvelope, slug: string): BridgeExportPag
 }
 
 describe("bridge export contract — collectExportPages + buildJsonExport", () => {
-  it("populates path, kind, citations, and advisoryFreshnessStatus for a basic concept", async () => {
+  it("populates path, kind, citations, and freshnessStatus for a basic concept", async () => {
     const root = await makeTempRoot("basic");
     await writePage(
       path.join(root, "wiki/concepts"),
@@ -68,7 +70,9 @@ describe("bridge export contract — collectExportPages + buildJsonExport", () =
 
     expect(page.path).toBe("wiki/concepts/retrieval.md");
     expect(page.kind).toBe("concept");
-    expect(page.advisoryFreshnessStatus).toBe("unverified");
+    expect(page.freshnessStatus).toBe("unverified");
+    expect(page.contradicted).toBe(false);
+    expect(page.archived).toBe(false);
     expect(page.citations).toEqual([{ file: "paper.md", start: 10, end: 15 }]);
   });
 

--- a/test/export-freshness.test.ts
+++ b/test/export-freshness.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Verifies that computed source-freshness flows into the JSON export contract:
+ * each page carries `freshnessStatus` / `contradicted` / `archived`, and
+ * computed-orphaned pages (every owning source deleted) are dropped so the
+ * export stays active-page-only and never emits `freshnessStatus: "orphaned"`.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+import { createHash } from "node:crypto";
+import { writePage } from "./fixtures/write-page.js";
+import { makeTempRoot } from "./fixtures/temp-root.js";
+import { writeTestStateJson } from "./fixtures/state-json.js";
+import { collectExportPages } from "../src/export/collect.js";
+
+const sha = (s: string) => createHash("sha256").update(s).digest("hex");
+
+async function writeSource(root: string, file: string, content: string) {
+  await mkdir(path.join(root, "sources"), { recursive: true });
+  await writeFile(path.join(root, "sources", file), content);
+}
+
+async function state(root: string, sources: Record<string, { hash: string; concepts: string[] }>) {
+  const entries = Object.fromEntries(
+    Object.entries(sources).map(([f, s]) => [f, { ...s, compiledAt: "t" }]),
+  );
+  await writeTestStateJson(root, { version: 1, indexHash: "", sources: entries });
+}
+
+describe("export freshness fields", () => {
+  it("marks a page stale when its source changed since compile", async () => {
+    const root = await makeTempRoot("export-fresh-stale");
+    await writeSource(root, "a.md", "NEW body");
+    await state(root, { "a.md": { hash: sha("OLD body"), concepts: ["topic"] } });
+    await writePage(path.join(root, "wiki/concepts"), "topic", { title: "Topic", summary: "s" }, "Body.\n");
+
+    const [page] = await collectExportPages(root);
+    expect(page.freshnessStatus).toBe("stale");
+    expect(page.contradicted).toBe(false);
+    expect(page.archived).toBe(false);
+  });
+
+  it("surfaces contradicted and archived as orthogonal axes", async () => {
+    const root = await makeTempRoot("export-fresh-flags");
+    await writePage(
+      path.join(root, "wiki/concepts"),
+      "disputed",
+      { title: "Disputed", summary: "s", contradictedBy: [{ slug: "other" }], archived: true },
+      "Body.\n",
+    );
+
+    const [page] = await collectExportPages(root);
+    expect(page.contradicted).toBe(true);
+    expect(page.archived).toBe(true);
+    expect(page.freshnessStatus).toBe("unverified"); // no source ownership in state
+  });
+
+  it("drops computed-orphaned pages (all owning sources deleted) from the export", async () => {
+    const root = await makeTempRoot("export-fresh-orphan");
+    // g.md owns "ghost" in state but the source file is gone from disk.
+    await state(root, { "g.md": { hash: sha("gone"), concepts: ["ghost"] } });
+    await writePage(path.join(root, "wiki/concepts"), "ghost", { title: "Ghost", summary: "s" }, "Body.\n");
+    await writePage(path.join(root, "wiki/concepts"), "alive", { title: "Alive", summary: "s" }, "Body.\n");
+
+    const slugs = (await collectExportPages(root)).map((p) => p.slug);
+    expect(slugs).toContain("alive");
+    expect(slugs).not.toContain("ghost");
+  });
+});

--- a/test/export-freshness.test.ts
+++ b/test/export-freshness.test.ts
@@ -6,33 +6,17 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { mkdir, writeFile } from "fs/promises";
 import path from "path";
-import { createHash } from "node:crypto";
 import { writePage } from "./fixtures/write-page.js";
 import { makeTempRoot } from "./fixtures/temp-root.js";
-import { writeTestStateJson } from "./fixtures/state-json.js";
+import { sha256Hex, writeSourceFile, writeSourceState } from "./fixtures/state-json.js";
 import { collectExportPages } from "../src/export/collect.js";
-
-const sha = (s: string) => createHash("sha256").update(s).digest("hex");
-
-async function writeSource(root: string, file: string, content: string) {
-  await mkdir(path.join(root, "sources"), { recursive: true });
-  await writeFile(path.join(root, "sources", file), content);
-}
-
-async function state(root: string, sources: Record<string, { hash: string; concepts: string[] }>) {
-  const entries = Object.fromEntries(
-    Object.entries(sources).map(([f, s]) => [f, { ...s, compiledAt: "t" }]),
-  );
-  await writeTestStateJson(root, { version: 1, indexHash: "", sources: entries });
-}
 
 describe("export freshness fields", () => {
   it("marks a page stale when its source changed since compile", async () => {
     const root = await makeTempRoot("export-fresh-stale");
-    await writeSource(root, "a.md", "NEW body");
-    await state(root, { "a.md": { hash: sha("OLD body"), concepts: ["topic"] } });
+    await writeSourceFile(root, "a.md", "NEW body");
+    await writeSourceState(root, { "a.md": { hash: sha256Hex("OLD body"), concepts: ["topic"] } });
     await writePage(path.join(root, "wiki/concepts"), "topic", { title: "Topic", summary: "s" }, "Body.\n");
 
     const [page] = await collectExportPages(root);
@@ -59,7 +43,7 @@ describe("export freshness fields", () => {
   it("drops computed-orphaned pages (all owning sources deleted) from the export", async () => {
     const root = await makeTempRoot("export-fresh-orphan");
     // g.md owns "ghost" in state but the source file is gone from disk.
-    await state(root, { "g.md": { hash: sha("gone"), concepts: ["ghost"] } });
+    await writeSourceState(root, { "g.md": { hash: sha256Hex("gone"), concepts: ["ghost"] } });
     await writePage(path.join(root, "wiki/concepts"), "ghost", { title: "Ghost", summary: "s" }, "Body.\n");
     await writePage(path.join(root, "wiki/concepts"), "alive", { title: "Alive", summary: "s" }, "Body.\n");
 

--- a/test/fixtures/state-json.ts
+++ b/test/fixtures/state-json.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared helpers for writing `.llmwiki/state.json` in tests.
+ *
+ * Freshness and state tests need compact state fixtures without going through
+ * the production atomic writer. These helpers keep that setup consistent and
+ * avoid duplicated mkdir/writeFile boilerplate across test files.
+ */
+
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+import { LLMWIKI_DIR, STATE_FILE } from "../../src/utils/constants.js";
+import type { WikiState } from "../../src/utils/types.js";
+
+/** Write a raw JSON string to the test project's state file. */
+export async function writeRawTestStateJson(root: string, contents: string): Promise<void> {
+  await mkdir(path.join(root, LLMWIKI_DIR), { recursive: true });
+  await writeFile(path.join(root, STATE_FILE), contents, "utf-8");
+}
+
+/** Write a parsed WikiState object to the test project's state file. */
+export async function writeTestStateJson(root: string, state: WikiState): Promise<void> {
+  await writeRawTestStateJson(root, JSON.stringify(state));
+}
+
+/** Write intentionally invalid state JSON for corrupt-state regression tests. */
+export async function writeCorruptTestStateJson(root: string): Promise<void> {
+  await writeRawTestStateJson(root, "{ not valid json");
+}

--- a/test/fixtures/state-json.ts
+++ b/test/fixtures/state-json.ts
@@ -7,9 +7,36 @@
  */
 
 import { mkdir, writeFile } from "fs/promises";
+import { createHash } from "node:crypto";
 import path from "path";
 import { LLMWIKI_DIR, STATE_FILE } from "../../src/utils/constants.js";
 import type { WikiState } from "../../src/utils/types.js";
+
+/** Hex SHA-256 of a string — mirrors the compiler's source hashing for fixtures. */
+export function sha256Hex(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+/**
+ * Write a state file from a `filename -> { hash, concepts }` map, filling in a
+ * fixed `compiledAt`. The common freshness-test setup, shared so the wrapper
+ * isn't re-declared per file.
+ */
+export async function writeSourceState(
+  root: string,
+  sources: Record<string, { hash: string; concepts: string[] }>,
+): Promise<void> {
+  const entries = Object.fromEntries(
+    Object.entries(sources).map(([file, s]) => [file, { ...s, compiledAt: "t" }]),
+  );
+  await writeTestStateJson(root, { version: 1, indexHash: "", sources: entries });
+}
+
+/** Write a source file under `sources/`, creating the directory if needed. */
+export async function writeSourceFile(root: string, file: string, content: string): Promise<void> {
+  await mkdir(path.join(root, "sources"), { recursive: true });
+  await writeFile(path.join(root, "sources", file), content);
+}
 
 /** Write a raw JSON string to the test project's state file. */
 export async function writeRawTestStateJson(root: string, contents: string): Promise<void> {

--- a/test/freshness-lint.test.ts
+++ b/test/freshness-lint.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { mkdir, writeFile } from "fs/promises";
+import { existsSync } from "fs";
 import path from "path";
 import { createHash } from "node:crypto";
 import { checkStalePages } from "../src/linter/rules.js";
@@ -20,13 +21,18 @@ async function writeState(dir: string, sources: Record<string, { hash: string; c
   await writeFile(path.join(dir, ".llmwiki/state.json"), JSON.stringify({ version: 1, indexHash: "", sources: entries }));
 }
 
+/** Write a source file whose current content differs from the recorded hash, making owners stale. */
+async function writeStaleSource(dir: string, concepts: string[]) {
+  await mkdir(path.join(dir, "sources"), { recursive: true });
+  await writeFile(path.join(dir, "sources/a.md"), "NEW body");
+  await writeState(dir, { "a.md": { hash: sha("OLD body"), concepts } });
+}
+
 describe("checkStalePages", () => {
   const env = useLintTempRoot("freshness-lint");
 
   it("reports a page whose source changed since compile", async () => {
-    await mkdir(path.join(env.dir, "sources"), { recursive: true });
-    await writeFile(path.join(env.dir, "sources/a.md"), "NEW body");
-    await writeState(env.dir, { "a.md": { hash: sha("OLD body"), concepts: ["topic"] } });
+    await writeStaleSource(env.dir, ["topic"]);
     await writeConcept(env.dir, "topic", { title: "Topic" }, "Body.");
 
     const snap = await buildFreshnessSnapshot(env.dir);
@@ -44,5 +50,30 @@ describe("checkStalePages", () => {
 
     const snap = await buildFreshnessSnapshot(env.dir);
     expect(await checkStalePages(env.dir, snap)).toEqual([]);
+  });
+
+  it("never reports a query page as stale", async () => {
+    await writeStaleSource(env.dir, ["topic"]);
+    await mkdir(path.join(env.dir, "wiki/queries"), { recursive: true });
+    await writeFile(path.join(env.dir, "wiki/queries/topic.md"), "---\ntitle: Topic\n---\n\nBody.\n");
+    const snap = await buildFreshnessSnapshot(env.dir);
+    expect(await checkStalePages(env.dir, snap)).toEqual([]);
+  });
+});
+
+describe("checkStalePages — corrupt state is read-only and non-fatal", () => {
+  const env = useLintTempRoot("freshness-lint-corrupt");
+
+  it("reports no stale pages and writes no .bak when state.json is corrupt", async () => {
+    await mkdir(path.join(env.dir, ".llmwiki"), { recursive: true });
+    await writeFile(path.join(env.dir, ".llmwiki/state.json"), "{ not valid json");
+    await mkdir(path.join(env.dir, "wiki/concepts"), { recursive: true });
+    await writeFile(path.join(env.dir, "wiki/concepts/topic.md"), "---\ntitle: Topic\n---\n\nBody.\n");
+
+    const snap = await buildFreshnessSnapshot(env.dir);
+    const results = await checkStalePages(env.dir, snap);
+
+    expect(results).toEqual([]); // corrupt state => every page unverified, never stale
+    expect(existsSync(path.join(env.dir, ".llmwiki/state.json.bak"))).toBe(false);
   });
 });

--- a/test/freshness-lint.test.ts
+++ b/test/freshness-lint.test.ts
@@ -4,6 +4,7 @@ import { existsSync } from "fs";
 import path from "path";
 import { createHash } from "node:crypto";
 import { checkStalePages } from "../src/linter/rules.js";
+import { lint } from "../src/linter/index.js";
 import { buildFreshnessSnapshot } from "../src/freshness/index.js";
 import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
 import { writeCorruptTestStateJson, writeTestStateJson } from "./fixtures/state-json.js";
@@ -60,6 +61,39 @@ describe("checkStalePages", () => {
     await writeFile(path.join(env.dir, "wiki/queries/topic.md"), "---\ntitle: Topic\n---\n\nBody.\n");
     const snap = await buildFreshnessSnapshot(env.dir);
     expect(await checkStalePages(env.dir, snap)).toEqual([]);
+  });
+
+  it("reports a computed-orphaned page (all owning sources deleted, no frontmatter flag)", async () => {
+    // a.md owns "topic" in state, but the source file does not exist on disk.
+    await writeState(env.dir, { "a.md": { hash: sha("gone"), concepts: ["topic"] } });
+    await writeConcept(env.dir, "topic", { title: "Topic" }, "Body.");
+
+    const snap = await buildFreshnessSnapshot(env.dir);
+    const results = await checkStalePages(env.dir, snap);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe("orphaned-page");
+  });
+
+  it("does not double-report a frontmatter-orphaned page (left to checkOrphanedPages)", async () => {
+    await writeState(env.dir, { "a.md": { hash: sha("gone"), concepts: ["topic"] } });
+    await writeConcept(env.dir, "topic", { title: "Topic", orphaned: true }, "Body.");
+
+    const snap = await buildFreshnessSnapshot(env.dir);
+    expect(await checkStalePages(env.dir, snap)).toEqual([]);
+  });
+});
+
+describe("lint() orchestrator surfaces freshness findings", () => {
+  const env = useLintTempRoot("freshness-lint-orchestrator");
+
+  it("includes the stale-page finding in the full lint summary", async () => {
+    await writeStaleSource(env.dir, ["topic"]);
+    await writeConcept(env.dir, "topic", { title: "Topic", summary: "s" }, "Body with a [[topic]] link.");
+
+    const summary = await lint(env.dir);
+    const staleFindings = summary.results.filter((r) => r.rule === "stale-page");
+    expect(staleFindings).toHaveLength(1);
+    expect(staleFindings[0].file).toContain("topic.md");
   });
 });
 

--- a/test/freshness-lint.test.ts
+++ b/test/freshness-lint.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+import { createHash } from "node:crypto";
+import { checkStalePages } from "../src/linter/rules.js";
+import { buildFreshnessSnapshot } from "../src/freshness/index.js";
+import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
+
+const sha = (s: string) => createHash("sha256").update(s).digest("hex");
+
+async function writeConcept(dir: string, slug: string, frontmatter: Record<string, unknown>, body: string) {
+  await mkdir(path.join(dir, "wiki/concepts"), { recursive: true });
+  const fm = Object.entries(frontmatter).map(([k, v]) => `${k}: ${JSON.stringify(v)}`).join("\n");
+  await writeFile(path.join(dir, "wiki/concepts", `${slug}.md`), `---\n${fm}\n---\n\n${body}\n`);
+}
+
+async function writeState(dir: string, sources: Record<string, { hash: string; concepts: string[] }>) {
+  await mkdir(path.join(dir, ".llmwiki"), { recursive: true });
+  const entries = Object.fromEntries(Object.entries(sources).map(([f, s]) => [f, { ...s, compiledAt: "t" }]));
+  await writeFile(path.join(dir, ".llmwiki/state.json"), JSON.stringify({ version: 1, indexHash: "", sources: entries }));
+}
+
+describe("checkStalePages", () => {
+  const env = useLintTempRoot("freshness-lint");
+
+  it("reports a page whose source changed since compile", async () => {
+    await mkdir(path.join(env.dir, "sources"), { recursive: true });
+    await writeFile(path.join(env.dir, "sources/a.md"), "NEW body");
+    await writeState(env.dir, { "a.md": { hash: sha("OLD body"), concepts: ["topic"] } });
+    await writeConcept(env.dir, "topic", { title: "Topic" }, "Body.");
+
+    const snap = await buildFreshnessSnapshot(env.dir);
+    const results = await checkStalePages(env.dir, snap);
+    expect(results).toHaveLength(1);
+    expect(results[0].rule).toBe("stale-page");
+    expect(results[0].severity).toBe("warning");
+  });
+
+  it("reports nothing when sources are unchanged", async () => {
+    await mkdir(path.join(env.dir, "sources"), { recursive: true });
+    await writeFile(path.join(env.dir, "sources/a.md"), "same");
+    await writeState(env.dir, { "a.md": { hash: sha("same"), concepts: ["topic"] } });
+    await writeConcept(env.dir, "topic", { title: "Topic" }, "Body.");
+
+    const snap = await buildFreshnessSnapshot(env.dir);
+    expect(await checkStalePages(env.dir, snap)).toEqual([]);
+  });
+});

--- a/test/freshness-lint.test.ts
+++ b/test/freshness-lint.test.ts
@@ -2,14 +2,16 @@ import { describe, it, expect } from "vitest";
 import { mkdir, writeFile } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
-import { createHash } from "node:crypto";
 import { checkStalePages } from "../src/linter/rules.js";
 import { lint } from "../src/linter/index.js";
 import { buildFreshnessSnapshot } from "../src/freshness/index.js";
 import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
-import { writeCorruptTestStateJson, writeTestStateJson } from "./fixtures/state-json.js";
-
-const sha = (s: string) => createHash("sha256").update(s).digest("hex");
+import {
+  sha256Hex,
+  writeCorruptTestStateJson,
+  writeSourceFile,
+  writeSourceState,
+} from "./fixtures/state-json.js";
 
 async function writeConcept(dir: string, slug: string, frontmatter: Record<string, unknown>, body: string) {
   await mkdir(path.join(dir, "wiki/concepts"), { recursive: true });
@@ -17,18 +19,18 @@ async function writeConcept(dir: string, slug: string, frontmatter: Record<strin
   await writeFile(path.join(dir, "wiki/concepts", `${slug}.md`), `---\n${fm}\n---\n\n${body}\n`);
 }
 
-async function writeState(dir: string, sources: Record<string, { hash: string; concepts: string[] }>) {
-  const entries = Object.fromEntries(
-    Object.entries(sources).map(([f, s]) => [f, { ...s, compiledAt: "t" }]),
-  );
-  await writeTestStateJson(dir, { version: 1, indexHash: "", sources: entries });
-}
-
 /** Write a source file whose current content differs from the recorded hash, making owners stale. */
 async function writeStaleSource(dir: string, concepts: string[]) {
-  await mkdir(path.join(dir, "sources"), { recursive: true });
-  await writeFile(path.join(dir, "sources/a.md"), "NEW body");
-  await writeState(dir, { "a.md": { hash: sha("OLD body"), concepts } });
+  await writeSourceFile(dir, "a.md", "NEW body");
+  await writeSourceState(dir, { "a.md": { hash: sha256Hex("OLD body"), concepts } });
+}
+
+/** Build the snapshot, run the rule, and assert exactly one finding of the given rule. Returns it. */
+async function expectSingleFinding(dir: string, rule: string) {
+  const results = await checkStalePages(dir, await buildFreshnessSnapshot(dir));
+  expect(results).toHaveLength(1);
+  expect(results[0].rule).toBe(rule);
+  return results[0];
 }
 
 describe("checkStalePages", () => {
@@ -38,17 +40,14 @@ describe("checkStalePages", () => {
     await writeStaleSource(env.dir, ["topic"]);
     await writeConcept(env.dir, "topic", { title: "Topic" }, "Body.");
 
-    const snap = await buildFreshnessSnapshot(env.dir);
-    const results = await checkStalePages(env.dir, snap);
-    expect(results).toHaveLength(1);
-    expect(results[0].rule).toBe("stale-page");
-    expect(results[0].severity).toBe("warning");
+    const finding = await expectSingleFinding(env.dir, "stale-page");
+    expect(finding.severity).toBe("warning");
   });
 
   it("reports nothing when sources are unchanged", async () => {
     await mkdir(path.join(env.dir, "sources"), { recursive: true });
     await writeFile(path.join(env.dir, "sources/a.md"), "same");
-    await writeState(env.dir, { "a.md": { hash: sha("same"), concepts: ["topic"] } });
+    await writeSourceState(env.dir, { "a.md": { hash: sha256Hex("same"), concepts: ["topic"] } });
     await writeConcept(env.dir, "topic", { title: "Topic" }, "Body.");
 
     const snap = await buildFreshnessSnapshot(env.dir);
@@ -65,17 +64,14 @@ describe("checkStalePages", () => {
 
   it("reports a computed-orphaned page (all owning sources deleted, no frontmatter flag)", async () => {
     // a.md owns "topic" in state, but the source file does not exist on disk.
-    await writeState(env.dir, { "a.md": { hash: sha("gone"), concepts: ["topic"] } });
+    await writeSourceState(env.dir, { "a.md": { hash: sha256Hex("gone"), concepts: ["topic"] } });
     await writeConcept(env.dir, "topic", { title: "Topic" }, "Body.");
 
-    const snap = await buildFreshnessSnapshot(env.dir);
-    const results = await checkStalePages(env.dir, snap);
-    expect(results).toHaveLength(1);
-    expect(results[0].rule).toBe("orphaned-page");
+    await expectSingleFinding(env.dir, "orphaned-page");
   });
 
   it("does not double-report a frontmatter-orphaned page (left to checkOrphanedPages)", async () => {
-    await writeState(env.dir, { "a.md": { hash: sha("gone"), concepts: ["topic"] } });
+    await writeSourceState(env.dir, { "a.md": { hash: sha256Hex("gone"), concepts: ["topic"] } });
     await writeConcept(env.dir, "topic", { title: "Topic", orphaned: true }, "Body.");
 
     const snap = await buildFreshnessSnapshot(env.dir);

--- a/test/freshness-lint.test.ts
+++ b/test/freshness-lint.test.ts
@@ -6,6 +6,7 @@ import { createHash } from "node:crypto";
 import { checkStalePages } from "../src/linter/rules.js";
 import { buildFreshnessSnapshot } from "../src/freshness/index.js";
 import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
+import { writeCorruptTestStateJson, writeTestStateJson } from "./fixtures/state-json.js";
 
 const sha = (s: string) => createHash("sha256").update(s).digest("hex");
 
@@ -16,9 +17,10 @@ async function writeConcept(dir: string, slug: string, frontmatter: Record<strin
 }
 
 async function writeState(dir: string, sources: Record<string, { hash: string; concepts: string[] }>) {
-  await mkdir(path.join(dir, ".llmwiki"), { recursive: true });
-  const entries = Object.fromEntries(Object.entries(sources).map(([f, s]) => [f, { ...s, compiledAt: "t" }]));
-  await writeFile(path.join(dir, ".llmwiki/state.json"), JSON.stringify({ version: 1, indexHash: "", sources: entries }));
+  const entries = Object.fromEntries(
+    Object.entries(sources).map(([f, s]) => [f, { ...s, compiledAt: "t" }]),
+  );
+  await writeTestStateJson(dir, { version: 1, indexHash: "", sources: entries });
 }
 
 /** Write a source file whose current content differs from the recorded hash, making owners stale. */
@@ -65,8 +67,7 @@ describe("checkStalePages — corrupt state is read-only and non-fatal", () => {
   const env = useLintTempRoot("freshness-lint-corrupt");
 
   it("reports no stale pages and writes no .bak when state.json is corrupt", async () => {
-    await mkdir(path.join(env.dir, ".llmwiki"), { recursive: true });
-    await writeFile(path.join(env.dir, ".llmwiki/state.json"), "{ not valid json");
+    await writeCorruptTestStateJson(env.dir);
     await mkdir(path.join(env.dir, "wiki/concepts"), { recursive: true });
     await writeFile(path.join(env.dir, "wiki/concepts/topic.md"), "---\ntitle: Topic\n---\n\nBody.\n");
 

--- a/test/freshness.test.ts
+++ b/test/freshness.test.ts
@@ -6,6 +6,7 @@ import { computeFreshness } from "../src/freshness/index.js";
 import { buildFreshnessSnapshot } from "../src/freshness/index.js";
 import type { FreshnessSnapshot } from "../src/freshness/types.js";
 import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
+import { writeTestStateJson } from "./fixtures/state-json.js";
 
 function snapshot(sources: FreshnessSnapshot["sources"], stateStatus: FreshnessSnapshot["stateStatus"] = "ok"): FreshnessSnapshot {
   return { stateStatus, sources };
@@ -84,14 +85,14 @@ describe("buildFreshnessSnapshot", () => {
   it("captures stateStatus and per-source recorded/current hash + existence", async () => {
     await mkdir(path.join(env.dir, "sources"), { recursive: true });
     await writeFile(path.join(env.dir, "sources/a.md"), "current body");
-    await mkdir(path.join(env.dir, ".llmwiki"), { recursive: true });
-    await writeFile(
-      path.join(env.dir, ".llmwiki/state.json"),
-      JSON.stringify({ version: 1, indexHash: "", sources: {
+    await writeTestStateJson(env.dir, {
+      version: 1,
+      indexHash: "",
+      sources: {
         "a.md": { hash: "OLD", concepts: ["topic"], compiledAt: "t" },
         "gone.md": { hash: "X", concepts: ["ghost"], compiledAt: "t" },
-      } }),
-    );
+      },
+    });
     const snap = await buildFreshnessSnapshot(env.dir);
     expect(snap.stateStatus).toBe("ok");
     expect(snap.sources["a.md"]).toEqual({ recordedHash: "OLD", currentHash: sha("current body"), exists: true, concepts: ["topic"] });

--- a/test/freshness.test.ts
+++ b/test/freshness.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+import { createHash } from "node:crypto";
 import { computeFreshness } from "../src/freshness/index.js";
+import { buildFreshnessSnapshot } from "../src/freshness/index.js";
 import type { FreshnessSnapshot } from "../src/freshness/types.js";
+import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
 
 function snapshot(sources: FreshnessSnapshot["sources"], stateStatus: FreshnessSnapshot["stateStatus"] = "ok"): FreshnessSnapshot {
   return { stateStatus, sources };
@@ -68,5 +73,34 @@ describe("computeFreshness — contradicted/archived", () => {
     const result = computeFreshness(concept("topic"), snap);
     expect(result.contradicted).toBe(false);
     expect(result.archived).toBe(false);
+  });
+});
+
+const sha = (s: string) => createHash("sha256").update(s).digest("hex");
+
+describe("buildFreshnessSnapshot", () => {
+  const env = useLintTempRoot("freshness-snap");
+
+  it("captures stateStatus and per-source recorded/current hash + existence", async () => {
+    await mkdir(path.join(env.dir, "sources"), { recursive: true });
+    await writeFile(path.join(env.dir, "sources/a.md"), "current body");
+    await mkdir(path.join(env.dir, ".llmwiki"), { recursive: true });
+    await writeFile(
+      path.join(env.dir, ".llmwiki/state.json"),
+      JSON.stringify({ version: 1, indexHash: "", sources: {
+        "a.md": { hash: "OLD", concepts: ["topic"], compiledAt: "t" },
+        "gone.md": { hash: "X", concepts: ["ghost"], compiledAt: "t" },
+      } }),
+    );
+    const snap = await buildFreshnessSnapshot(env.dir);
+    expect(snap.stateStatus).toBe("ok");
+    expect(snap.sources["a.md"]).toEqual({ recordedHash: "OLD", currentHash: sha("current body"), exists: true, concepts: ["topic"] });
+    expect(snap.sources["gone.md"]).toEqual({ recordedHash: "X", currentHash: null, exists: false, concepts: ["ghost"] });
+  });
+
+  it("returns empty sources when state is missing", async () => {
+    const snap = await buildFreshnessSnapshot(env.dir);
+    expect(snap.stateStatus).toBe("missing");
+    expect(snap.sources).toEqual({});
   });
 });

--- a/test/freshness.test.ts
+++ b/test/freshness.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { computeFreshness } from "../src/freshness/index.js";
+import type { FreshnessSnapshot } from "../src/freshness/types.js";
+
+function snapshot(sources: FreshnessSnapshot["sources"], stateStatus: FreshnessSnapshot["stateStatus"] = "ok"): FreshnessSnapshot {
+  return { stateStatus, sources };
+}
+const concept = (slug: string, frontmatter: Record<string, unknown> = {}) =>
+  ({ slug, pageDirectory: "concepts" as const, frontmatter });
+
+describe("computeFreshness — freshnessStatus", () => {
+  it("fresh when the owning source exists and its hash matches", () => {
+    const snap = snapshot({ "a.md": { recordedHash: "h", currentHash: "h", exists: true, concepts: ["topic"] } });
+    expect(computeFreshness(concept("topic"), snap).freshnessStatus).toBe("fresh");
+  });
+
+  it("stale when an owning source's hash drifted", () => {
+    const snap = snapshot({ "a.md": { recordedHash: "h1", currentHash: "h2", exists: true, concepts: ["topic"] } });
+    expect(computeFreshness(concept("topic"), snap).freshnessStatus).toBe("stale");
+  });
+
+  it("orphaned when ALL owning sources are deleted", () => {
+    const snap = snapshot({ "a.md": { recordedHash: "h", currentHash: null, exists: false, concepts: ["topic"] } });
+    expect(computeFreshness(concept("topic"), snap).freshnessStatus).toBe("orphaned");
+  });
+
+  it("STALE (not orphaned) when one owner is deleted but another is live [key regression]", () => {
+    const snap = snapshot({
+      "a.md": { recordedHash: "h", currentHash: null, exists: false, concepts: ["merged"] },
+      "b.md": { recordedHash: "h", currentHash: "h", exists: true, concepts: ["merged"] },
+    });
+    expect(computeFreshness(concept("merged"), snap).freshnessStatus).toBe("stale");
+  });
+
+  it("unverified when the page has no owner in state", () => {
+    const snap = snapshot({ "a.md": { recordedHash: "h", currentHash: "h", exists: true, concepts: ["other"] } });
+    expect(computeFreshness(concept("handwritten"), snap).freshnessStatus).toBe("unverified");
+  });
+
+  it("unverified for any page when state is missing or corrupt", () => {
+    expect(computeFreshness(concept("topic"), snapshot({}, "missing")).freshnessStatus).toBe("unverified");
+    expect(computeFreshness(concept("topic"), snapshot({}, "corrupt")).freshnessStatus).toBe("unverified");
+  });
+
+  it("unverified for query pages, never orphaned or fresh", () => {
+    const snap = snapshot({ "a.md": { recordedHash: "h", currentHash: "h", exists: true, concepts: ["q"] } });
+    const queryPage = { slug: "q", pageDirectory: "queries" as const, frontmatter: {} };
+    expect(computeFreshness(queryPage, snap).freshnessStatus).toBe("unverified");
+  });
+
+  it("orphaned via legacy frontmatter flag", () => {
+    const snap = snapshot({ "a.md": { recordedHash: "h", currentHash: "h", exists: true, concepts: ["topic"] } });
+    expect(computeFreshness(concept("topic", { orphaned: true }), snap).freshnessStatus).toBe("orphaned");
+  });
+});
+
+describe("computeFreshness — contradicted/archived", () => {
+  it("derives contradicted from contradictedBy and archived from frontmatter", () => {
+    const snap = snapshot({ "a.md": { recordedHash: "h", currentHash: "h", exists: true, concepts: ["topic"] } });
+    const page = concept("topic", { contradictedBy: [{ slug: "other" }], archived: true });
+    const result = computeFreshness(page, snap);
+    expect(result.contradicted).toBe(true);
+    expect(result.archived).toBe(true);
+  });
+
+  it("defaults contradicted/archived to false", () => {
+    const snap = snapshot({ "a.md": { recordedHash: "h", currentHash: "h", exists: true, concepts: ["topic"] } });
+    const result = computeFreshness(concept("topic"), snap);
+    expect(result.contradicted).toBe(false);
+    expect(result.archived).toBe(false);
+  });
+});

--- a/test/state-classified.test.ts
+++ b/test/state-classified.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { existsSync } from "fs";
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+import { readStateClassified } from "../src/utils/state.js";
+import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
+
+describe("readStateClassified", () => {
+  const env = useLintTempRoot("state-classified");
+
+  it("reports missing when state.json does not exist", async () => {
+    const result = await readStateClassified(env.dir);
+    expect(result.status).toBe("missing");
+    expect(result.state.sources).toEqual({});
+  });
+
+  it("reports ok and parses a valid state file", async () => {
+    await mkdir(path.join(env.dir, ".llmwiki"), { recursive: true });
+    await writeFile(
+      path.join(env.dir, ".llmwiki/state.json"),
+      JSON.stringify({ version: 1, indexHash: "", sources: { "a.md": { hash: "h", concepts: ["x"], compiledAt: "t" } } }),
+    );
+    const result = await readStateClassified(env.dir);
+    expect(result.status).toBe("ok");
+    expect(result.state.sources["a.md"].hash).toBe("h");
+  });
+
+  it("reports corrupt WITHOUT writing a .bak (read-only)", async () => {
+    await mkdir(path.join(env.dir, ".llmwiki"), { recursive: true });
+    await writeFile(path.join(env.dir, ".llmwiki/state.json"), "{ not valid json");
+    const result = await readStateClassified(env.dir);
+    expect(result.status).toBe("corrupt");
+    expect(result.state.sources).toEqual({});
+    expect(existsSync(path.join(env.dir, ".llmwiki/state.json.bak"))).toBe(false);
+  });
+});

--- a/test/state-classified.test.ts
+++ b/test/state-classified.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { existsSync } from "fs";
-import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 import { readStateClassified } from "../src/utils/state.js";
 import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
+import { writeCorruptTestStateJson, writeTestStateJson } from "./fixtures/state-json.js";
 
 describe("readStateClassified", () => {
   const env = useLintTempRoot("state-classified");
@@ -15,19 +15,18 @@ describe("readStateClassified", () => {
   });
 
   it("reports ok and parses a valid state file", async () => {
-    await mkdir(path.join(env.dir, ".llmwiki"), { recursive: true });
-    await writeFile(
-      path.join(env.dir, ".llmwiki/state.json"),
-      JSON.stringify({ version: 1, indexHash: "", sources: { "a.md": { hash: "h", concepts: ["x"], compiledAt: "t" } } }),
-    );
+    await writeTestStateJson(env.dir, {
+      version: 1,
+      indexHash: "",
+      sources: { "a.md": { hash: "h", concepts: ["x"], compiledAt: "t" } },
+    });
     const result = await readStateClassified(env.dir);
     expect(result.status).toBe("ok");
     expect(result.state.sources["a.md"].hash).toBe("h");
   });
 
   it("reports corrupt WITHOUT writing a .bak (read-only)", async () => {
-    await mkdir(path.join(env.dir, ".llmwiki"), { recursive: true });
-    await writeFile(path.join(env.dir, ".llmwiki/state.json"), "{ not valid json");
+    await writeCorruptTestStateJson(env.dir);
     const result = await readStateClassified(env.dir);
     expect(result.status).toBe("corrupt");
     expect(result.state.sources).toEqual({});


### PR DESCRIPTION
Adds a computed source-freshness layer — the foundation the trust roadmap's freshness/lifecycle work builds on — and wires it into the first two surfaces.

A new `src/freshness/` module derives each page's `freshnessStatus` (`fresh`/`stale`/`orphaned`/`unverified`) plus orthogonal `contradicted`/`archived` flags, on demand from `.llmwiki/state.json` and the current `sources/`, with nothing persisted as the answer. It's built once per run as a shared snapshot (one read-only state read + one source-hash pass) so consumers never duplicate hashing.

Surfaces wired in this PR:
- **`llmwiki lint`** reports `stale` pages and computed-`orphaned` pages (sources deleted but not yet recompiled), without double-reporting pages already flagged orphaned in frontmatter.
- **JSON export** carries `freshnessStatus`/`contradicted`/`archived` per page, replacing the old `advisoryFreshnessStatus: "unverified"` placeholder. The export stays active-page-only, so it emits `fresh`/`stale`/`unverified` and drops orphaned pages.

Key correctness rules: a concept page is stale (not orphaned) when one of several shared sources is deleted but another stays live — matching the compiler's shared-concept preservation; query pages are always `unverified`; and missing or corrupt `state.json` yields `unverified` rather than misclassifying every page. Freshness reads go through a new read-only `readStateClassified()` so lint/export never write the `.bak` side effect that `readState()` produces on corrupt input.

Out of scope (tracked as follow-up plans): the remaining surfaces (MCP `wiki_status`/`get_context_pack`, context packs, viewer badges), `refresh --stale`, and claim-span freshness.

## Test plan
- [x] `npx tsc --noEmit`, `npm run build`, `npx fallow` — all green
- [x] `npm test` — 1229 passing (unit coverage for the classifier/snapshot/read-only state read; integration coverage for stale + orphaned lint, the `lint()` orchestrator, the corrupt-state read-only guard, and freshness flowing into the JSON export)
