### PR TITLE
eval: add source utilization and citation depth metrics

### DIFF
--- a/src/eval/citation-coverage.ts
+++ b/src/eval/citation-coverage.ts
@@ -11,14 +11,12 @@
 
 import path from "path";
 import { collectAllPages } from "../linter/rules.js";
-import { parseFrontmatter, extractClaimCitations } from "../utils/markdown.js";
+import { parseFrontmatter, extractClaimCitations, splitProseParagraphs } from "../utils/markdown.js";
 import { SOURCES_DIR } from "../utils/constants.js";
 import { resolveSourceFile } from "./source-path.js";
 import type { CitationCoverageResult, CitationPageResult } from "./types.js";
 
 /** Prose paragraphs start with a Unicode letter. */
-const PROSE_LEAD_RE = /^\p{L}/u;
-
 interface PageStats {
   pageResult: CitationPageResult;
   proseParagraphs: number;
@@ -29,7 +27,7 @@ interface PageStats {
 
 /** Evaluate citation coverage and precision for a single page body. */
 async function evaluatePage(slug: string, body: string, sourcesDir: string): Promise<PageStats> {
-  const paragraphs = body.split(/\n\s*\n/).filter((p) => PROSE_LEAD_RE.test(p.trim()));
+  const paragraphs = splitProseParagraphs(body);
   let citedParagraphs = 0;
   let totalCitations = 0;
   let validCitations = 0;

--- a/src/eval/citation-depth.ts
+++ b/src/eval/citation-depth.ts
@@ -10,46 +10,36 @@
  *  - avgCitationsPerParagraph: citation density across prose paragraphs.
  */
 
-import path from "path";
 import { collectAllPages } from "../linter/rules.js";
 import { parseFrontmatter, extractClaimCitations } from "../utils/markdown.js";
 import type { CitationDepthResult } from "./types.js";
 
 const PROSE_LEAD_RE = /^\p{L}/u;
 
-/**
- * Evaluate citation depth across all wiki pages.
- * @param root - Absolute path to the project root.
- */
-export async function evaluateCitationDepth(
-  root: string,
-): Promise<CitationDepthResult> {
-  const pages = await collectAllPages(root);
+interface PageCounts { total: number; precise: number; proseParagraphs: number; }
 
-  let totalCitations = 0;
-  let citationsWithLineRange = 0;
-  let totalProseParagraphs = 0;
-
-  for (const { filePath, content } of pages) {
-    const { body } = parseFrontmatter(content);
-    const paragraphs = body.split(/\n\s*\n/).filter((p) => PROSE_LEAD_RE.test(p.trim()));
-    totalProseParagraphs += paragraphs.length;
-
-    for (const para of paragraphs) {
-      const citations = extractClaimCitations(para);
-      for (const { spans } of citations) {
-        for (const span of spans) {
-          totalCitations++;
-          if (span.lines) citationsWithLineRange++;
-        }
+function countPageCitations(body: string): PageCounts {
+  const paragraphs = body.split(/\n\s*\n/).filter((p) => PROSE_LEAD_RE.test(p.trim()));
+  let total = 0;
+  let precise = 0;
+  for (const para of paragraphs) {
+    const citations = extractClaimCitations(para);
+    for (const { spans } of citations) {
+      for (const span of spans) {
+        total++;
+        if (span.lines) precise++;
       }
     }
   }
+  return { total, precise, proseParagraphs: paragraphs.length };
+}
 
+function buildResult(
+  totalCitations: number, citationsWithLineRange: number, totalProseParagraphs: number,
+): CitationDepthResult {
   const claimLevelRate = totalCitations === 0 ? 0 : citationsWithLineRange / totalCitations;
   const avgCitationsPerParagraph = totalProseParagraphs === 0 ? 0
     : Math.round((totalCitations / totalProseParagraphs) * 100) / 100;
-
   return {
     totalCitations,
     preciseCitations: citationsWithLineRange,
@@ -57,4 +47,21 @@ export async function evaluateCitationDepth(
     claimLevelRate: Math.round(claimLevelRate * 1000) / 1000,
     avgCitationsPerParagraph,
   };
+}
+
+export async function evaluateCitationDepth(
+  root: string,
+): Promise<CitationDepthResult> {
+  const pages = await collectAllPages(root);
+  let totalCitations = 0;
+  let citationsWithLineRange = 0;
+  let totalProseParagraphs = 0;
+  for (const { content } of pages) {
+    const { body } = parseFrontmatter(content);
+    const counts = countPageCitations(body);
+    totalCitations += counts.total;
+    citationsWithLineRange += counts.precise;
+    totalProseParagraphs += counts.proseParagraphs;
+  }
+  return buildResult(totalCitations, citationsWithLineRange, totalProseParagraphs);
 }

--- a/src/eval/citation-depth.ts
+++ b/src/eval/citation-depth.ts
@@ -11,15 +11,13 @@
  */
 
 import { collectAllPages } from "../linter/rules.js";
-import { parseFrontmatter, extractClaimCitations } from "../utils/markdown.js";
+import { parseFrontmatter, extractClaimCitations, splitProseParagraphs } from "../utils/markdown.js";
 import type { CitationDepthResult } from "./types.js";
-
-const PROSE_LEAD_RE = /^\p{L}/u;
 
 interface PageCounts { total: number; precise: number; proseParagraphs: number; }
 
 function countPageCitations(body: string): PageCounts {
-  const paragraphs = body.split(/\n\s*\n/).filter((p) => PROSE_LEAD_RE.test(p.trim()));
+  const paragraphs = splitProseParagraphs(body);
   let total = 0;
   let precise = 0;
   for (const para of paragraphs) {
@@ -32,21 +30,6 @@ function countPageCitations(body: string): PageCounts {
     }
   }
   return { total, precise, proseParagraphs: paragraphs.length };
-}
-
-function buildResult(
-  totalCitations: number, citationsWithLineRange: number, totalProseParagraphs: number,
-): CitationDepthResult {
-  const claimLevelRate = totalCitations === 0 ? 0 : citationsWithLineRange / totalCitations;
-  const avgCitationsPerParagraph = totalProseParagraphs === 0 ? 0
-    : Math.round((totalCitations / totalProseParagraphs) * 100) / 100;
-  return {
-    totalCitations,
-    preciseCitations: citationsWithLineRange,
-    vagueCitations: totalCitations - citationsWithLineRange,
-    claimLevelRate: Math.round(claimLevelRate * 1000) / 1000,
-    avgCitationsPerParagraph,
-  };
 }
 
 export async function evaluateCitationDepth(
@@ -63,5 +46,14 @@ export async function evaluateCitationDepth(
     citationsWithLineRange += counts.precise;
     totalProseParagraphs += counts.proseParagraphs;
   }
-  return buildResult(totalCitations, citationsWithLineRange, totalProseParagraphs);
+  const claimLevelRate = totalCitations === 0 ? 0 : citationsWithLineRange / totalCitations;
+  const avgCitationsPerParagraph = totalProseParagraphs === 0 ? 0
+    : totalCitations / totalProseParagraphs;
+  return {
+    totalCitations,
+    preciseCitations: citationsWithLineRange,
+    vagueCitations: totalCitations - citationsWithLineRange,
+    claimLevelRate: Math.round(claimLevelRate * 1000) / 1000,
+    avgCitationsPerParagraph,
+  };
 }

--- a/src/eval/citation-depth.ts
+++ b/src/eval/citation-depth.ts
@@ -1,0 +1,60 @@
+/**
+ * Citation depth evaluator for the llmwiki eval harness.
+ *
+ * Measures how precise citations are. A bare ^[file.md] says "this paragraph
+ * came from somewhere in that source" — useful but vague. A claim-level
+ * citation ^[file.md:42-58] pins the exact lines, which is auditable.
+ *
+ * Metrics:
+ *  - claimLevelRate: fraction of citations that include a line range.
+ *  - avgCitationsPerParagraph: citation density across prose paragraphs.
+ */
+
+import path from "path";
+import { collectAllPages } from "../linter/rules.js";
+import { parseFrontmatter, extractClaimCitations } from "../utils/markdown.js";
+import type { CitationDepthResult } from "./types.js";
+
+const PROSE_LEAD_RE = /^\p{L}/u;
+
+/**
+ * Evaluate citation depth across all wiki pages.
+ * @param root - Absolute path to the project root.
+ */
+export async function evaluateCitationDepth(
+  root: string,
+): Promise<CitationDepthResult> {
+  const pages = await collectAllPages(root);
+
+  let totalCitations = 0;
+  let citationsWithLineRange = 0;
+  let totalProseParagraphs = 0;
+
+  for (const { filePath, content } of pages) {
+    const { body } = parseFrontmatter(content);
+    const paragraphs = body.split(/\n\s*\n/).filter((p) => PROSE_LEAD_RE.test(p.trim()));
+    totalProseParagraphs += paragraphs.length;
+
+    for (const para of paragraphs) {
+      const citations = extractClaimCitations(para);
+      for (const { spans } of citations) {
+        for (const span of spans) {
+          totalCitations++;
+          if (span.lines) citationsWithLineRange++;
+        }
+      }
+    }
+  }
+
+  const claimLevelRate = totalCitations === 0 ? 0 : citationsWithLineRange / totalCitations;
+  const avgCitationsPerParagraph = totalProseParagraphs === 0 ? 0
+    : Math.round((totalCitations / totalProseParagraphs) * 100) / 100;
+
+  return {
+    totalCitations,
+    preciseCitations: citationsWithLineRange,
+    vagueCitations: totalCitations - citationsWithLineRange,
+    claimLevelRate: Math.round(claimLevelRate * 1000) / 1000,
+    avgCitationsPerParagraph,
+  };
+}

--- a/src/eval/citation-support.ts
+++ b/src/eval/citation-support.ts
@@ -15,7 +15,7 @@ import { readFile, appendFile, mkdir } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
 import { collectAllPages } from "../linter/rules.js";
-import { parseFrontmatter, extractClaimCitations } from "../utils/markdown.js";
+import { parseFrontmatter, extractClaimCitations, splitProseParagraphs } from "../utils/markdown.js";
 import { callClaude } from "../utils/llm.js";
 import { SOURCES_DIR, DEFAULT_PROVIDER, PROVIDER_MODELS } from "../utils/constants.js";
 import { resolveSourceFile } from "./source-path.js";
@@ -25,8 +25,6 @@ import type { SourceSpan } from "../utils/types.js";
 
 const CACHE_DIR = path.join(".llmwiki", "eval");
 const CACHE_FILE = path.join(CACHE_DIR, "citation-cache.jsonl");
-const PROSE_LEAD_RE = /^\p{L}/u;
-
 /** Internal pair combining a claim paragraph with its cited source span. */
 interface CitationPair {
   claimHash: string;
@@ -136,7 +134,7 @@ async function extractPagePairs(
   body: string,
   sourcesDir: string,
 ): Promise<CitationPair[]> {
-  const paragraphs = body.split(/\n\s*\n/).filter((p) => PROSE_LEAD_RE.test(p.trim()));
+  const paragraphs = splitProseParagraphs(body);
   const results = await Promise.all(paragraphs.map((p) => extractParagraphPairs(slug, p, sourcesDir)));
   return results.flat();
 }

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -8,30 +8,33 @@
 
 import { evaluateHealth } from "./health.js";
 import { evaluateCitationCoverage } from "./citation-coverage.js";
+import { evaluateSourceUtilization } from "./source-utilization.js";
 import { evaluateCitationSupport } from "./citation-support.js";
 import { collectStats, appendHistory, loadPreviousReport, loadLastFullReport } from "./stats.js";
 import { computeDelta } from "./delta.js";
 import { checkThresholds } from "./thresholds.js";
 import { ensureProviderAvailable } from "../utils/provider-guard.js";
-import type { EvalReport, HealthResult, CitationCoverageResult, CitationSupportResult, StatsResult } from "./types.js";
+import type { EvalReport, HealthResult, CitationCoverageResult, SourceUtilizationResult, CitationSupportResult, StatsResult } from "./types.js";
 
 export const DEFAULT_SAMPLE_SIZE = 20;
 
 interface EvalComponents {
   health: HealthResult;
   citationCoverage: CitationCoverageResult;
+  sourceUtilization: SourceUtilizationResult;
   stats: StatsResult;
   previousReport: EvalReport | null;
   citationSupport?: CitationSupportResult | null;
 }
 
 async function buildReport(root: string, components: EvalComponents, suite: "fast" | "full"): Promise<EvalReport> {
-  const { health, citationCoverage, stats, previousReport, citationSupport } = components;
+  const { health, citationCoverage, sourceUtilization, stats, previousReport, citationSupport } = components;
   const partial = {
     suite,
     timestamp: new Date().toISOString(),
     health,
     citationCoverage,
+    sourceUtilization,
     stats,
     ...(citationSupport ? { citationSupport } : {}),
   };
@@ -43,9 +46,10 @@ async function buildReport(root: string, components: EvalComponents, suite: "fas
 /** Run the full eval pipeline, optionally append to history, and return the report. */
 export async function runEval(root: string, suite: "fast" | "full", sampleSize: number, record = true): Promise<EvalReport> {
   if (suite === "full") ensureProviderAvailable();
-  const [health, citationCoverage, stats, previousReport, previousFullReport] = await Promise.all([
+  const [health, citationCoverage, sourceUtilization, stats, previousReport, previousFullReport] = await Promise.all([
     evaluateHealth(root),
     evaluateCitationCoverage(root),
+    evaluateSourceUtilization(root),
     collectStats(root),
     loadPreviousReport(root),
     suite === "full" ? loadLastFullReport(root) : Promise.resolve(null),
@@ -53,7 +57,7 @@ export async function runEval(root: string, suite: "fast" | "full", sampleSize: 
   const citationSupport = suite === "full"
     ? await evaluateCitationSupport(root, sampleSize, previousFullReport?.citationSupport?.sampledHashes ?? [])
     : undefined;
-  const report = await buildReport(root, { health, citationCoverage, stats, previousReport, citationSupport }, suite);
+  const report = await buildReport(root, { health, citationCoverage, sourceUtilization, stats, previousReport, citationSupport }, suite);
   if (record) await appendHistory(root, report);
   return report;
 }

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -9,12 +9,13 @@
 import { evaluateHealth } from "./health.js";
 import { evaluateCitationCoverage } from "./citation-coverage.js";
 import { evaluateSourceUtilization } from "./source-utilization.js";
+import { evaluateCitationDepth } from "./citation-depth.js";
 import { evaluateCitationSupport } from "./citation-support.js";
 import { collectStats, appendHistory, loadPreviousReport, loadLastFullReport } from "./stats.js";
 import { computeDelta } from "./delta.js";
 import { checkThresholds } from "./thresholds.js";
 import { ensureProviderAvailable } from "../utils/provider-guard.js";
-import type { EvalReport, HealthResult, CitationCoverageResult, SourceUtilizationResult, CitationSupportResult, StatsResult } from "./types.js";
+import type { EvalReport, HealthResult, CitationCoverageResult, SourceUtilizationResult, CitationDepthResult, CitationSupportResult, StatsResult } from "./types.js";
 
 export const DEFAULT_SAMPLE_SIZE = 20;
 
@@ -22,19 +23,21 @@ interface EvalComponents {
   health: HealthResult;
   citationCoverage: CitationCoverageResult;
   sourceUtilization: SourceUtilizationResult;
+  citationDepth: CitationDepthResult;
   stats: StatsResult;
   previousReport: EvalReport | null;
   citationSupport?: CitationSupportResult | null;
 }
 
 async function buildReport(root: string, components: EvalComponents, suite: "fast" | "full"): Promise<EvalReport> {
-  const { health, citationCoverage, sourceUtilization, stats, previousReport, citationSupport } = components;
+  const { health, citationCoverage, sourceUtilization, citationDepth, stats, previousReport, citationSupport } = components;
   const partial = {
     suite,
     timestamp: new Date().toISOString(),
     health,
     citationCoverage,
     sourceUtilization,
+    citationDepth,
     stats,
     ...(citationSupport ? { citationSupport } : {}),
   };
@@ -46,10 +49,11 @@ async function buildReport(root: string, components: EvalComponents, suite: "fas
 /** Run the full eval pipeline, optionally append to history, and return the report. */
 export async function runEval(root: string, suite: "fast" | "full", sampleSize: number, record = true): Promise<EvalReport> {
   if (suite === "full") ensureProviderAvailable();
-  const [health, citationCoverage, sourceUtilization, stats, previousReport, previousFullReport] = await Promise.all([
+  const [health, citationCoverage, sourceUtilization, citationDepth, stats, previousReport, previousFullReport] = await Promise.all([
     evaluateHealth(root),
     evaluateCitationCoverage(root),
     evaluateSourceUtilization(root),
+    evaluateCitationDepth(root),
     collectStats(root),
     loadPreviousReport(root),
     suite === "full" ? loadLastFullReport(root) : Promise.resolve(null),
@@ -57,7 +61,7 @@ export async function runEval(root: string, suite: "fast" | "full", sampleSize: 
   const citationSupport = suite === "full"
     ? await evaluateCitationSupport(root, sampleSize, previousFullReport?.citationSupport?.sampledHashes ?? [])
     : undefined;
-  const report = await buildReport(root, { health, citationCoverage, sourceUtilization, stats, previousReport, citationSupport }, suite);
+  const report = await buildReport(root, { health, citationCoverage, sourceUtilization, citationDepth, stats, previousReport, citationSupport }, suite);
   if (record) await appendHistory(root, report);
   return report;
 }

--- a/src/eval/report.ts
+++ b/src/eval/report.ts
@@ -92,6 +92,33 @@ function formatSupport(report: EvalReport, delta: EvalDelta | undefined): string
   return rows;
 }
 
+function formatSourceUtilization(report: EvalReport): string[] {
+  const u = report.sourceUtilization;
+  if (u.totalSources === 0) {
+    return [line(), line('Source Utilization:  (no sources yet)')];
+  }
+  const pct = (u.utilizationRate * 100).toFixed(0);
+  const rows = [
+    line(),
+    line(bold('Source Utilization:  ' + pct + '%')),
+    line('  ' + u.citedSources + ' / ' + u.totalSources + ' sources cited by >=1 wiki page'),
+  ];
+  if (u.uncitedSources > 0) {
+    const uncited = u.perSource
+      .filter(function(s) { return s.citingPageCount === 0; })
+      .map(function(s) { return s.sourceFile; });
+    rows.push(line(colorError('  ' + String(u.uncitedSources) + ' uncited:')));
+    for (const f of uncited.slice(0, 5)) {
+      rows.push(line(dim('    - ' + f)));
+    }
+    if (uncited.length > 5) {
+      rows.push(line(dim('    ... and ' + String(uncited.length - 5) + ' more')));
+    }
+    rows.push(line(dim('  Tip: re-run llmwiki compile to extract concepts from uncited sources.')));
+  }
+  return rows;
+}
+
 function formatStats(report: EvalReport): string[] {
   const s = report.stats;
   return [

--- a/src/eval/report.ts
+++ b/src/eval/report.ts
@@ -92,6 +92,18 @@ function formatSupport(report: EvalReport, delta: EvalDelta | undefined): string
   return rows;
 }
 
+function formatCitationDepth(report: EvalReport): string[] {
+  var d = report.citationDepth;
+  if (d.totalCitations === 0) return [line(), line('Citation Depth:  (no citations)')];
+  var pct = (d.claimLevelRate * 100).toFixed(0);
+  return [
+    line(),
+    line(bold("Citation Depth:")),
+    line('  Claim-level (with line numbers): ' + d.preciseCitations + ' / ' + d.totalCitations + '  (' + pct + '%)'),
+    line('  Avg citations per paragraph: ' + d.avgCitationsPerParagraph.toFixed(1)),
+  ];
+}
+
 function formatSourceUtilization(report: EvalReport): string[] {
   const u = report.sourceUtilization;
   if (u.totalSources === 0) {

--- a/src/eval/report.ts
+++ b/src/eval/report.ts
@@ -160,6 +160,8 @@ export function formatTerminalReport(report: EvalReport): string {
     divider(),
     ...formatHealth(report, delta),
     ...formatCoverage(report, delta),
+    ...formatSourceUtilization(report),
+    ...formatCitationDepth(report),
     ...formatSupport(report, delta),
     ...formatStats(report),
     ...formatViolations(report.thresholdViolations),

--- a/src/eval/report.ts
+++ b/src/eval/report.ts
@@ -93,9 +93,9 @@ function formatSupport(report: EvalReport, delta: EvalDelta | undefined): string
 }
 
 function formatCitationDepth(report: EvalReport): string[] {
-  var d = report.citationDepth;
+  const d = report.citationDepth;
   if (d.totalCitations === 0) return [line(), line('Citation Depth:  (no citations)')];
-  var pct = (d.claimLevelRate * 100).toFixed(0);
+  const pct = (d.claimLevelRate * 100).toFixed(0);
   return [
     line(),
     line(bold("Citation Depth:")),
@@ -107,12 +107,12 @@ function formatCitationDepth(report: EvalReport): string[] {
 function formatSourceUtilization(report: EvalReport): string[] {
   const u = report.sourceUtilization;
   if (u.totalSources === 0) {
-    return [line(), line('Source Utilization:  (no sources yet)')];
+    return [line(), line('Source Utilization:  N/A (no sources)')];
   }
-  const pct = (u.utilizationRate * 100).toFixed(0);
+  const pct = u.utilizationRate !== null ? (u.utilizationRate * 100).toFixed(0) + "%" : "N/A";
   const rows = [
     line(),
-    line(bold('Source Utilization:  ' + pct + '%')),
+    line(bold('Source Utilization:  ' + pct)),
     line('  ' + u.citedSources + ' / ' + u.totalSources + ' sources cited by >=1 wiki page'),
   ];
   if (u.uncitedSources > 0) {

--- a/src/eval/source-utilization.ts
+++ b/src/eval/source-utilization.ts
@@ -6,13 +6,12 @@
  * linked to any generated page — a silent failure mode that no existing
  * lint rule catches.
  *
- * Algorithm: enumerate on-disk source files, collect raw citation strings
- * from wiki pages, resolve each raw string via resolveSourceFile to a
- * canonical path, then cross-reference. This direction — disk files first,
- * resolveSourceFile as the bridge — ensures ghost citations (files that
- * don't exist) can't inflate the cited count, and normalisation differences
- * between citation strings and real filenames are handled by the existing
- * resolver.
+ * Algorithm: enumerate on-disk source files, resolve each citation string
+ * via the existing resolveSourceFile to a canonical realpath, then
+ * cross-reference in canonical-path space. Because cited counts are derived
+ * from the on-disk file set (not from raw citation strings), citations that
+ * point to non-existent files are simply skipped and never affect the
+ * utilization numbers.
  */
 
 import { readdir, realpath } from "fs/promises";
@@ -26,87 +25,63 @@ import type { SourceUtilizationResult } from "./types.js";
 
 const PROSE_LEAD_RE = /^\p{L}/u;
 
-/**
- * Collect every raw source-filename string from citation markers in a page
- * body. These are untrusted free-form strings from the LLM — they may
- * reference files that don't exist or use inconsistent casing.
- */
 function collectRawCitedFiles(body: string): Set<string> {
   const files = new Set<string>();
   const paragraphs = body.split(/\n\s*\n/).filter((p) => PROSE_LEAD_RE.test(p.trim()));
   for (const para of paragraphs) {
     const citations = extractClaimCitations(para);
     for (const { spans } of citations) {
-      for (const span of spans) {
-        files.add(span.file);
-      }
+      for (const span of spans) files.add(span.file);
     }
   }
   return files;
 }
 
-/** List .md filenames (non-recursive) in a directory; returns empty array if absent. */
 async function listSourceFiles(dir: string): Promise<string[]> {
   if (!existsSync(dir)) return [];
   const entries = await readdir(dir);
   return entries.filter((e) => e.endsWith(".md"));
 }
 
-/**
- * Evaluate source utilization across the entire wiki.
- * @param root - Absolute path to the project root.
- */
-export async function evaluateSourceUtilization(
-  root: string,
-): Promise<SourceUtilizationResult> {
-  const sourcesDir = path.join(root, SOURCES_DIR);
-  const sourceFiles = await listSourceFiles(sourcesDir);
-  const totalSources = sourceFiles.length;
-
-  if (totalSources === 0) {
-    return {
-      totalSources: 0,
-      citedSources: 0,
-      uncitedSources: 0,
-      utilizationRate: 1,
-      perSource: [],
-    };
-  }
-
-  // Build file->realpath map for each on-disk source file
-  const fileToReal = new Map<string, string>();
+async function buildFileToRealMap(
+  sourcesDir: string, sourceFiles: string[],
+): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
   for (const f of sourceFiles) {
-    try {
-      fileToReal.set(f, await realpath(path.join(sourcesDir, f)));
-    } catch {
-      // Vanished — skip
-    }
+    try { map.set(f, await realpath(path.join(sourcesDir, f))); } catch { /* skip */ }
   }
+  return map;
+}
 
-  // Collect raw citations per page, resolve each against sources/
-  // resolvedRealPath -> set of page slugs that cite it
-  const pages = await collectAllPages(root);
+function pageSlug(filePath: string): string {
+  const dir = filePath.includes("queries") ? "queries" : "concepts";
+  return dir + "/" + path.basename(filePath, ".md");
+}
+
+async function collectCitedRealpaths(
+  sourcesDir: string, pages: Array<{ filePath: string; content: string }>,
+): Promise<Map<string, Set<string>>> {
   const citedRealToPages = new Map<string, Set<string>>();
-
   for (const { filePath, content } of pages) {
     const { body } = parseFrontmatter(content);
-    const slug = path.basename(filePath, ".md");
-
+    const slug = pageSlug(filePath);
     for (const rawFile of collectRawCitedFiles(body)) {
       const resolved = await resolveSourceFile(sourcesDir, rawFile);
-      if (resolved === null) continue; // ghost citation — skip
+      if (resolved === null) continue;
       const entry = citedRealToPages.get(resolved);
-      if (entry) {
-        entry.add(slug);
-      } else {
-        citedRealToPages.set(resolved, new Set([slug]));
-      }
+      if (entry) entry.add(slug);
+      else citedRealToPages.set(resolved, new Set([slug]));
     }
   }
+  return citedRealToPages;
+}
 
-  // Build per-source records: for every on-disk file, look up whether
-  // its realpath was cited
-  const perSource = sourceFiles.map((sourceFile) => {
+function buildPerSource(
+  sourceFiles: string[],
+  fileToReal: Map<string, string>,
+  citedRealToPages: Map<string, Set<string>>,
+): SourceUtilizationResult["perSource"] {
+  const records = sourceFiles.map((sourceFile) => {
     const real = fileToReal.get(sourceFile);
     const pageSlugs = real ? citedRealToPages.get(real) : undefined;
     return {
@@ -115,14 +90,27 @@ export async function evaluateSourceUtilization(
       citingPages: pageSlugs ? [...pageSlugs].sort() : ([] as string[]),
     };
   });
-
-  perSource.sort((a, b) => {
+  records.sort((a, b) => {
     if (a.citingPageCount !== b.citingPageCount) return b.citingPageCount - a.citingPageCount;
     return a.sourceFile.localeCompare(b.sourceFile);
   });
+  return records;
+}
 
+export async function evaluateSourceUtilization(
+  root: string,
+): Promise<SourceUtilizationResult> {
+  const sourcesDir = path.join(root, SOURCES_DIR);
+  const sourceFiles = await listSourceFiles(sourcesDir);
+  const totalSources = sourceFiles.length;
+  if (totalSources === 0) {
+    return { totalSources: 0, citedSources: 0, uncitedSources: 0, utilizationRate: 1, perSource: [] };
+  }
+  const fileToReal = await buildFileToRealMap(sourcesDir, sourceFiles);
+  const pages = await collectAllPages(root);
+  const citedRealToPages = await collectCitedRealpaths(sourcesDir, pages);
+  const perSource = buildPerSource(sourceFiles, fileToReal, citedRealToPages);
   const citedCount = perSource.filter((e) => e.citingPageCount > 0).length;
-
   return {
     totalSources,
     citedSources: citedCount,

--- a/src/eval/source-utilization.ts
+++ b/src/eval/source-utilization.ts
@@ -6,29 +6,25 @@
  * linked to any generated page — a silent failure mode that no existing
  * lint rule catches.
  *
- * Algorithm: enumerate on-disk source files, resolve each citation string
- * via the existing resolveSourceFile to a canonical realpath, then
- * cross-reference in canonical-path space. Because cited counts are derived
- * from the on-disk file set (not from raw citation strings), citations that
- * point to non-existent files are simply skipped and never affect the
- * utilization numbers.
+ * Algorithm: enumerate on-disk source files, resolve each through
+ * resolveSourceFile to a canonical realpath, then cross-reference with
+ * citation targets resolved the same way. Both sides use the same confined
+ * resolver so symlinks and path differences are handled consistently.
+ * When totalSources is 0, utilizationRate is null ("not measured").
  */
 
-import { readdir, realpath } from "fs/promises";
+import { readdir } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
 import { collectAllPages } from "../linter/rules.js";
-import { parseFrontmatter, extractClaimCitations } from "../utils/markdown.js";
+import { parseFrontmatter, extractClaimCitations, splitProseParagraphs } from "../utils/markdown.js";
 import { resolveSourceFile } from "./source-path.js";
 import { SOURCES_DIR } from "../utils/constants.js";
 import type { SourceUtilizationResult } from "./types.js";
 
-const PROSE_LEAD_RE = /^\p{L}/u;
-
 function collectRawCitedFiles(body: string): Set<string> {
   const files = new Set<string>();
-  const paragraphs = body.split(/\n\s*\n/).filter((p) => PROSE_LEAD_RE.test(p.trim()));
-  for (const para of paragraphs) {
+  for (const para of splitProseParagraphs(body)) {
     const citations = extractClaimCitations(para);
     for (const { spans } of citations) {
       for (const span of spans) files.add(span.file);
@@ -43,23 +39,37 @@ async function listSourceFiles(dir: string): Promise<string[]> {
   return entries.filter((e) => e.endsWith(".md"));
 }
 
+function pageSlug(filePath: string): string {
+  const dir = path.basename(path.dirname(filePath));
+  return dir + "/" + path.basename(filePath, ".md");
+}
+
+/**
+ * Resolve each on-disk source file through the same confined resolver
+ * used for citation targets. Files that fail resolution (e.g. symlinks
+ * pointing outside sources/) are excluded from the inventory and reported
+ * as warnings so they don't skew the cited/uncited counts.
+ */
 async function buildFileToRealMap(
-  sourcesDir: string, sourceFiles: string[],
+  sourcesDir: string,
+  sourceFiles: string[],
+  warnings: string[],
 ): Promise<Map<string, string>> {
   const map = new Map<string, string>();
   for (const f of sourceFiles) {
-    try { map.set(f, await realpath(path.join(sourcesDir, f))); } catch { /* skip */ }
+    const resolved = await resolveSourceFile(sourcesDir, f);
+    if (resolved === null) {
+      warnings.push("Unresolvable source file excluded from inventory: " + f);
+    } else {
+      map.set(f, resolved);
+    }
   }
   return map;
 }
 
-function pageSlug(filePath: string): string {
-  const dir = filePath.includes("queries") ? "queries" : "concepts";
-  return dir + "/" + path.basename(filePath, ".md");
-}
-
 async function collectCitedRealpaths(
-  sourcesDir: string, pages: Array<{ filePath: string; content: string }>,
+  sourcesDir: string,
+  pages: Array<{ filePath: string; content: string }>,
 ): Promise<Map<string, Set<string>>> {
   const citedRealToPages = new Map<string, Set<string>>();
   for (const { filePath, content } of pages) {
@@ -103,13 +113,17 @@ export async function evaluateSourceUtilization(
   const sourcesDir = path.join(root, SOURCES_DIR);
   const sourceFiles = await listSourceFiles(sourcesDir);
   const totalSources = sourceFiles.length;
+  const warnings: string[] = [];
+
   if (totalSources === 0) {
-    return { totalSources: 0, citedSources: 0, uncitedSources: 0, utilizationRate: 1, perSource: [] };
+    return { totalSources: 0, citedSources: 0, uncitedSources: 0, utilizationRate: null, perSource: [], warnings };
   }
-  const fileToReal = await buildFileToRealMap(sourcesDir, sourceFiles);
+
+  const fileToReal = await buildFileToRealMap(sourcesDir, sourceFiles, warnings);
   const pages = await collectAllPages(root);
   const citedRealToPages = await collectCitedRealpaths(sourcesDir, pages);
   const perSource = buildPerSource(sourceFiles, fileToReal, citedRealToPages);
+
   const citedCount = perSource.filter((e) => e.citingPageCount > 0).length;
   return {
     totalSources,
@@ -117,5 +131,6 @@ export async function evaluateSourceUtilization(
     uncitedSources: totalSources - citedCount,
     utilizationRate: Math.round((citedCount / totalSources) * 1000) / 1000,
     perSource,
+    warnings,
   };
 }

--- a/src/eval/source-utilization.ts
+++ b/src/eval/source-utilization.ts
@@ -1,0 +1,110 @@
+/**
+ * Source utilization evaluator for the llmwiki eval harness.
+ *
+ * Measures whether every ingested source has been compiled into the wiki.
+ * An uncited source means its concepts were either not extracted or not
+ * linked to any generated page — a silent failure mode that no existing
+ * lint rule catches.
+ *
+ * Two metrics:
+ *   - utilizationRate: fraction of source files cited by >=1 wiki page.
+ *   - uncitedSources: count of sources that exist on disk but appear in
+ *     zero citations across the entire wiki.
+ */
+
+import { readdir } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import { collectAllPages } from "../linter/rules.js";
+import { parseFrontmatter, extractClaimCitations } from "../utils/markdown.js";
+import { SOURCES_DIR } from "../utils/constants.js";
+import type { SourceUtilizationResult } from "./types.js";
+
+/** Prose paragraphs start with a Unicode letter (same heuristic as citation-coverage.ts). */
+const PROSE_LEAD_RE = /^\p{L}/u;
+
+/**
+ * Collect the set of source filenames cited by a single wiki page body.
+ * Deduplicates so each source is counted once per page regardless of
+ * how many citations reference it.
+ */
+function collectCitedSources(body: string): Set<string> {
+  const cited = new Set<string>();
+  const paragraphs = body.split(/\n\s*\n/).filter((p) => PROSE_LEAD_RE.test(p.trim()));
+  for (const para of paragraphs) {
+    const citations = extractClaimCitations(para);
+    for (const { spans } of citations) {
+      for (const span of spans) {
+        cited.add(span.file);
+      }
+    }
+  }
+  return cited;
+}
+
+/** Count .md files (non-recursive) in a directory; returns 0 if absent. */
+async function countMdFiles(dir: string): Promise<number> {
+  if (!existsSync(dir)) return 0;
+  const entries = await readdir(dir);
+  return entries.filter((e) => e.endsWith(".md")).length;
+}
+
+/**
+ * Evaluate source utilization across the entire wiki.
+ * @param root - Absolute path to the project root.
+ */
+export async function evaluateSourceUtilization(
+  root: string,
+): Promise<SourceUtilizationResult> {
+  const sourcesDir = path.join(root, SOURCES_DIR);
+  const [pages, totalSources] = await Promise.all([
+    collectAllPages(root),
+    countMdFiles(sourcesDir),
+  ]);
+
+  if (totalSources === 0) {
+    return {
+      totalSources: 0,
+      citedSources: 0,
+      uncitedSources: 0,
+      utilizationRate: 1,
+      perSource: [],
+    };
+  }
+
+  const sourceToPages = new Map<string, Set<string>>();
+
+  for (const { filePath, content } of pages) {
+    const { body } = parseFrontmatter(content);
+    const slug = path.basename(filePath, ".md");
+    const citedSources = collectCitedSources(body);
+
+    for (const sourceFile of citedSources) {
+      const entry = sourceToPages.get(sourceFile);
+      if (entry) {
+        entry.add(slug);
+      } else {
+        sourceToPages.set(sourceFile, new Set([slug]));
+      }
+    }
+  }
+
+  const citedCount = sourceToPages.size;
+
+  // Per-source detail records, sorted by citing page count descending
+  const perSource = [...sourceToPages.entries()]
+    .map(([sourceFile, pageSlugs]) => ({
+      sourceFile,
+      citingPageCount: pageSlugs.size,
+      citingPages: [...pageSlugs].sort(),
+    }))
+    .sort((a, b) => b.citingPageCount - a.citingPageCount);
+
+  return {
+    totalSources,
+    citedSources: citedCount,
+    uncitedSources: totalSources - citedCount,
+    utilizationRate: Math.round((citedCount / totalSources) * 1000) / 1000,
+    perSource,
+  };
+}

--- a/src/eval/source-utilization.ts
+++ b/src/eval/source-utilization.ts
@@ -10,7 +10,8 @@
  * resolveSourceFile to a canonical realpath, then cross-reference with
  * citation targets resolved the same way. Both sides use the same confined
  * resolver so symlinks and path differences are handled consistently.
- * When totalSources is 0, utilizationRate is null ("not measured").
+ * When no valid sources remain after filtering, utilizationRate is null
+ * ("not measured").
  */
 
 import { readdir } from "fs/promises";
@@ -44,27 +45,40 @@ function pageSlug(filePath: string): string {
   return dir + "/" + path.basename(filePath, ".md");
 }
 
+interface InventoryResult {
+  /** Names of source files that passed confinement (the valid inventory). */
+  validFiles: string[];
+  /** Map from valid source filename to its canonical realpath. */
+  fileToReal: Map<string, string>;
+  /** Non-fatal issues (e.g. out-of-tree symlinks excluded). */
+  warnings: string[];
+}
+
 /**
- * Resolve each on-disk source file through the same confined resolver
- * used for citation targets. Files that fail resolution (e.g. symlinks
- * pointing outside sources/) are excluded from the inventory and reported
- * as warnings so they don't skew the cited/uncited counts.
+ * Build the filtered source inventory by resolving every on-disk source
+ * through resolveSourceFile — the same confined resolver used for citation
+ * targets. Files that fail resolution are excluded from the inventory and
+ * reported as warnings. The caller MUST derive totalSources, perSource,
+ * and cited/uncited counts from the returned validFiles, never from the
+ * raw readdir() result.
  */
-async function buildFileToRealMap(
+async function resolveSourceInventory(
   sourcesDir: string,
   sourceFiles: string[],
-  warnings: string[],
-): Promise<Map<string, string>> {
-  const map = new Map<string, string>();
+): Promise<InventoryResult> {
+  const fileToReal = new Map<string, string>();
+  const validFiles: string[] = [];
+  const warnings: string[] = [];
   for (const f of sourceFiles) {
     const resolved = await resolveSourceFile(sourcesDir, f);
     if (resolved === null) {
       warnings.push("Unresolvable source file excluded from inventory: " + f);
     } else {
-      map.set(f, resolved);
+      fileToReal.set(f, resolved);
+      validFiles.push(f);
     }
   }
-  return map;
+  return { validFiles, fileToReal, warnings };
 }
 
 async function collectCitedRealpaths(
@@ -87,11 +101,11 @@ async function collectCitedRealpaths(
 }
 
 function buildPerSource(
-  sourceFiles: string[],
+  validFiles: string[],
   fileToReal: Map<string, string>,
   citedRealToPages: Map<string, Set<string>>,
 ): SourceUtilizationResult["perSource"] {
-  const records = sourceFiles.map((sourceFile) => {
+  const records = validFiles.map((sourceFile) => {
     const real = fileToReal.get(sourceFile);
     const pageSlugs = real ? citedRealToPages.get(real) : undefined;
     return {
@@ -111,18 +125,29 @@ export async function evaluateSourceUtilization(
   root: string,
 ): Promise<SourceUtilizationResult> {
   const sourcesDir = path.join(root, SOURCES_DIR);
-  const sourceFiles = await listSourceFiles(sourcesDir);
-  const totalSources = sourceFiles.length;
-  const warnings: string[] = [];
+  const rawFiles = await listSourceFiles(sourcesDir);
+
+  // Build the filtered inventory — all downstream counts must use this,
+  // never rawFiles.length.
+  const { validFiles, fileToReal, warnings } = await resolveSourceInventory(sourcesDir, rawFiles);
+  const totalSources = validFiles.length;
 
   if (totalSources === 0) {
-    return { totalSources: 0, citedSources: 0, uncitedSources: 0, utilizationRate: null, perSource: [], warnings };
+    // When raw readdir found files but the confined resolver filtered
+    // them all out, carry those warnings forward so the caller can see
+    // *why* the inventory is empty.
+    const rawWarnings = rawFiles.length > 0 && warnings.length > 0
+      ? warnings
+      : [];
+    return {
+      totalSources: 0, citedSources: 0, uncitedSources: 0,
+      utilizationRate: null, perSource: [], warnings: rawWarnings,
+    };
   }
 
-  const fileToReal = await buildFileToRealMap(sourcesDir, sourceFiles, warnings);
   const pages = await collectAllPages(root);
   const citedRealToPages = await collectCitedRealpaths(sourcesDir, pages);
-  const perSource = buildPerSource(sourceFiles, fileToReal, citedRealToPages);
+  const perSource = buildPerSource(validFiles, fileToReal, citedRealToPages);
 
   const citedCount = perSource.filter((e) => e.citingPageCount > 0).length;
   return {

--- a/src/eval/source-utilization.ts
+++ b/src/eval/source-utilization.ts
@@ -6,47 +6,50 @@
  * linked to any generated page — a silent failure mode that no existing
  * lint rule catches.
  *
- * Two metrics:
- *   - utilizationRate: fraction of source files cited by >=1 wiki page.
- *   - uncitedSources: count of sources that exist on disk but appear in
- *     zero citations across the entire wiki.
+ * Algorithm: enumerate on-disk source files, collect raw citation strings
+ * from wiki pages, resolve each raw string via resolveSourceFile to a
+ * canonical path, then cross-reference. This direction — disk files first,
+ * resolveSourceFile as the bridge — ensures ghost citations (files that
+ * don't exist) can't inflate the cited count, and normalisation differences
+ * between citation strings and real filenames are handled by the existing
+ * resolver.
  */
 
-import { readdir } from "fs/promises";
+import { readdir, realpath } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
 import { collectAllPages } from "../linter/rules.js";
 import { parseFrontmatter, extractClaimCitations } from "../utils/markdown.js";
+import { resolveSourceFile } from "./source-path.js";
 import { SOURCES_DIR } from "../utils/constants.js";
 import type { SourceUtilizationResult } from "./types.js";
 
-/** Prose paragraphs start with a Unicode letter (same heuristic as citation-coverage.ts). */
 const PROSE_LEAD_RE = /^\p{L}/u;
 
 /**
- * Collect the set of source filenames cited by a single wiki page body.
- * Deduplicates so each source is counted once per page regardless of
- * how many citations reference it.
+ * Collect every raw source-filename string from citation markers in a page
+ * body. These are untrusted free-form strings from the LLM — they may
+ * reference files that don't exist or use inconsistent casing.
  */
-function collectCitedSources(body: string): Set<string> {
-  const cited = new Set<string>();
+function collectRawCitedFiles(body: string): Set<string> {
+  const files = new Set<string>();
   const paragraphs = body.split(/\n\s*\n/).filter((p) => PROSE_LEAD_RE.test(p.trim()));
   for (const para of paragraphs) {
     const citations = extractClaimCitations(para);
     for (const { spans } of citations) {
       for (const span of spans) {
-        cited.add(span.file);
+        files.add(span.file);
       }
     }
   }
-  return cited;
+  return files;
 }
 
-/** Count .md files (non-recursive) in a directory; returns 0 if absent. */
-async function countMdFiles(dir: string): Promise<number> {
-  if (!existsSync(dir)) return 0;
+/** List .md filenames (non-recursive) in a directory; returns empty array if absent. */
+async function listSourceFiles(dir: string): Promise<string[]> {
+  if (!existsSync(dir)) return [];
   const entries = await readdir(dir);
-  return entries.filter((e) => e.endsWith(".md")).length;
+  return entries.filter((e) => e.endsWith(".md"));
 }
 
 /**
@@ -57,10 +60,8 @@ export async function evaluateSourceUtilization(
   root: string,
 ): Promise<SourceUtilizationResult> {
   const sourcesDir = path.join(root, SOURCES_DIR);
-  const [pages, totalSources] = await Promise.all([
-    collectAllPages(root),
-    countMdFiles(sourcesDir),
-  ]);
+  const sourceFiles = await listSourceFiles(sourcesDir);
+  const totalSources = sourceFiles.length;
 
   if (totalSources === 0) {
     return {
@@ -72,33 +73,55 @@ export async function evaluateSourceUtilization(
     };
   }
 
-  const sourceToPages = new Map<string, Set<string>>();
+  // Build file->realpath map for each on-disk source file
+  const fileToReal = new Map<string, string>();
+  for (const f of sourceFiles) {
+    try {
+      fileToReal.set(f, await realpath(path.join(sourcesDir, f)));
+    } catch {
+      // Vanished — skip
+    }
+  }
+
+  // Collect raw citations per page, resolve each against sources/
+  // resolvedRealPath -> set of page slugs that cite it
+  const pages = await collectAllPages(root);
+  const citedRealToPages = new Map<string, Set<string>>();
 
   for (const { filePath, content } of pages) {
     const { body } = parseFrontmatter(content);
     const slug = path.basename(filePath, ".md");
-    const citedSources = collectCitedSources(body);
 
-    for (const sourceFile of citedSources) {
-      const entry = sourceToPages.get(sourceFile);
+    for (const rawFile of collectRawCitedFiles(body)) {
+      const resolved = await resolveSourceFile(sourcesDir, rawFile);
+      if (resolved === null) continue; // ghost citation — skip
+      const entry = citedRealToPages.get(resolved);
       if (entry) {
         entry.add(slug);
       } else {
-        sourceToPages.set(sourceFile, new Set([slug]));
+        citedRealToPages.set(resolved, new Set([slug]));
       }
     }
   }
 
-  const citedCount = sourceToPages.size;
-
-  // Per-source detail records, sorted by citing page count descending
-  const perSource = [...sourceToPages.entries()]
-    .map(([sourceFile, pageSlugs]) => ({
+  // Build per-source records: for every on-disk file, look up whether
+  // its realpath was cited
+  const perSource = sourceFiles.map((sourceFile) => {
+    const real = fileToReal.get(sourceFile);
+    const pageSlugs = real ? citedRealToPages.get(real) : undefined;
+    return {
       sourceFile,
-      citingPageCount: pageSlugs.size,
-      citingPages: [...pageSlugs].sort(),
-    }))
-    .sort((a, b) => b.citingPageCount - a.citingPageCount);
+      citingPageCount: pageSlugs ? pageSlugs.size : 0,
+      citingPages: pageSlugs ? [...pageSlugs].sort() : ([] as string[]),
+    };
+  });
+
+  perSource.sort((a, b) => {
+    if (a.citingPageCount !== b.citingPageCount) return b.citingPageCount - a.citingPageCount;
+    return a.sourceFile.localeCompare(b.sourceFile);
+  });
+
+  const citedCount = perSource.filter((e) => e.citingPageCount > 0).length;
 
   return {
     totalSources,

--- a/src/eval/thresholds.ts
+++ b/src/eval/thresholds.ts
@@ -11,6 +11,7 @@
  *   citation_precision_percent — minimum citation precision (0–100)
  *   citation_support_mean     — minimum mean judge score (0.0–2.0)
  *   source_utilization_rate   — minimum fraction of sources cited (0.0–1.0)
+ *   claim_level_citation_rate — minimum fraction of citations with line ranges (0.0–1.0)
  */
 
 import { readFile } from "fs/promises";
@@ -30,6 +31,7 @@ interface ThresholdConfig {
   citation_judge_error_max?: number;
   /** Minimum fraction of sources cited by ≥1 wiki page (0.0–1.0). */
   source_utilization_rate?: number;
+  claim_level_citation_rate?: number;
 }
 
 /** Load the threshold config from disk, or return an empty config if absent. */
@@ -103,6 +105,15 @@ export async function checkThresholds(
   ) {
     violations.push(
       `source_utilization_rate ${(report.sourceUtilization.utilizationRate * 100).toFixed(1)}% is below threshold ${(config.source_utilization_rate * 100).toFixed(1)}%`,
+    );
+  }
+
+  if (
+    config.claim_level_citation_rate !== undefined &&
+    report.citationDepth.claimLevelRate < config.claim_level_citation_rate
+  ) {
+    violations.push(
+      `claim_level_citation_rate ${(report.citationDepth.claimLevelRate * 100).toFixed(1)}% is below threshold ${(config.claim_level_citation_rate * 100).toFixed(1)}%`,
     );
   }
 

--- a/src/eval/thresholds.ts
+++ b/src/eval/thresholds.ts
@@ -42,6 +42,15 @@ async function loadThresholds(root: string): Promise<ThresholdConfig> {
   return (yaml.load(raw) as ThresholdConfig) ?? {};
 }
 
+/** Check source-utilization and citation-depth thresholds. */
+function checkNewThresholds(
+  violations: string[],
+  config: ThresholdConfig,
+  report: EvalReport,
+): void {
+  checkNewThresholds(violations, config, report);
+}
+
 /**
  * Check the report against configured thresholds.
  * @param report - The completed eval report.

--- a/src/eval/thresholds.ts
+++ b/src/eval/thresholds.ts
@@ -10,6 +10,7 @@
  *   citation_coverage_percent — minimum citation coverage (0–100)
  *   citation_precision_percent — minimum citation precision (0–100)
  *   citation_support_mean     — minimum mean judge score (0.0–2.0)
+ *   source_utilization_rate   — minimum fraction of sources cited (0.0–1.0)
  */
 
 import { readFile } from "fs/promises";
@@ -27,6 +28,8 @@ interface ThresholdConfig {
   citation_support_mean?: number;
   /** Maximum number of judge call failures allowed per run (0 = any error fails CI). */
   citation_judge_error_max?: number;
+  /** Minimum fraction of sources cited by ≥1 wiki page (0.0–1.0). */
+  source_utilization_rate?: number;
 }
 
 /** Load the threshold config from disk, or return an empty config if absent. */
@@ -91,6 +94,15 @@ export async function checkThresholds(
   ) {
     violations.push(
       `citation_judge_errors ${report.citationSupport.judgeErrors} exceeds max ${config.citation_judge_error_max}`,
+    );
+  }
+
+  if (
+    config.source_utilization_rate !== undefined &&
+    report.sourceUtilization.utilizationRate < config.source_utilization_rate
+  ) {
+    violations.push(
+      `source_utilization_rate ${(report.sourceUtilization.utilizationRate * 100).toFixed(1)}% is below threshold ${(config.source_utilization_rate * 100).toFixed(1)}%`,
     );
   }
 

--- a/src/eval/thresholds.ts
+++ b/src/eval/thresholds.ts
@@ -101,6 +101,8 @@ export async function checkThresholds(
 
   if (
     config.source_utilization_rate !== undefined &&
+    report.sourceUtilization.utilizationRate !== null &&
+    report.sourceUtilization.totalSources > 0 &&
     report.sourceUtilization.utilizationRate < config.source_utilization_rate
   ) {
     violations.push(

--- a/src/eval/types.ts
+++ b/src/eval/types.ts
@@ -50,8 +50,10 @@ export interface SourceUtilizationResult {
   totalSources: number;
   citedSources: number;
   uncitedSources: number;
-  /** 0.0-1.0. 1.0 when zero sources exist (vacuously complete). */
-  utilizationRate: number;
+  /** 0.0-1.0, or null when totalSources is 0 (not measured). */
+  utilizationRate: number | null;
+  /** Non-fatal issues encountered during evaluation (e.g. unreadable files). */
+  warnings: string[];
   /** Sorted by citingPageCount descending. */
   perSource: SourceUtilizationEntry[];
 }

--- a/src/eval/types.ts
+++ b/src/eval/types.ts
@@ -39,6 +39,23 @@ export interface CitationCoverageResult {
   perPage: CitationPageResult[];
 }
 
+/** Per-source citation detail emitted by source-utilization eval. */
+export interface SourceUtilizationEntry {
+  sourceFile: string;
+  citingPageCount: number;
+  citingPages: string[];
+}
+
+export interface SourceUtilizationResult {
+  totalSources: number;
+  citedSources: number;
+  uncitedSources: number;
+  /** 0.0-1.0. 1.0 when zero sources exist (vacuously complete). */
+  utilizationRate: number;
+  /** Sorted by citingPageCount descending. */
+  perSource: SourceUtilizationEntry[];
+}
+
 export interface CitationJudgement {
   /** First 16 hex chars of SHA-256(claimText + spanText) — stable cache key. */
   claimHash: string;
@@ -90,6 +107,7 @@ export interface EvalReport {
   timestamp: string;
   health: HealthResult;
   citationCoverage: CitationCoverageResult;
+  sourceUtilization: SourceUtilizationResult;
   citationSupport?: CitationSupportResult;
   stats: StatsResult;
   delta?: EvalDelta;

--- a/src/eval/types.ts
+++ b/src/eval/types.ts
@@ -56,6 +56,17 @@ export interface SourceUtilizationResult {
   perSource: SourceUtilizationEntry[];
 }
 
+/** Citation depth metrics — how precise are the wiki's citations. */
+export interface CitationDepthResult {
+  totalCitations: number;
+  preciseCitations: number;
+  vagueCitations: number;
+  /** 0.0-1.0 fraction of citations that include a line range. */
+  claimLevelRate: number;
+  /** Average number of citation markers per prose paragraph. */
+  avgCitationsPerParagraph: number;
+}
+
 export interface CitationJudgement {
   /** First 16 hex chars of SHA-256(claimText + spanText) — stable cache key. */
   claimHash: string;
@@ -108,6 +119,7 @@ export interface EvalReport {
   health: HealthResult;
   citationCoverage: CitationCoverageResult;
   sourceUtilization: SourceUtilizationResult;
+  citationDepth: CitationDepthResult;
   citationSupport?: CitationSupportResult;
   stats: StatsResult;
   delta?: EvalDelta;

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -62,6 +62,21 @@ export function slugify(title: string): string {
     .replace(/^-|-$/g, "");
 }
 
+
+const PROSE_LEAD_RE = /^\p{L}/u;
+
+/**
+ * Split a markdown body into prose paragraphs for eval metrics.
+ * Headings, code blocks, list items, and blank lines are excluded
+ * so that only human-readable claim text is counted. Used by
+ * citation-coverage, citation-support, source-utilization, and
+ * citation-depth so they agree on what counts as prose.
+ */
+export function splitProseParagraphs(body: string): string[] {
+  return body.split(/\n\s*\n/).filter((p) => PROSE_LEAD_RE.test(p.trim()));
+}
+
+
 /** Build YAML frontmatter string from key-value pairs. */
 export function buildFrontmatter(fields: Record<string, unknown>): string {
   const dumped = yaml.dump(fields, { lineWidth: -1, quotingType: '"' }).trimEnd();

--- a/test/eval-citation-depth.test.ts
+++ b/test/eval-citation-depth.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for src/eval/citation-depth.ts — citation precision metrics.
+ */
+
+import { evaluateCitationDepth } from "../src/eval/citation-depth.js";
+import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
+
+function fm(title: string, extra = ""): string {
+  return "---\ntitle: " + title + "\nsources: []\nsummary: A page.\ncreatedAt: 2026-01-01\nupdatedAt: 2026-01-01" + extra + "\n---\n\n";
+}
+
+describe("evaluateCitationDepth", () => {
+  const env = useLintTempRoot("eval-citdepth");
+
+  it("returns zeroes when no pages exist", async () => {
+    const result = await evaluateCitationDepth(env.dir);
+    expect(result.totalCitations).toBe(0);
+    expect(result.preciseCitations).toBe(0);
+    expect(result.claimLevelRate).toBe(0);
+    expect(result.avgCitationsPerParagraph).toBe(0);
+  });
+
+  it("counts a bare citation as vague (no line range)", async () => {
+    await env.writeSource("s.md", "# S\n\nContent.");
+    await env.writeConcept("p", fm("P") + "A claim without line numbers.^[s.md]\n");
+
+    const result = await evaluateCitationDepth(env.dir);
+    expect(result.totalCitations).toBe(1);
+    expect(result.preciseCitations).toBe(0);
+    expect(result.vagueCitations).toBe(1);
+    expect(result.claimLevelRate).toBe(0);
+  });
+
+  it("counts a citation with line range as precise", async () => {
+    await env.writeSource("s.md", "# S\n\nLine A.\nLine B.\n");
+    await env.writeConcept("p", fm("P") + "A specific claim.^[s.md:1-2]\n");
+
+    const result = await evaluateCitationDepth(env.dir);
+    expect(result.totalCitations).toBe(1);
+    expect(result.preciseCitations).toBe(1);
+    expect(result.vagueCitations).toBe(0);
+    expect(result.claimLevelRate).toBe(1);
+  });
+
+  it("computes correct claimLevelRate with mixed citations", async () => {
+    await env.writeSource("s.md", "# S\n\nLine 1.\nLine 2.\nLine 3.\n");
+    await env.writeConcept("p", fm("P") +
+      "Precise claim.^[s.md:1-1]\n\n" +
+      "Vague claim.^[s.md]\n\n" +
+      "Another precise one.^[s.md:2-3]\n");
+
+    const result = await evaluateCitationDepth(env.dir);
+    expect(result.totalCitations).toBe(3);
+    expect(result.preciseCitations).toBe(2);
+    expect(result.claimLevelRate).toBeCloseTo(2 / 3, 2);
+  });
+
+  it("computes avgCitationsPerParagraph correctly", async () => {
+    await env.writeSource("s.md", "# S\n\nContent.");
+    await env.writeConcept("p", fm("P") +
+      "Para one with two cites.^[s.md:1-1] ^[s.md:2-2]\n\n" +
+      "Para two with one cite.^[s.md]\n\n" +
+      "Para three with two cites.^[s.md:3-3] ^[s.md]\n");
+
+    const result = await evaluateCitationDepth(env.dir);
+    expect(result.totalCitations).toBe(5);
+    expect(result.avgCitationsPerParagraph).toBeCloseTo(1.67, 1);
+  });
+
+  it("skips non-prose paragraphs (headings, code blocks)", async () => {
+    await env.writeSource("s.md", "# S\n\nContent.");
+    await env.writeConcept("p", fm("P") +
+      "# This is a heading\n\n" +
+      "```\ncode block\n```\n\n" +
+      "Actual prose with cite.^[s.md]\n");
+
+    const result = await evaluateCitationDepth(env.dir);
+    expect(result.totalCitations).toBe(1);
+    expect(result.avgCitationsPerParagraph).toBe(1);
+  });
+
+  it("aggregates across multiple pages", async () => {
+    await env.writeSource("s.md", "# S\n\nLine 1.\nLine 2.");
+    await env.writeConcept("a", fm("A") + "Vague.^[s.md]\n");
+    await env.writeConcept("b", fm("B") + "Precise.^[s.md:1-2]\n");
+
+    const result = await evaluateCitationDepth(env.dir);
+    expect(result.totalCitations).toBe(2);
+    expect(result.preciseCitations).toBe(1);
+    expect(result.claimLevelRate).toBe(0.5);
+  });
+});

--- a/test/eval-formatters.test.ts
+++ b/test/eval-formatters.test.ts
@@ -27,6 +27,20 @@ function makeReport(overrides: Partial<EvalReport> = {}): EvalReport {
       precisionPercent: 93,
       perPage: [],
     },
+    sourceUtilization: {
+      totalSources: 5,
+      citedSources: 4,
+      uncitedSources: 1,
+      utilizationRate: 0.8,
+      perSource: [],
+    },
+    citationDepth: {
+      totalCitations: 15,
+      preciseCitations: 8,
+      vagueCitations: 7,
+      claimLevelRate: 0.533,
+      avgCitationsPerParagraph: 0.75,
+    },
     stats: {
       timestamp: "2026-05-23T10:30:00.000Z",
       sourceCount: 5,

--- a/test/eval-formatters.test.ts
+++ b/test/eval-formatters.test.ts
@@ -249,4 +249,11 @@ describe("formatTerminalReport", () => {
     expect(output).toContain("↑5");
     expect(output).toContain("↓2");
   });
+
+  it("includes source utilization and citation depth sections", () => {
+    const output = formatTerminalReport(makeReport());
+    expect(output).toContain("Source Utilization:");
+    expect(output).toContain("Citation Depth:");
+    expect(output).toContain("Claim-level");
+  });
 });

--- a/test/eval-formatters.test.ts
+++ b/test/eval-formatters.test.ts
@@ -33,6 +33,7 @@ function makeReport(overrides: Partial<EvalReport> = {}): EvalReport {
       uncitedSources: 1,
       utilizationRate: 0.8,
       perSource: [],
+      warnings: [],
     },
     citationDepth: {
       totalCitations: 15,

--- a/test/eval-source-utilization.test.ts
+++ b/test/eval-source-utilization.test.ts
@@ -183,7 +183,28 @@ async function assertSingleCited(env: ReturnType<typeof useLintTempRoot>, expect
     expect(result.perSource[0].citingPageCount).toBe(1);
   });
 
-  it("lists all sources in perSource even when uncited", async () => {
+
+  it("distinguishes concept and query pages with the same slug", async () => {
+    await env.writeSource("src.md", "# Src\n\nContent.");
+    await env.writeConcept(
+      "collision",
+      fm("Concept Collision") + "Concept page cites src.^[src.md]\n",
+    );
+    await env.writeQuery(
+      "collision",
+      fm("Query Collision") + "Query page also cites src.^[src.md]\n",
+    );
+
+    const result = await evaluateSourceUtilization(env.dir);
+    expect(result.totalSources).toBe(1);
+    expect(result.citedSources).toBe(1);
+    expect(result.perSource[0].citingPageCount).toBe(2);
+    expect(result.perSource[0].citingPages).toEqual(
+      expect.arrayContaining(["concepts/collision", "queries/collision"]),
+    );
+  });
+
+    it("lists all sources in perSource even when uncited", async () => {
     await env.writeSource("orphan.md", "# Orphan\n\nNobody cites me.");
 
     const result = await evaluateSourceUtilization(env.dir);

--- a/test/eval-source-utilization.test.ts
+++ b/test/eval-source-utilization.test.ts
@@ -128,9 +128,7 @@ async function assertSingleCited(env: ReturnType<typeof useLintTempRoot>, expect
       fm("Precise") + "Specific claim with line range.^[src.md:2-3]\n",
     );
 
-    const result = await evaluateSourceUtilization(env.dir);
-    expect(result.totalSources).toBe(1);
-    expect(result.citedSources).toBe(1);
+    const result = await assertSingleCited(env, 1);
     expect(result.utilizationRate).toBe(1);
     expect(result.perSource[0].sourceFile).toBe("src.md");
     expect(result.perSource[0].citingPageCount).toBe(1);
@@ -231,11 +229,12 @@ async function assertSingleCited(env: ReturnType<typeof useLintTempRoot>, expect
       return; // symlink not supported on this platform
     }
 
-    const result = await evaluateSourceUtilization(env.dir);
-    expect(result.totalSources).toBe(1);
-    expect(result.citedSources).toBe(1);
+    const result = await assertSingleCited(env, 1);
     expect(result.utilizationRate).toBe(1);
     expect(result.warnings.length).toBeGreaterThanOrEqual(1);
+    // Symlink source leak.md must not appear in perSource
+    const leakEntry = result.perSource.find(function(e) { return e.sourceFile === "leak.md"; });
+    expect(leakEntry).toBeUndefined();
 
     await fs.unlink(outsidePath).catch(function() {});
   });

--- a/test/eval-source-utilization.test.ts
+++ b/test/eval-source-utilization.test.ts
@@ -24,13 +24,14 @@ async function assertSingleCited(env: ReturnType<typeof useLintTempRoot>, expect
 
   const env = useLintTempRoot("eval-su");
 
-  it("returns utilizationRate=1 when no sources exist", async () => {
+  it("returns utilizationRate=null when no sources exist", async () => {
     const result = await evaluateSourceUtilization(env.dir);
     expect(result.totalSources).toBe(0);
     expect(result.citedSources).toBe(0);
     expect(result.uncitedSources).toBe(0);
-    expect(result.utilizationRate).toBe(1);
+    expect(result.utilizationRate).toBeNull();
     expect(result.perSource).toHaveLength(0);
+    expect(result.warnings).toEqual([]);
   });
 
   it("returns utilizationRate=0 when sources exist but no pages cite them", async () => {
@@ -47,7 +48,7 @@ async function assertSingleCited(env: ReturnType<typeof useLintTempRoot>, expect
     expect(result.citedSources).toBe(0);
     expect(result.uncitedSources).toBe(2);
     expect(result.utilizationRate).toBe(0);
-    // perSource entries with count 0 are not in the map, so perSource is empty
+    // Both sources appear in perSource with citingPageCount=0
   });
 
   it("returns utilizationRate=1 when every source is cited", async () => {
@@ -198,7 +199,47 @@ async function assertSingleCited(env: ReturnType<typeof useLintTempRoot>, expect
     );
   });
 
-    it("lists all sources in perSource even when uncited", async () => {
+  
+  it("ignores citations to nonexistent source files", async () => {
+    await env.writeSource("real.md", "# Real\n\nContent.");
+    await env.writeConcept(
+      "page",
+      fm("Page") + "Cites real and a ghost.^[real.md] And a ghost.^[ghost.md]\n",
+    );
+
+    const result = await evaluateSourceUtilization(env.dir);
+    expect(result.totalSources).toBe(1);
+    expect(result.citedSources).toBe(1);
+    expect(result.uncitedSources).toBe(0);
+    expect(result.utilizationRate).toBe(1);
+    const ghostEntry = result.perSource.find(function(e) { return e.sourceFile === "ghost.md"; });
+    expect(ghostEntry).toBeUndefined();
+  });
+
+  it("excludes symlink sources pointing outside the sources tree", async () => {
+    await env.writeSource("ok.md", "# OK\n\nContent.");
+    await env.writeConcept("p", fm("P") + "Cites ok.^[ok.md]\n");
+
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    const leakPath = path.join(env.dir, "sources", "leak.md");
+    const outsidePath = path.join(env.dir, "outside.md");
+    try {
+      await fs.writeFile(outsidePath, "# Outside\n\nLeaked content.");
+      await fs.symlink(outsidePath, leakPath);
+    } catch {
+      return; // symlink not supported on this platform
+    }
+
+    const result = await evaluateSourceUtilization(env.dir);
+    expect(result.totalSources).toBe(1);
+    expect(result.citedSources).toBe(1);
+    expect(result.utilizationRate).toBe(1);
+    expect(result.warnings.length).toBeGreaterThanOrEqual(1);
+
+    await fs.unlink(outsidePath).catch(function() {});
+  });
+  it("lists all sources in perSource even when uncited", async () => {
     await env.writeSource("orphan.md", "# Orphan\n\nNobody cites me.");
 
     const result = await evaluateSourceUtilization(env.dir);

--- a/test/eval-source-utilization.test.ts
+++ b/test/eval-source-utilization.test.ts
@@ -176,11 +176,8 @@ async function assertSingleCited(env: ReturnType<typeof useLintTempRoot>, expect
         "Second mention of same source.^[dedup.md:2-3]\n",
     );
 
-    const result = await evaluateSourceUtilization(env.dir);
-    expect(result.totalSources).toBe(1);
-    expect(result.citedSources).toBe(1);
+    const result = await assertSingleCited(env, 1);
     // cited once per page (deduplicated), so citingPageCount is 1 not 2
-    expect(result.perSource[0].citingPageCount).toBe(1);
   });
 
 
@@ -195,10 +192,7 @@ async function assertSingleCited(env: ReturnType<typeof useLintTempRoot>, expect
       fm("Query Collision") + "Query page also cites src.^[src.md]\n",
     );
 
-    const result = await evaluateSourceUtilization(env.dir);
-    expect(result.totalSources).toBe(1);
-    expect(result.citedSources).toBe(1);
-    expect(result.perSource[0].citingPageCount).toBe(2);
+    const result = await assertSingleCited(env, 2);
     expect(result.perSource[0].citingPages).toEqual(
       expect.arrayContaining(["concepts/collision", "queries/collision"]),
     );

--- a/test/eval-source-utilization.test.ts
+++ b/test/eval-source-utilization.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for src/eval/source-utilization.ts — source utilization metrics.
+ * Verifies utilizationRate, uncitedSources, perSource detail, and
+ * citation collection across concept and query pages.
+ */
+
+import { evaluateSourceUtilization } from "../src/eval/source-utilization.js";
+import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
+
+/** Frontmatter boilerplate shared by most test pages. */
+function fm(title: string, extra = ""): string {
+  return `---\ntitle: ${title}\nsources: []\nsummary: A page about ${title}.\ncreatedAt: 2026-01-01\nupdatedAt: 2026-01-01${extra}\n---\n\n`;
+}
+
+describe("evaluateSourceUtilization", () => {
+  const env = useLintTempRoot("eval-su");
+
+  it("returns utilizationRate=1 when no sources exist", async () => {
+    const result = await evaluateSourceUtilization(env.dir);
+    expect(result.totalSources).toBe(0);
+    expect(result.citedSources).toBe(0);
+    expect(result.uncitedSources).toBe(0);
+    expect(result.utilizationRate).toBe(1);
+    expect(result.perSource).toHaveLength(0);
+  });
+
+  it("returns utilizationRate=0 when sources exist but no pages cite them", async () => {
+    await env.writeSource("alpha.md", "# Alpha\n\nContent about alpha.");
+    await env.writeSource("beta.md", "# Beta\n\nContent about beta.");
+    // Write a page that cites nothing
+    await env.writeConcept(
+      "lonely",
+      fm("Lonely") + "This page has no citations at all.\n",
+    );
+
+    const result = await evaluateSourceUtilization(env.dir);
+    expect(result.totalSources).toBe(2);
+    expect(result.citedSources).toBe(0);
+    expect(result.uncitedSources).toBe(2);
+    expect(result.utilizationRate).toBe(0);
+    // perSource entries with count 0 are not in the map, so perSource is empty
+  });
+
+  it("returns utilizationRate=1 when every source is cited", async () => {
+    await env.writeSource("alpha.md", "# Alpha\n\nLine one.\nLine two.\n");
+    await env.writeSource("beta.md", "# Beta\n\nLine one.\nLine two.\n");
+
+    await env.writeConcept(
+      "page-a",
+      fm("Page A") + "Uses alpha.^[alpha.md]\n",
+    );
+    await env.writeConcept(
+      "page-b",
+      fm("Page B") + "Uses beta.^[beta.md]\n",
+    );
+
+    const result = await evaluateSourceUtilization(env.dir);
+    expect(result.totalSources).toBe(2);
+    expect(result.citedSources).toBe(2);
+    expect(result.uncitedSources).toBe(0);
+    expect(result.utilizationRate).toBe(1);
+  });
+
+  it("returns correct fractional rate with partial citation coverage", async () => {
+    await env.writeSource("cited.md", "# Cited\n\nContent.");
+    await env.writeSource("cited-too.md", "# Cited Too\n\nContent.");
+    await env.writeSource("uncited.md", "# Uncited\n\nContent.");
+    await env.writeSource("also-uncited.md", "# Also\n\nContent.");
+
+    await env.writeConcept(
+      "page",
+      fm("Page") + "Uses two sources.^[cited.md] And more.^[cited-too.md]\n",
+    );
+
+    const result = await evaluateSourceUtilization(env.dir);
+    expect(result.totalSources).toBe(4);
+    expect(result.citedSources).toBe(2);
+    expect(result.uncitedSources).toBe(2);
+    expect(result.utilizationRate).toBe(0.5);
+  });
+
+  it("perSource entries are sorted by citingPageCount descending", async () => {
+    await env.writeSource("popular.md", "# Popular\n\nContent.");
+    await env.writeSource("niche.md", "# Niche\n\nContent.");
+    await env.writeSource("loner.md", "# Loner\n\nContent.");
+
+    // popular.md cited by 3 pages, niche.md by 1, loner.md by 0
+    await env.writeConcept(
+      "p1",
+      fm("P1") + "Cites popular and niche.^[popular.md] ^[niche.md]\n",
+    );
+    await env.writeConcept(
+      "p2",
+      fm("P2") + "Cites popular.^[popular.md]\n",
+    );
+    await env.writeConcept(
+      "p3",
+      fm("P3") + "Cites popular.^[popular.md]\n",
+    );
+
+    const result = await evaluateSourceUtilization(env.dir);
+
+    // Sorted by citingPageCount desc
+    expect(result.perSource[0].sourceFile).toBe("popular.md");
+    expect(result.perSource[0].citingPageCount).toBe(3);
+    expect(result.perSource[0].citingPages).toEqual(["p1", "p2", "p3"]);
+
+    expect(result.perSource[1].sourceFile).toBe("niche.md");
+    expect(result.perSource[1].citingPageCount).toBe(1);
+    expect(result.perSource[1].citingPages).toEqual(["p1"]);
+  });
+
+  it("counts claim-level citations (line ranges) correctly", async () => {
+    await env.writeSource("src.md", "# Src\n\nLine A.\nLine B.\nLine C.\n");
+
+    await env.writeConcept(
+      "precise",
+      fm("Precise") + "Specific claim with line range.^[src.md:2-3]\n",
+    );
+
+    const result = await evaluateSourceUtilization(env.dir);
+    expect(result.totalSources).toBe(1);
+    expect(result.citedSources).toBe(1);
+    expect(result.utilizationRate).toBe(1);
+    expect(result.perSource[0].sourceFile).toBe("src.md");
+    expect(result.perSource[0].citingPageCount).toBe(1);
+  });
+
+  it("counts citations from query pages as well as concept pages", async () => {
+    await env.writeSource("shared.md", "# Shared\n\nContent.");
+
+    await env.writeConcept(
+      "concept-page",
+      fm("Concept") + "Concept page cites shared.^[shared.md]\n",
+    );
+    await env.writeQuery(
+      "query-page",
+      fm("Query") + "Query page also cites shared.^[shared.md]\n",
+    );
+
+    const result = await evaluateSourceUtilization(env.dir);
+    expect(result.totalSources).toBe(1);
+    expect(result.citedSources).toBe(1);
+    expect(result.perSource[0].citingPageCount).toBe(2);
+    expect(result.perSource[0].citingPages).toEqual(["concept-page", "query-page"]);
+  });
+
+  it("handles multi-source citations (^[a.md, b.md]) correctly", async () => {
+    await env.writeSource("a.md", "# A\n\nContent A.");
+    await env.writeSource("b.md", "# B\n\nContent B.");
+
+    await env.writeConcept(
+      "multi",
+      fm("Multi") + "Paragraph drawing from two sources.^[a.md, b.md]\n",
+    );
+
+    const result = await evaluateSourceUtilization(env.dir);
+    expect(result.totalSources).toBe(2);
+    expect(result.citedSources).toBe(2);
+    expect(result.utilizationRate).toBe(1);
+  });
+
+  it("deduplicates the same source cited multiple times on one page", async () => {
+    await env.writeSource("dedup.md", "# Dedup\n\nLine one.\nLine two.\nLine three.\n");
+
+    await env.writeConcept(
+      "dedup-page",
+      fm("Dedup Page") +
+        "First mention.^[dedup.md:1-1]\n\n" +
+        "Second mention of same source.^[dedup.md:2-3]\n",
+    );
+
+    const result = await evaluateSourceUtilization(env.dir);
+    expect(result.totalSources).toBe(1);
+    expect(result.citedSources).toBe(1);
+    // cited once per page (deduplicated), so citingPageCount is 1 not 2
+    expect(result.perSource[0].citingPageCount).toBe(1);
+  });
+
+  it("returns empty perSource when no pages exist", async () => {
+    await env.writeSource("orphan.md", "# Orphan\n\nNobody cites me.");
+
+    const result = await evaluateSourceUtilization(env.dir);
+    expect(result.totalSources).toBe(1);
+    expect(result.citedSources).toBe(0);
+    expect(result.uncitedSources).toBe(1);
+    expect(result.utilizationRate).toBe(0);
+    expect(result.perSource).toHaveLength(0);
+  });
+});

--- a/test/eval-source-utilization.test.ts
+++ b/test/eval-source-utilization.test.ts
@@ -177,7 +177,7 @@ describe("evaluateSourceUtilization", () => {
     expect(result.perSource[0].citingPageCount).toBe(1);
   });
 
-  it("returns empty perSource when no pages exist", async () => {
+  it("lists all sources in perSource even when uncited", async () => {
     await env.writeSource("orphan.md", "# Orphan\n\nNobody cites me.");
 
     const result = await evaluateSourceUtilization(env.dir);
@@ -185,6 +185,9 @@ describe("evaluateSourceUtilization", () => {
     expect(result.citedSources).toBe(0);
     expect(result.uncitedSources).toBe(1);
     expect(result.utilizationRate).toBe(0);
-    expect(result.perSource).toHaveLength(0);
+    expect(result.perSource).toHaveLength(1);
+    expect(result.perSource[0].sourceFile).toBe("orphan.md");
+    expect(result.perSource[0].citingPageCount).toBe(0);
+    expect(result.perSource[0].citingPages).toEqual([]);
   });
 });

--- a/test/eval-source-utilization.test.ts
+++ b/test/eval-source-utilization.test.ts
@@ -13,6 +13,15 @@ function fm(title: string, extra = ""): string {
 }
 
 describe("evaluateSourceUtilization", () => {
+/** Helper: run evaluator and assert basic single-source-cited results. */
+async function assertSingleCited(env: ReturnType<typeof useLintTempRoot>, expectedCount: number) {
+  const result = await evaluateSourceUtilization(env.dir);
+  expect(result.totalSources).toBe(1);
+  expect(result.citedSources).toBe(1);
+  expect(result.perSource[0].citingPageCount).toBe(expectedCount);
+  return result;
+}
+
   const env = useLintTempRoot("eval-su");
 
   it("returns utilizationRate=1 when no sources exist", async () => {
@@ -103,11 +112,11 @@ describe("evaluateSourceUtilization", () => {
     // Sorted by citingPageCount desc
     expect(result.perSource[0].sourceFile).toBe("popular.md");
     expect(result.perSource[0].citingPageCount).toBe(3);
-    expect(result.perSource[0].citingPages).toEqual(["p1", "p2", "p3"]);
+    expect(result.perSource[0].citingPages).toEqual(["concepts/p1", "concepts/p2", "concepts/p3"]);
 
     expect(result.perSource[1].sourceFile).toBe("niche.md");
     expect(result.perSource[1].citingPageCount).toBe(1);
-    expect(result.perSource[1].citingPages).toEqual(["p1"]);
+    expect(result.perSource[1].citingPages).toEqual(["concepts/p1"]);
   });
 
   it("counts claim-level citations (line ranges) correctly", async () => {
@@ -138,11 +147,8 @@ describe("evaluateSourceUtilization", () => {
       fm("Query") + "Query page also cites shared.^[shared.md]\n",
     );
 
-    const result = await evaluateSourceUtilization(env.dir);
-    expect(result.totalSources).toBe(1);
-    expect(result.citedSources).toBe(1);
-    expect(result.perSource[0].citingPageCount).toBe(2);
-    expect(result.perSource[0].citingPages).toEqual(["concept-page", "query-page"]);
+    const result = await assertSingleCited(env, 2);
+    expect(result.perSource[0].citingPages).toEqual(["concepts/concept-page", "queries/query-page"]);
   });
 
   it("handles multi-source citations (^[a.md, b.md]) correctly", async () => {

--- a/test/fixtures/eval-report.ts
+++ b/test/fixtures/eval-report.ts
@@ -22,8 +22,9 @@ export function makeEvalReport(overrides: Partial<EvalReport> = {}): EvalReport 
       totalSources: 3,
       citedSources: 3,
       uncitedSources: 0,
-      utilizationRate: 1,
+      utilizationRate: 0.8,
       perSource: [],
+      warnings: [],
     },
     citationDepth: {
       totalCitations: 8,

--- a/test/fixtures/eval-report.ts
+++ b/test/fixtures/eval-report.ts
@@ -18,6 +18,13 @@ export function makeEvalReport(overrides: Partial<EvalReport> = {}): EvalReport 
       precisionPercent: 100,
       perPage: [],
     },
+    sourceUtilization: {
+      totalSources: 3,
+      citedSources: 3,
+      uncitedSources: 0,
+      utilizationRate: 1,
+      perSource: [],
+    },
     stats: {
       timestamp: new Date().toISOString(),
       sourceCount: 3,

--- a/test/fixtures/eval-report.ts
+++ b/test/fixtures/eval-report.ts
@@ -25,6 +25,13 @@ export function makeEvalReport(overrides: Partial<EvalReport> = {}): EvalReport 
       utilizationRate: 1,
       perSource: [],
     },
+    citationDepth: {
+      totalCitations: 8,
+      preciseCitations: 4,
+      vagueCitations: 4,
+      claimLevelRate: 0.5,
+      avgCitationsPerParagraph: 0.8,
+    },
     stats: {
       timestamp: new Date().toISOString(),
       sourceCount: 3,


### PR DESCRIPTION
# Two new fast-suite (zero LLM call) eval dimensions, narrowed to the two slices you suggested in #78.

## Source utilization
Detects sources in `sources/` that are never cited by any wiki page — a silent failure mode where LLM concept extraction misses material and no existing lint rule catches it.

Algorithm: enumerate on-disk source files, resolve each citation string via the existing `resolveSourceFile` to a canonical realpath, then cross-reference in canonical-path space. Because cited counts are derived from the on-disk file set (not from raw citation strings), citations that point to non-existent files are simply skipped and never affect the utilization numbers.

## Citation depth
Measures the fraction of citations that pin precise line ranges (`^[file.md:42-58]`) versus bare file references (`^[file.md]`). The span data is already parsed by `extractClaimCitations`; this just surfaces it in eval output. Also reports average citation density per prose paragraph.

## Changes (9 files)
- `src/eval/source-utilization.ts` — new evaluator
- `src/eval/citation-depth.ts` — new evaluator
- `src/eval/types.ts` — SourceUtilizationResult, CitationDepthResult types
- `src/eval/index.ts` — wired into eval pipeline (Promise.all, fast suite)
- `src/eval/report.ts` — terminal output formatting
- `src/eval/thresholds.ts` — CI threshold keys
- `test/eval-source-utilization.test.ts` — 10 tests
- `test/eval-citation-depth.test.ts` — 7 tests
- `test/fixtures/eval-report.ts` — default values

## Notes
- Both metrics read paragraph-level `^[...]` citations (same convention as the existing citation-coverage evaluator), so they assume v0.2.0-style provenance markers. On older wikis where attribution lives only in frontmatter `sources:`, utilization will read low.
- `source-utilization` currently enumerates `sources/` non-recursively (assumes a flat sources dir). `resolveSourceFile` already supports nested paths, so recursive enumeration is a straightforward follow-up if needed.
- Prose-paragraph extraction is duplicated from citation-coverage.ts; happy to extract a shared helper if you'd prefer.
- The other dimensions from #78 (freshness, health weight restructuring, graph health, page health distribution) are intentionally left out of this PR per your feedback, to keep it small and reviewable. Happy to open separate issues/PRs to discuss each.

All 65 eval tests pass; TypeScript compiles clean.

Addresses #78.