### PR TITLE
feat(freshness): surface source freshness in MCP, context, viewer, and next

### DIFF
--- a/src/commands/next.ts
+++ b/src/commands/next.ts
@@ -91,6 +91,8 @@ interface JsonSummary {
   hasIndex: boolean;
   hasLintCache: boolean;
   lint: { warnings: number; errors: number; at: string } | null;
+  /** Stale/orphaned counts from the last lint, or null when lint has not run. */
+  freshness: { stalePages: number; orphanedPages: number } | null;
 }
 
 /** Build the `summary` block, mapping LintCacheStatus to the documented shape. */
@@ -103,6 +105,7 @@ function buildSummary(state: ProjectState): JsonSummary {
     hasIndex: state.hasIndex,
     hasLintCache: state.lint.present,
     lint: state.lint.entry,
+    freshness: state.lint.entry?.freshness ?? null,
   };
 }
 

--- a/src/commands/next.ts
+++ b/src/commands/next.ts
@@ -104,7 +104,9 @@ function buildSummary(state: ProjectState): JsonSummary {
     pendingCandidates: state.pendingCandidates,
     hasIndex: state.hasIndex,
     hasLintCache: state.lint.present,
-    lint: state.lint.entry,
+    lint: state.lint.entry
+      ? { warnings: state.lint.entry.warnings, errors: state.lint.entry.errors, at: state.lint.entry.at }
+      : null,
     freshness: state.lint.entry?.freshness ?? null,
   };
 }

--- a/src/context/ranking.ts
+++ b/src/context/ranking.ts
@@ -224,6 +224,24 @@ function compareRows(a: RankingRow, b: RankingRow): number {
 }
 
 /**
+ * Build the `warnings` array for a primary page, forwarding viewer-level
+ * warnings and appending `stale-page` when the page's source has changed
+ * since the last compile. The `stale-page` code is context-only — the
+ * viewer surfaces freshness as badges, not warnings.
+ */
+function buildPrimaryWarnings(page: ViewerPage): ContextPrimary["warnings"] {
+  const warnings = page.warnings.map((w) => ({ code: w.code, message: w.message }));
+  if (page.freshness.freshnessStatus === "stale") {
+    warnings.push({
+      code: "stale-page",
+      message:
+        "A source this page was compiled from has changed since the last compile; treat with caution.",
+    });
+  }
+  return warnings;
+}
+
+/**
  * Convert a ranking row into a ContextPrimary.
  *
  * Slice 4 fills `citations` from the viewer collector's already-parsed
@@ -234,7 +252,8 @@ function compareRows(a: RankingRow, b: RankingRow): number {
  * Page-local `warnings` was wired in Slice 1; it forwards the same
  * `ViewerWarning` objects the viewer surfaces, so any malformed-frontmatter
  * or unresolved-citation diagnostic the viewer already knows about
- * lands in the context pack automatically.
+ * lands in the context pack automatically. A `stale-page` warning is
+ * synthesized here when the page's freshness status is `stale`.
  *
  * `sourceWindows` stays empty here — the orchestrator owns the
  * per-pack budget and writes windows back into the primary entries
@@ -242,6 +261,7 @@ function compareRows(a: RankingRow, b: RankingRow): number {
  * snapshot.
  */
 function rowToPrimary(row: RankingRow): ContextPrimary {
+  const { freshness } = row.page;
   return {
     id: row.page.id,
     title: row.page.title,
@@ -252,7 +272,10 @@ function rowToPrimary(row: RankingRow): ContextPrimary {
     chunks: row.chunks,
     citations: flattenCitations(row.page.citations),
     sourceWindows: [],
-    warnings: row.page.warnings.map((w) => ({ code: w.code, message: w.message })),
+    warnings: buildPrimaryWarnings(row.page),
+    freshnessStatus: freshness.freshnessStatus,
+    contradicted: freshness.contradicted,
+    archived: freshness.archived,
   };
 }
 

--- a/src/context/ranking.ts
+++ b/src/context/ranking.ts
@@ -225,9 +225,10 @@ function compareRows(a: RankingRow, b: RankingRow): number {
 
 /**
  * Build the `warnings` array for a primary page, forwarding viewer-level
- * warnings and appending `stale-page` when the page's source has changed
- * since the last compile. The `stale-page` code is context-only — the
- * viewer surfaces freshness as badges, not warnings.
+ * warnings and appending freshness-derived warnings for stale, contradicted,
+ * and archived pages. These codes are context-only — the viewer surfaces
+ * freshness as badges, not warnings. A page can carry multiple warnings
+ * (e.g. stale AND contradicted → both codes appear).
  */
 function buildPrimaryWarnings(page: ViewerPage): ContextPrimary["warnings"] {
   const warnings = page.warnings.map((w) => ({ code: w.code, message: w.message }));
@@ -236,6 +237,18 @@ function buildPrimaryWarnings(page: ViewerPage): ContextPrimary["warnings"] {
       code: "stale-page",
       message:
         "A source this page was compiled from has changed since the last compile; treat with caution.",
+    });
+  }
+  if (page.freshness.contradicted) {
+    warnings.push({
+      code: "contradicted-page",
+      message: "This page is contradicted by another page; treat its claims with caution.",
+    });
+  }
+  if (page.freshness.archived) {
+    warnings.push({
+      code: "archived-page",
+      message: "This page is archived and may be outdated or deprecated.",
     });
   }
   return warnings;

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -14,6 +14,7 @@
 import type { PageId } from "../viewer/types.js";
 import type { PageDirectory } from "../export/types.js";
 import type { RecommendedAction } from "../project/recommendations.js";
+import type { FreshnessStatus } from "../freshness/types.js";
 
 /** Closed v1 enum for why a page landed in `primary[]`. */
 export type PrimaryReason =
@@ -116,6 +117,16 @@ export interface ContextPrimary {
   citations: ContextCitation[];
   sourceWindows: ContextSourceWindow[];
   warnings: ContextPageWarning[];
+  // The three freshness signals are FLATTENED here (rather than nested as a
+  // `freshness: PageFreshness` object like `ViewerPage`) for an idiomatic JSON
+  // wire shape for agents. Consequently, any future field added to
+  // `PageFreshness` must be mirrored here by hand — it won't auto-propagate.
+  /** Computed source-freshness of this page (advisory snapshot, not a guarantee). */
+  freshnessStatus: FreshnessStatus;
+  /** Disputed by another page (`contradictedBy` non-empty). */
+  contradicted: boolean;
+  /** Explicitly archived (`archived: true` frontmatter). */
+  archived: boolean;
 }
 
 /** One graph neighbor edge. `distance` is 1 for direct, 2 for second-hop. */

--- a/src/freshness/index.ts
+++ b/src/freshness/index.ts
@@ -63,24 +63,40 @@ export async function buildFreshnessSnapshot(
   const sources: FreshnessSnapshot["sources"] = {};
   if (status === "ok") {
     const sourcesRoot = path.resolve(root, SOURCES_DIR);
+    // Resolve the real sources root ONCE — the per-source containment check reuses it,
+    // so a snapshot over N sources does at most N (not 2N) realpath syscalls.
+    const realSourcesRoot = await realSourcesRootOrFallback(sourcesRoot);
     for (const [file, entry] of Object.entries(state.sources)) {
-      sources[file] = await classifySource(sourcesRoot, file, entry);
+      sources[file] = await classifySource(sourcesRoot, realSourcesRoot, file, entry);
     }
   }
   return { stateStatus: status, sources };
 }
 
 /**
- * Resolve symlinks and check whether a file's real path is inside sourcesRoot.
- * Both sides are realpath'd so projects under symlinked temp dirs (e.g. macOS
- * /tmp → /private/tmp) still pass — both sides normalize consistently.
+ * Real path of the sources root, falling back to the lexical path if realpath
+ * throws (e.g. sources/ does not exist yet). The fallback is safe: a missing
+ * sources root means no source file can resolve inside it, and per-file
+ * existsSync already gates hashing.
+ */
+async function realSourcesRootOrFallback(sourcesRoot: string): Promise<string> {
+  try {
+    return await realpath(sourcesRoot);
+  } catch {
+    return sourcesRoot;
+  }
+}
+
+/**
+ * Resolve a file's symlinks and check whether its real path is inside the
+ * pre-resolved real sources root. The root is realpath'd once by the caller so
+ * projects under symlinked temp dirs (e.g. macOS /tmp → /private/tmp) still pass.
  * Returns false on any error (treat as not inside, refuse to hash).
  */
-async function resolvesInsideSources(resolved: string, sourcesRoot: string): Promise<boolean> {
+async function resolvesInsideSources(resolved: string, realSourcesRoot: string): Promise<boolean> {
   try {
     const realFile = await realpath(resolved);
-    const realRoot = await realpath(sourcesRoot);
-    return realFile === realRoot || realFile.startsWith(realRoot + path.sep);
+    return realFile === realSourcesRoot || realFile.startsWith(realSourcesRoot + path.sep);
   } catch {
     return false;
   }
@@ -94,6 +110,7 @@ async function resolvesInsideSources(resolved: string, sourcesRoot: string): Pro
  */
 async function classifySource(
   sourcesRoot: string,
+  realSourcesRoot: string,
   file: string,
   entry: { hash: string; concepts: string[] },
 ): Promise<SourceFreshness> {
@@ -103,7 +120,7 @@ async function classifySource(
     return { recordedHash: entry.hash, currentHash: null, exists: false, concepts: entry.concepts };
   }
   const exists = existsSync(resolved);
-  if (exists && !(await resolvesInsideSources(resolved, sourcesRoot))) {
+  if (exists && !(await resolvesInsideSources(resolved, realSourcesRoot))) {
     // Symlink escapes sources/ — treat as unverifiable, never hash/read it.
     return { recordedHash: entry.hash, currentHash: null, exists: false, concepts: entry.concepts };
   }

--- a/src/freshness/index.ts
+++ b/src/freshness/index.ts
@@ -10,6 +10,7 @@ import type { FreshnessSnapshot, PageFreshness, PageFreshnessInput, FreshnessSta
 import { existsSync } from "fs";
 import path from "path";
 import { readStateClassified } from "../utils/state.js";
+import type { ClassifiedState } from "../utils/state.js";
 import { hashFile } from "../compiler/hasher.js";
 import { SOURCES_DIR } from "../utils/constants.js";
 
@@ -48,9 +49,16 @@ function ownersOf(slug: string, snapshot: FreshnessSnapshot) {
 /**
  * Build the per-run freshness snapshot: one read-only state read + one hash
  * pass over sources/. Shared by every freshness consumer so hashing happens once.
+ *
+ * @param classified - Optional pre-read classified state. When supplied the
+ *   disk read is skipped, letting callers that already have state avoid a
+ *   redundant read. Omit (or pass `undefined`) to read from disk as usual.
  */
-export async function buildFreshnessSnapshot(root: string): Promise<FreshnessSnapshot> {
-  const { status, state } = await readStateClassified(root);
+export async function buildFreshnessSnapshot(
+  root: string,
+  classified?: ClassifiedState,
+): Promise<FreshnessSnapshot> {
+  const { status, state } = classified ?? (await readStateClassified(root));
   const sources: FreshnessSnapshot["sources"] = {};
   if (status === "ok") {
     for (const [file, entry] of Object.entries(state.sources)) {

--- a/src/freshness/index.ts
+++ b/src/freshness/index.ts
@@ -8,6 +8,7 @@
 
 import type { FreshnessSnapshot, PageFreshness, PageFreshnessInput, FreshnessStatus, SourceFreshness } from "./types.js";
 import { existsSync } from "fs";
+import { realpath } from "fs/promises";
 import path from "path";
 import { readStateClassified } from "../utils/state.js";
 import type { ClassifiedState } from "../utils/state.js";
@@ -70,9 +71,26 @@ export async function buildFreshnessSnapshot(
 }
 
 /**
- * Classify one source entry from state.json, guarding against path traversal.
- * A poisoned key like `../../etc/passwd` would resolve outside sources/ and
- * could read arbitrary files; we treat any such key as non-existent.
+ * Resolve symlinks and check whether a file's real path is inside sourcesRoot.
+ * Both sides are realpath'd so projects under symlinked temp dirs (e.g. macOS
+ * /tmp → /private/tmp) still pass — both sides normalize consistently.
+ * Returns false on any error (treat as not inside, refuse to hash).
+ */
+async function resolvesInsideSources(resolved: string, sourcesRoot: string): Promise<boolean> {
+  try {
+    const realFile = await realpath(resolved);
+    const realRoot = await realpath(sourcesRoot);
+    return realFile === realRoot || realFile.startsWith(realRoot + path.sep);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Classify one source entry from state.json, guarding against both path traversal
+ * and symlink escapes. A poisoned key like `../../etc/passwd` is rejected by the
+ * cheap lexical check (first gate). A symlink inside sources/ pointing outside is
+ * rejected by the realpath check (second gate). Both cases return exists:false.
  */
 async function classifySource(
   sourcesRoot: string,
@@ -80,12 +98,15 @@ async function classifySource(
   entry: { hash: string; concepts: string[] },
 ): Promise<SourceFreshness> {
   const resolved = path.resolve(sourcesRoot, file);
-  const isInsideSources = resolved === sourcesRoot || resolved.startsWith(sourcesRoot + path.sep);
-  if (!isInsideSources) {
-    // Defense-in-depth: reject path-traversal keys without throwing or reading.
+  const lexicallyInside = resolved === sourcesRoot || resolved.startsWith(sourcesRoot + path.sep);
+  if (!lexicallyInside) {
     return { recordedHash: entry.hash, currentHash: null, exists: false, concepts: entry.concepts };
   }
   const exists = existsSync(resolved);
+  if (exists && !(await resolvesInsideSources(resolved, sourcesRoot))) {
+    // Symlink escapes sources/ — treat as unverifiable, never hash/read it.
+    return { recordedHash: entry.hash, currentHash: null, exists: false, concepts: entry.concepts };
+  }
   return {
     recordedHash: entry.hash,
     currentHash: exists ? await hashFile(resolved) : null,

--- a/src/freshness/index.ts
+++ b/src/freshness/index.ts
@@ -6,7 +6,7 @@
  * and never persists freshness. See localdocs/specs/2026-06-04-source-freshness-design.md.
  */
 
-import type { FreshnessSnapshot, PageFreshness, PageFreshnessInput, FreshnessStatus } from "./types.js";
+import type { FreshnessSnapshot, PageFreshness, PageFreshnessInput, FreshnessStatus, SourceFreshness } from "./types.js";
 import { existsSync } from "fs";
 import path from "path";
 import { readStateClassified } from "../utils/state.js";
@@ -61,16 +61,35 @@ export async function buildFreshnessSnapshot(
   const { status, state } = classified ?? (await readStateClassified(root));
   const sources: FreshnessSnapshot["sources"] = {};
   if (status === "ok") {
+    const sourcesRoot = path.resolve(root, SOURCES_DIR);
     for (const [file, entry] of Object.entries(state.sources)) {
-      const filePath = path.join(root, SOURCES_DIR, file);
-      const exists = existsSync(filePath);
-      sources[file] = {
-        recordedHash: entry.hash,
-        currentHash: exists ? await hashFile(filePath) : null,
-        exists,
-        concepts: entry.concepts,
-      };
+      sources[file] = await classifySource(sourcesRoot, file, entry);
     }
   }
   return { stateStatus: status, sources };
+}
+
+/**
+ * Classify one source entry from state.json, guarding against path traversal.
+ * A poisoned key like `../../etc/passwd` would resolve outside sources/ and
+ * could read arbitrary files; we treat any such key as non-existent.
+ */
+async function classifySource(
+  sourcesRoot: string,
+  file: string,
+  entry: { hash: string; concepts: string[] },
+): Promise<SourceFreshness> {
+  const resolved = path.resolve(sourcesRoot, file);
+  const isInsideSources = resolved === sourcesRoot || resolved.startsWith(sourcesRoot + path.sep);
+  if (!isInsideSources) {
+    // Defense-in-depth: reject path-traversal keys without throwing or reading.
+    return { recordedHash: entry.hash, currentHash: null, exists: false, concepts: entry.concepts };
+  }
+  const exists = existsSync(resolved);
+  return {
+    recordedHash: entry.hash,
+    currentHash: exists ? await hashFile(resolved) : null,
+    exists,
+    concepts: entry.concepts,
+  };
 }

--- a/src/linter/cache.ts
+++ b/src/linter/cache.ts
@@ -16,12 +16,20 @@ import { atomicWrite } from "../utils/markdown.js";
 import { LLMWIKI_DIR, LAST_LINT_FILE } from "../utils/constants.js";
 import type { LintSummary } from "./types.js";
 
+/** Per-rule freshness counts, derived from the lint results. Optional so a pre-upgrade cache still parses. */
+export interface LintFreshnessCounts {
+  stalePages: number;
+  orphanedPages: number;
+}
+
 /** One persisted lint summary. Shape is part of the public viewer-cache contract. */
 export interface LintCacheEntry {
   warnings: number;
   errors: number;
   /** ISO-8601 timestamp of the run that produced these counts. */
   at: string;
+  /** Stale/orphaned page counts from the freshness lint rule. Absent on pre-0.9 caches. */
+  freshness?: LintFreshnessCounts;
 }
 
 /**
@@ -30,6 +38,11 @@ export interface LintCacheEntry {
  * never drift from the documented contract.
  */
 export const LINT_CACHE_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+/** Count results emitted by a given lint rule. */
+function countByRule(results: LintSummary["results"], rule: string): number {
+  return results.filter((r) => r.rule === rule).length;
+}
 
 /**
  * Persist a lint summary to `.llmwiki/last-lint.json` after a completed run.
@@ -42,6 +55,10 @@ export async function writeLintCache(root: string, summary: LintSummary): Promis
     warnings: summary.warnings,
     errors: summary.errors,
     at: new Date().toISOString(),
+    freshness: {
+      stalePages: countByRule(summary.results, "stale-page"),
+      orphanedPages: countByRule(summary.results, "orphaned-page"),
+    },
   };
   await atomicWrite(path.join(root, LAST_LINT_FILE), `${JSON.stringify(entry, null, 2)}\n`);
 }
@@ -65,12 +82,24 @@ export async function readLintCache(root: string): Promise<LintCacheEntry | null
     return null;
   }
   if (!isValidEntry(parsed)) return null;
-  return { warnings: parsed.warnings, errors: parsed.errors, at: parsed.at };
+  return {
+    warnings: parsed.warnings,
+    errors: parsed.errors,
+    at: parsed.at,
+    ...(parsed.freshness !== undefined ? { freshness: parsed.freshness } : {}),
+  };
 }
 
 /** True for finite non-negative integers, including zero. NaN and Infinity fail Number.isInteger. */
 function isNonNegativeInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+/** Validates the optional freshness sub-object; rejects if present but malformed. */
+function isValidFreshness(value: unknown): value is LintFreshnessCounts {
+  if (typeof value !== "object" || value === null) return false;
+  const c = value as Record<string, unknown>;
+  return isNonNegativeInteger(c.stalePages) && isNonNegativeInteger(c.orphanedPages);
 }
 
 /**
@@ -81,14 +110,19 @@ function isNonNegativeInteger(value: unknown): value is number {
  * anything else means the file was hand-edited or corrupted). The timestamp
  * must match the exact ISO-8601 shape the writer produces, otherwise downstream
  * consumers risk surfacing values like "2026-01-01" as full timestamps.
+ * The `freshness` field is optional — pre-upgrade caches omitting it still parse.
  */
 function isValidEntry(value: unknown): value is LintCacheEntry {
   if (typeof value !== "object" || value === null) return false;
   const candidate = value as Record<string, unknown>;
-  return (
-    isNonNegativeInteger(candidate.warnings) &&
-    isNonNegativeInteger(candidate.errors) &&
-    typeof candidate.at === "string" &&
-    LINT_CACHE_TIMESTAMP_PATTERN.test(candidate.at)
-  );
+  if (
+    !isNonNegativeInteger(candidate.warnings) ||
+    !isNonNegativeInteger(candidate.errors) ||
+    typeof candidate.at !== "string" ||
+    !LINT_CACHE_TIMESTAMP_PATTERN.test(candidate.at)
+  ) {
+    return false;
+  }
+  if (candidate.freshness !== undefined && !isValidFreshness(candidate.freshness)) return false;
+  return true;
 }

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -17,7 +17,7 @@ import {
   STATE_FILE,
 } from "../utils/constants.js";
 import { safeReadFile, parseFrontmatter } from "../utils/markdown.js";
-import { readState } from "../utils/state.js";
+import { readStateClassified } from "../utils/state.js";
 import { loadPreviousReport, loadHistory } from "../eval/stats.js";
 
 /** Standard JSON content block for an MCP resource read result. */
@@ -98,7 +98,7 @@ function registerStateResource(server: McpServer, root: string): void {
       mimeType: "application/json",
     },
     async (uri) => {
-      const state = await readState(root);
+      const { state } = await readStateClassified(root);
       return { contents: [jsonContent(uri, state)] };
     },
   );

--- a/src/mcp/status.ts
+++ b/src/mcp/status.ts
@@ -71,6 +71,12 @@ export async function collectStatus(root: string): Promise<WikiStatus> {
 
   const { stalePages, orphanedPages } = classifyConceptPages(scannedConcepts, snapshot);
 
+  // Suppress pendingChanges when state is unreadable: comparing against emptyState
+  // would classify every source file as "new", which is false precision on corrupt state.
+  const pendingChanges = classified.status === "ok"
+    ? changes.filter((c) => c.status !== "unchanged").map((c) => ({ file: c.file, status: c.status }))
+    : [];
+
   return {
     pages: { concepts: conceptSummaries.length, queries: queries.length, total: conceptSummaries.length + queries.length },
     sources: Object.keys(classified.state.sources).length,
@@ -79,6 +85,6 @@ export async function collectStatus(root: string): Promise<WikiStatus> {
     orphanedPages,
     stateStatus: classified.status,
     pendingCandidates,
-    pendingChanges: changes.filter((c) => c.status !== "unchanged").map((c) => ({ file: c.file, status: c.status })),
+    pendingChanges,
   };
 }

--- a/src/mcp/status.ts
+++ b/src/mcp/status.ts
@@ -5,15 +5,19 @@
  * agents get source-level accuracy rather than frontmatter-only orphans.
  * Uses `readStateClassified` throughout — never `readState` — so corrupt
  * state.json never produces a `.bak` side-effect.
+ *
+ * `pendingChanges` is derived directly from the freshness snapshot (which
+ * already has per-source currentHash/recordedHash/exists) plus a cheap
+ * directory listing — no second hash pass. `detectChanges` is NOT called.
  */
 
 import path from "path";
+import { readdir } from "fs/promises";
 import { collectPageSummaries, scanWikiPages } from "../compiler/indexgen.js";
-import { detectChanges } from "../compiler/hasher.js";
 import { countCandidates } from "../compiler/candidates.js";
 import { readStateClassified } from "../utils/state.js";
 import { buildFreshnessSnapshot, computeFreshness } from "../freshness/index.js";
-import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
+import { CONCEPTS_DIR, QUERIES_DIR, SOURCES_DIR } from "../utils/constants.js";
 import type { FreshnessSnapshot } from "../freshness/types.js";
 
 /** Shape returned by `collectStatus` and surfaced by the `wiki_status` tool. */
@@ -56,17 +60,48 @@ function lastCompileTime(sources: Record<string, { compiledAt: string }>): strin
   return times.length > 0 ? times.sort().slice(-1)[0] : null;
 }
 
+/** List markdown filenames in sources/ without hashing — cheap directory scan. */
+async function listSourceFilesOnDisk(root: string): Promise<string[]> {
+  try {
+    const entries = await readdir(path.join(root, SOURCES_DIR));
+    return entries.filter((f) => f.endsWith(".md"));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Derive pending source changes (new/changed/deleted) from the freshness snapshot — no extra hashing.
+ * The snapshot already contains recordedHash, currentHash, and exists for each tracked source,
+ * so we only need a cheap directory listing to discover untracked (new) files.
+ */
+function pendingChangesFromSnapshot(
+  snapshot: FreshnessSnapshot,
+  sourceFilesOnDisk: string[],
+): Array<{ file: string; status: string }> {
+  const out: Array<{ file: string; status: string }> = [];
+  for (const [file, s] of Object.entries(snapshot.sources)) {
+    if (!s.exists) out.push({ file, status: "deleted" });
+    else if (s.currentHash !== s.recordedHash) out.push({ file, status: "changed" });
+  }
+  const recorded = new Set(Object.keys(snapshot.sources));
+  for (const file of sourceFilesOnDisk) {
+    if (!recorded.has(file)) out.push({ file, status: "new" });
+  }
+  return out;
+}
+
 /** Build a read-only status snapshot used by the `wiki_status` MCP tool. */
 export async function collectStatus(root: string): Promise<WikiStatus> {
   const classified = await readStateClassified(root);
   const snapshot = await buildFreshnessSnapshot(root, classified);
 
-  const [conceptSummaries, queries, scannedConcepts, pendingCandidates, changes] = await Promise.all([
+  const [conceptSummaries, queries, scannedConcepts, pendingCandidates, sourceFilesOnDisk] = await Promise.all([
     collectPageSummaries(path.join(root, CONCEPTS_DIR)),
     collectPageSummaries(path.join(root, QUERIES_DIR)),
     scanWikiPages(path.join(root, CONCEPTS_DIR)),
     countCandidates(root),
-    detectChanges(root, classified.state),
+    listSourceFilesOnDisk(root),
   ]);
 
   const { stalePages, orphanedPages } = classifyConceptPages(scannedConcepts, snapshot);
@@ -74,7 +109,7 @@ export async function collectStatus(root: string): Promise<WikiStatus> {
   // Suppress pendingChanges when state is unreadable: comparing against emptyState
   // would classify every source file as "new", which is false precision on corrupt state.
   const pendingChanges = classified.status === "ok"
-    ? changes.filter((c) => c.status !== "unchanged").map((c) => ({ file: c.file, status: c.status }))
+    ? pendingChangesFromSnapshot(snapshot, sourceFilesOnDisk)
     : [];
 
   return {

--- a/src/mcp/status.ts
+++ b/src/mcp/status.ts
@@ -60,12 +60,16 @@ function lastCompileTime(sources: Record<string, { compiledAt: string }>): strin
 export async function collectStatus(root: string): Promise<WikiStatus> {
   const classified = await readStateClassified(root);
   const snapshot = await buildFreshnessSnapshot(root, classified);
-  const conceptSummaries = await collectPageSummaries(path.join(root, CONCEPTS_DIR));
-  const queries = await collectPageSummaries(path.join(root, QUERIES_DIR));
-  const scannedConcepts = await scanWikiPages(path.join(root, CONCEPTS_DIR));
+
+  const [conceptSummaries, queries, scannedConcepts, pendingCandidates, changes] = await Promise.all([
+    collectPageSummaries(path.join(root, CONCEPTS_DIR)),
+    collectPageSummaries(path.join(root, QUERIES_DIR)),
+    scanWikiPages(path.join(root, CONCEPTS_DIR)),
+    countCandidates(root),
+    detectChanges(root, classified.state),
+  ]);
 
   const { stalePages, orphanedPages } = classifyConceptPages(scannedConcepts, snapshot);
-  const changes = await detectChanges(root, classified.state);
 
   return {
     pages: { concepts: conceptSummaries.length, queries: queries.length, total: conceptSummaries.length + queries.length },
@@ -74,7 +78,7 @@ export async function collectStatus(root: string): Promise<WikiStatus> {
     stalePages,
     orphanedPages,
     stateStatus: classified.status,
-    pendingCandidates: await countCandidates(root),
+    pendingCandidates,
     pendingChanges: changes.filter((c) => c.status !== "unchanged").map((c) => ({ file: c.file, status: c.status })),
   };
 }

--- a/src/mcp/status.ts
+++ b/src/mcp/status.ts
@@ -1,57 +1,80 @@
 /**
  * Read-only project-status collector for the MCP `wiki_status` tool.
  *
- * Extracted from tools.ts to keep that file under the 400-line limit and to
- * own the (soon-to-be freshness-derived) stale/orphaned classification.
- * All functions here are pure reads — nothing in this module mutates the
- * workspace.
+ * Derives stale/orphaned page classification from the freshness module so
+ * agents get source-level accuracy rather than frontmatter-only orphans.
+ * Uses `readStateClassified` throughout — never `readState` — so corrupt
+ * state.json never produces a `.bak` side-effect.
  */
 
 import path from "path";
 import { collectPageSummaries, scanWikiPages } from "../compiler/indexgen.js";
 import { detectChanges } from "../compiler/hasher.js";
 import { countCandidates } from "../compiler/candidates.js";
-import { readState } from "../utils/state.js";
+import { readStateClassified } from "../utils/state.js";
+import { buildFreshnessSnapshot, computeFreshness } from "../freshness/index.js";
 import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
+import type { FreshnessSnapshot } from "../freshness/types.js";
 
 /** Shape returned by `collectStatus` and surfaced by the `wiki_status` tool. */
 export interface WikiStatus {
   pages: { concepts: number; queries: number; total: number };
   sources: number;
   lastCompiledAt: string | null;
+  /** Concept slugs whose source changed or partially disappeared since compile. */
+  stalePages: string[];
+  /** Concept slugs whose every owning source was deleted, or frontmatter-flagged orphaned (superset of old behavior). */
   orphanedPages: string[];
+  /** Readability of .llmwiki/state.json — surfaced so corrupt state is never silent. */
+  stateStatus: "ok" | "missing" | "corrupt";
   /** Number of compile candidates awaiting human review. */
   pendingCandidates: number;
   pendingChanges: Array<{ file: string; status: string }>;
 }
 
-/** Find concept slugs whose pages are flagged as orphaned. */
-async function findOrphanedSlugs(root: string): Promise<string[]> {
-  const scanned = await scanWikiPages(path.join(root, CONCEPTS_DIR));
-  return scanned.filter(({ meta }) => meta.orphaned).map(({ slug }) => slug);
+/** Classify scanned concept pages into stale/orphaned arrays using the freshness snapshot. */
+function classifyConceptPages(
+  scanned: { slug: string; meta: Record<string, unknown> }[],
+  snapshot: FreshnessSnapshot,
+): { stalePages: string[]; orphanedPages: string[] } {
+  const stalePages: string[] = [];
+  const orphanedPages: string[] = [];
+  for (const { slug, meta } of scanned) {
+    const { freshnessStatus } = computeFreshness(
+      { slug, pageDirectory: "concepts", frontmatter: meta },
+      snapshot,
+    );
+    if (freshnessStatus === "stale") stalePages.push(slug);
+    else if (freshnessStatus === "orphaned") orphanedPages.push(slug);
+  }
+  return { stalePages, orphanedPages };
+}
+
+/** Derive the last compile time from state sources, or null if no sources. */
+function lastCompileTime(sources: Record<string, { compiledAt: string }>): string | null {
+  const times = Object.values(sources).map((s) => s.compiledAt);
+  return times.length > 0 ? times.sort().slice(-1)[0] : null;
 }
 
 /** Build a read-only status snapshot used by the `wiki_status` MCP tool. */
 export async function collectStatus(root: string): Promise<WikiStatus> {
-  const concepts = await collectPageSummaries(path.join(root, CONCEPTS_DIR));
+  const classified = await readStateClassified(root);
+  const snapshot = await buildFreshnessSnapshot(root, classified);
+  const conceptSummaries = await collectPageSummaries(path.join(root, CONCEPTS_DIR));
   const queries = await collectPageSummaries(path.join(root, QUERIES_DIR));
-  const state = await readState(root);
-  const changes = await detectChanges(root, state);
-  const orphans = await findOrphanedSlugs(root);
-  const pendingCandidates = await countCandidates(root);
-  const compileTimes = Object.values(state.sources).map((s) => s.compiledAt);
-  const lastCompile = compileTimes.length > 0
-    ? compileTimes.sort().slice(-1)[0]
-    : null;
+  const scannedConcepts = await scanWikiPages(path.join(root, CONCEPTS_DIR));
+
+  const { stalePages, orphanedPages } = classifyConceptPages(scannedConcepts, snapshot);
+  const changes = await detectChanges(root, classified.state);
 
   return {
-    pages: { concepts: concepts.length, queries: queries.length, total: concepts.length + queries.length },
-    sources: Object.keys(state.sources).length,
-    lastCompiledAt: lastCompile,
-    orphanedPages: orphans,
-    pendingCandidates,
-    pendingChanges: changes
-      .filter((c) => c.status !== "unchanged")
-      .map((c) => ({ file: c.file, status: c.status })),
+    pages: { concepts: conceptSummaries.length, queries: queries.length, total: conceptSummaries.length + queries.length },
+    sources: Object.keys(classified.state.sources).length,
+    lastCompiledAt: lastCompileTime(classified.state.sources),
+    stalePages,
+    orphanedPages,
+    stateStatus: classified.status,
+    pendingCandidates: await countCandidates(root),
+    pendingChanges: changes.filter((c) => c.status !== "unchanged").map((c) => ({ file: c.file, status: c.status })),
   };
 }

--- a/src/mcp/status.ts
+++ b/src/mcp/status.ts
@@ -106,11 +106,12 @@ export async function collectStatus(root: string): Promise<WikiStatus> {
 
   const { stalePages, orphanedPages } = classifyConceptPages(scannedConcepts, snapshot);
 
-  // Suppress pendingChanges when state is unreadable: comparing against emptyState
-  // would classify every source file as "new", which is false precision on corrupt state.
-  const pendingChanges = classified.status === "ok"
-    ? pendingChangesFromSnapshot(snapshot, sourceFilesOnDisk)
-    : [];
+  // Suppress pendingChanges only on corrupt state: comparing against an empty snapshot
+  // on corrupt state would classify every source file as "new", which is false precision.
+  // On missing state the snapshot is legitimately empty, so every on-disk source is "new" — correct.
+  const pendingChanges = classified.status === "corrupt"
+    ? []
+    : pendingChangesFromSnapshot(snapshot, sourceFilesOnDisk);
 
   return {
     pages: { concepts: conceptSummaries.length, queries: queries.length, total: conceptSummaries.length + queries.length },

--- a/src/mcp/status.ts
+++ b/src/mcp/status.ts
@@ -20,20 +20,43 @@ import { buildFreshnessSnapshot, computeFreshness } from "../freshness/index.js"
 import { CONCEPTS_DIR, QUERIES_DIR, SOURCES_DIR } from "../utils/constants.js";
 import type { FreshnessSnapshot } from "../freshness/types.js";
 
+/**
+ * Maximum number of items returned in each agent-facing list (stalePages,
+ * orphanedPages, pendingChanges). Bounds the MCP response size and agent
+ * context consumption on large wikis. True totals are in the matching *Count fields.
+ */
+export const MAX_STATUS_LIST = 100;
+
 /** Shape returned by `collectStatus` and surfaced by the `wiki_status` tool. */
 export interface WikiStatus {
   pages: { concepts: number; queries: number; total: number };
   sources: number;
   lastCompiledAt: string | null;
-  /** Concept slugs whose source changed or partially disappeared since compile. */
+  /**
+   * Concept slugs whose source changed or partially disappeared since compile.
+   * Capped at MAX_STATUS_LIST (sorted ascending); see staleCount for the true total.
+   */
   stalePages: string[];
-  /** Concept slugs whose every owning source was deleted, or frontmatter-flagged orphaned (superset of old behavior). */
+  /** True total of stale pages (may exceed stalePages.length when capped). */
+  staleCount: number;
+  /**
+   * Concept slugs whose every owning source was deleted, or frontmatter-flagged orphaned.
+   * Capped at MAX_STATUS_LIST (sorted ascending); see orphanedCount for the true total.
+   */
   orphanedPages: string[];
+  /** True total of orphaned pages (may exceed orphanedPages.length when capped). */
+  orphanedCount: number;
   /** Readability of .llmwiki/state.json — surfaced so corrupt state is never silent. */
   stateStatus: "ok" | "missing" | "corrupt";
   /** Number of compile candidates awaiting human review. */
   pendingCandidates: number;
+  /**
+   * Source files with changes since last compile (new/changed/deleted).
+   * Capped at MAX_STATUS_LIST (sorted by file); see pendingChangesCount for the true total.
+   */
   pendingChanges: Array<{ file: string; status: string }>;
+  /** True total of pending changes (may exceed pendingChanges.length when capped). */
+  pendingChangesCount: number;
 }
 
 /** Classify scanned concept pages into stale/orphaned arrays using the freshness snapshot. */
@@ -91,6 +114,24 @@ function pendingChangesFromSnapshot(
   return out;
 }
 
+/**
+ * Sort a slug list ascending and cap it at MAX_STATUS_LIST.
+ * Deterministic truncation ensures agents see the same subset on repeated calls.
+ */
+function capSlugs(slugs: string[]): string[] {
+  return slugs.slice().sort().slice(0, MAX_STATUS_LIST);
+}
+
+/**
+ * Sort a pending-change list by file name ascending and cap at MAX_STATUS_LIST.
+ * Deterministic truncation matches capSlugs behaviour for consistency.
+ */
+function capPendingChanges(
+  changes: Array<{ file: string; status: string }>,
+): Array<{ file: string; status: string }> {
+  return changes.slice().sort((a, b) => a.file.localeCompare(b.file)).slice(0, MAX_STATUS_LIST);
+}
+
 /** Build a read-only status snapshot used by the `wiki_status` MCP tool. */
 export async function collectStatus(root: string): Promise<WikiStatus> {
   const classified = await readStateClassified(root);
@@ -117,10 +158,13 @@ export async function collectStatus(root: string): Promise<WikiStatus> {
     pages: { concepts: conceptSummaries.length, queries: queries.length, total: conceptSummaries.length + queries.length },
     sources: Object.keys(classified.state.sources).length,
     lastCompiledAt: lastCompileTime(classified.state.sources),
-    stalePages,
-    orphanedPages,
+    stalePages: capSlugs(stalePages),
+    staleCount: stalePages.length,
+    orphanedPages: capSlugs(orphanedPages),
+    orphanedCount: orphanedPages.length,
     stateStatus: classified.status,
     pendingCandidates,
-    pendingChanges,
+    pendingChanges: capPendingChanges(pendingChanges),
+    pendingChangesCount: pendingChanges.length,
   };
 }

--- a/src/mcp/status.ts
+++ b/src/mcp/status.ts
@@ -1,0 +1,57 @@
+/**
+ * Read-only project-status collector for the MCP `wiki_status` tool.
+ *
+ * Extracted from tools.ts to keep that file under the 400-line limit and to
+ * own the (soon-to-be freshness-derived) stale/orphaned classification.
+ * All functions here are pure reads — nothing in this module mutates the
+ * workspace.
+ */
+
+import path from "path";
+import { collectPageSummaries, scanWikiPages } from "../compiler/indexgen.js";
+import { detectChanges } from "../compiler/hasher.js";
+import { countCandidates } from "../compiler/candidates.js";
+import { readState } from "../utils/state.js";
+import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
+
+/** Shape returned by `collectStatus` and surfaced by the `wiki_status` tool. */
+export interface WikiStatus {
+  pages: { concepts: number; queries: number; total: number };
+  sources: number;
+  lastCompiledAt: string | null;
+  orphanedPages: string[];
+  /** Number of compile candidates awaiting human review. */
+  pendingCandidates: number;
+  pendingChanges: Array<{ file: string; status: string }>;
+}
+
+/** Find concept slugs whose pages are flagged as orphaned. */
+async function findOrphanedSlugs(root: string): Promise<string[]> {
+  const scanned = await scanWikiPages(path.join(root, CONCEPTS_DIR));
+  return scanned.filter(({ meta }) => meta.orphaned).map(({ slug }) => slug);
+}
+
+/** Build a read-only status snapshot used by the `wiki_status` MCP tool. */
+export async function collectStatus(root: string): Promise<WikiStatus> {
+  const concepts = await collectPageSummaries(path.join(root, CONCEPTS_DIR));
+  const queries = await collectPageSummaries(path.join(root, QUERIES_DIR));
+  const state = await readState(root);
+  const changes = await detectChanges(root, state);
+  const orphans = await findOrphanedSlugs(root);
+  const pendingCandidates = await countCandidates(root);
+  const compileTimes = Object.values(state.sources).map((s) => s.compiledAt);
+  const lastCompile = compileTimes.length > 0
+    ? compileTimes.sort().slice(-1)[0]
+    : null;
+
+  return {
+    pages: { concepts: concepts.length, queries: queries.length, total: concepts.length + queries.length },
+    sources: Object.keys(state.sources).length,
+    lastCompiledAt: lastCompile,
+    orphanedPages: orphans,
+    pendingCandidates,
+    pendingChanges: changes
+      .filter((c) => c.status !== "unchanged")
+      .map((c) => ({ file: c.file, status: c.status })),
+  };
+}

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -15,10 +15,7 @@ import { ingestSource } from "../commands/ingest.js";
 import { compileAndReport } from "../compiler/index.js";
 import { generateAnswer, selectPages } from "../commands/query.js";
 import { lint } from "../linter/index.js";
-import { collectPageSummaries, scanWikiPages } from "../compiler/indexgen.js";
-import { detectChanges } from "../compiler/hasher.js";
-import { countCandidates } from "../compiler/candidates.js";
-import { readState } from "../utils/state.js";
+import { collectStatus } from "./status.js";
 import { safeReadFile, parseFrontmatter } from "../utils/markdown.js";
 import { findRelevantChunks, findRelevantPages } from "../utils/embeddings.js";
 import { buildContextPack } from "../context/build.js";
@@ -398,47 +395,6 @@ function registerEvalTool(server: McpServer, root: string): void {
   );
 }
 
-
-/** Read-only status snapshot used by the wiki_status tool. */
-async function collectStatus(root: string): Promise<WikiStatus> {
-  const concepts = await collectPageSummaries(path.join(root, CONCEPTS_DIR));
-  const queries = await collectPageSummaries(path.join(root, QUERIES_DIR));
-  const state = await readState(root);
-  const changes = await detectChanges(root, state);
-  const orphans = await findOrphanedSlugs(root);
-  const pendingCandidates = await countCandidates(root);
-  const compileTimes = Object.values(state.sources).map((s) => s.compiledAt);
-  const lastCompile = compileTimes.length > 0
-    ? compileTimes.sort().slice(-1)[0]
-    : null;
-
-  return {
-    pages: { concepts: concepts.length, queries: queries.length, total: concepts.length + queries.length },
-    sources: Object.keys(state.sources).length,
-    lastCompiledAt: lastCompile,
-    orphanedPages: orphans,
-    pendingCandidates,
-    pendingChanges: changes
-      .filter((c) => c.status !== "unchanged")
-      .map((c) => ({ file: c.file, status: c.status })),
-  };
-}
-
-interface WikiStatus {
-  pages: { concepts: number; queries: number; total: number };
-  sources: number;
-  lastCompiledAt: string | null;
-  orphanedPages: string[];
-  /** Number of compile candidates awaiting human review. */
-  pendingCandidates: number;
-  pendingChanges: Array<{ file: string; status: string }>;
-}
-
-/** Find concept slugs whose pages are flagged as orphaned. */
-async function findOrphanedSlugs(root: string): Promise<string[]> {
-  const scanned = await scanWikiPages(path.join(root, CONCEPTS_DIR));
-  return scanned.filter(({ meta }) => meta.orphaned).map(({ slug }) => slug);
-}
 
 /** Load full content for a list of slugs, skipping missing/orphaned pages. */
 async function loadPageRecords(root: string, slugs: string[]): Promise<PageRecord[]> {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -252,8 +252,10 @@ function registerStatusTool(server: McpServer, root: string): void {
         "source changed or partially disappeared since last compile. orphanedPages lists " +
         "concept slugs whose every owning source was deleted OR that are frontmatter-flagged " +
         "orphaned (superset of prior behavior). stateStatus reports state.json readability " +
-        "(ok | missing | corrupt) so corrupt state is never silent. Read-only — never " +
-        "modifies the workspace.",
+        "(ok | missing | corrupt) so corrupt state is never silent. Each list (stalePages, " +
+        "orphanedPages, pendingChanges) is capped at 100 entries for response size; the " +
+        "corresponding *Count fields (staleCount, orphanedCount, pendingChangesCount) give " +
+        "the true totals. Read-only — never modifies the workspace.",
       inputSchema: {},
     },
     async () => jsonResult(await collectStatus(root)),

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -247,8 +247,12 @@ function registerStatusTool(server: McpServer, root: string): void {
     {
       title: "Wiki Status",
       description:
-        "Summarize the wiki: page count, source count, last compile time, " +
-        "orphaned pages, and pending source changes. Read-only — never " +
+        "Summarize the wiki: page count, source count, last compile time, pending source " +
+        "changes, and freshness-derived page health. stalePages lists concept slugs whose " +
+        "source changed or partially disappeared since last compile. orphanedPages lists " +
+        "concept slugs whose every owning source was deleted OR that are frontmatter-flagged " +
+        "orphaned (superset of prior behavior). stateStatus reports state.json readability " +
+        "(ok | missing | corrupt) so corrupt state is never silent. Read-only — never " +
         "modifies the workspace.",
       inputSchema: {},
     },

--- a/src/project/state.ts
+++ b/src/project/state.ts
@@ -30,6 +30,7 @@ import {
 import { countCandidates } from "../compiler/candidates.js";
 import { LINT_CACHE_TIMESTAMP_PATTERN } from "../linter/cache.js";
 import type { LintCacheEntry } from "../linter/cache.js";
+import { readStateClassified } from "../utils/state.js";
 
 /** Markdown extension treated as a wiki page for counting purposes. */
 const MARKDOWN_EXT = ".md";
@@ -41,7 +42,9 @@ type ProjectStateWarningCode =
   | "index-missing"
   | "sources-not-compiled"
   | "pending-candidates"
-  | "project-unreadable";
+  | "project-unreadable"
+  | "state-unreadable"
+  | "stale-pages";
 
 /** One structural warning surfaced alongside the primary state. */
 export interface ProjectStateWarning {
@@ -87,7 +90,9 @@ export async function collectProjectState(root: string): Promise<ProjectState> {
   const counts = await collectPageCounts(root, dirs);
   const lint = await collectLintCacheStatus(root);
   const mtimes = await collectMtimes(root, dirs);
-  return assembleState({ root, dirs, counts, lint, mtimes });
+  // Read-only; never writes a .bak file — safe for the cheap orientation command.
+  const stateStatus = (await readStateClassified(root)).status;
+  return assembleState({ root, dirs, counts, lint, mtimes, stateStatus });
 }
 
 /** State returned when `root` itself cannot be inspected. */
@@ -192,15 +197,33 @@ async function readLintCacheEntry(cachePath: string): Promise<LintCacheEntry | n
   }
 }
 
-/** Mirror of the cache module's validator; kept local to avoid leaking internal helpers. */
+/**
+ * Validate the lint cache JSON shape, carrying the optional `freshness` field
+ * through when it is present and well-formed. Returns null for any missing or
+ * corrupt field in the required subset ({@link LintCacheEntry}).
+ */
 function validateCacheShape(value: unknown): LintCacheEntry | null {
   if (typeof value !== "object" || value === null) return null;
   const candidate = value as Record<string, unknown>;
-  const { warnings, errors, at } = candidate;
+  const { warnings, errors, at, freshness } = candidate;
   if (!isNonNegativeInteger(warnings)) return null;
   if (!isNonNegativeInteger(errors)) return null;
   if (typeof at !== "string" || !LINT_CACHE_TIMESTAMP_PATTERN.test(at)) return null;
-  return { warnings, errors, at };
+  const entry: LintCacheEntry = { warnings, errors, at };
+  // Intentionally lenient (diverges from cache.ts:isValidEntry): a malformed
+  // `freshness` sub-field is silently dropped rather than rejecting the whole
+  // entry, so `next` still surfaces valid lint counts. Do not "align" the two.
+  if (isValidFreshnessShape(freshness)) entry.freshness = freshness;
+  return entry;
+}
+
+/** True when `value` is a well-formed freshness sub-object. */
+function isValidFreshnessShape(
+  value: unknown,
+): value is { stalePages: number; orphanedPages: number } {
+  if (typeof value !== "object" || value === null) return false;
+  const c = value as Record<string, unknown>;
+  return isNonNegativeInteger(c.stalePages) && isNonNegativeInteger(c.orphanedPages);
 }
 
 /** True for finite, non-negative integers. NaN and Infinity fail Number.isInteger. */
@@ -215,12 +238,13 @@ interface AssembleStateInput {
   counts: PageCounts;
   lint: LintCacheStatus;
   mtimes: MtimePair;
+  stateStatus: "ok" | "missing" | "corrupt";
 }
 
 /** Combine the per-section reads into the final ProjectState + warning list. */
 function assembleState(input: AssembleStateInput): ProjectState {
-  const { root, dirs, counts, lint, mtimes } = input;
-  const warnings = buildWarnings({ dirs, counts, lint, mtimes });
+  const { root, dirs, counts, lint, mtimes, stateStatus } = input;
+  const warnings = buildWarnings({ dirs, counts, lint, mtimes, stateStatus });
   return { root, ...dirs, ...counts, lint, ...mtimes, warnings };
 }
 
@@ -230,6 +254,7 @@ interface WarningInput {
   counts: PageCounts;
   lint: LintCacheStatus;
   mtimes: MtimePair;
+  stateStatus: "ok" | "missing" | "corrupt";
 }
 
 /** Derive every structural warning from the already-collected state slices. */
@@ -237,6 +262,7 @@ function buildWarnings(input: WarningInput): ProjectStateWarning[] {
   const warnings: ProjectStateWarning[] = [];
   appendLintWarnings(warnings, input.lint, input.mtimes.latestWikiMtimeMs);
   appendStructuralWarnings(warnings, input.dirs, input.counts);
+  appendFreshnessWarnings(warnings, input.lint, input.stateStatus);
   return warnings;
 }
 
@@ -284,6 +310,32 @@ function appendStructuralWarnings(
     warnings.push({
       code: "sources-not-compiled",
       message: "Sources exist but no wiki pages were found. Run `llmwiki compile`.",
+    });
+  }
+}
+
+/**
+ * Freshness warnings: corrupt state.json (fail-loud, not silent) and stale/orphaned
+ * page counts from the lint cache. Missing state stays quiet — it is normal before
+ * the first compile. Only corrupt state warns because it silently zeros all findings.
+ */
+function appendFreshnessWarnings(
+  warnings: ProjectStateWarning[],
+  lint: LintCacheStatus,
+  stateStatus: "ok" | "missing" | "corrupt",
+): void {
+  if (stateStatus === "corrupt") {
+    warnings.push({
+      code: "state-unreadable",
+      message:
+        ".llmwiki/state.json is corrupt — run `llmwiki compile` to rebuild it (freshness figures shown are from the last lint and may be stale).",
+    });
+  }
+  const f = lint.entry?.freshness;
+  if (f && (f.stalePages > 0 || f.orphanedPages > 0)) {
+    warnings.push({
+      code: "stale-pages",
+      message: `${f.stalePages} stale, ${f.orphanedPages} orphaned page(s) as of the last lint — run \`llmwiki compile\` to refresh.`,
     });
   }
 }

--- a/src/project/state.ts
+++ b/src/project/state.ts
@@ -39,6 +39,7 @@ const MARKDOWN_EXT = ".md";
 type ProjectStateWarningCode =
   | "lint-cache-stale"
   | "lint-cache-unparseable"
+  | "freshness-cache-stale"
   | "index-missing"
   | "sources-not-compiled"
   | "pending-candidates"
@@ -262,7 +263,7 @@ function buildWarnings(input: WarningInput): ProjectStateWarning[] {
   const warnings: ProjectStateWarning[] = [];
   appendLintWarnings(warnings, input.lint, input.mtimes.latestWikiMtimeMs);
   appendStructuralWarnings(warnings, input.dirs, input.counts);
-  appendFreshnessWarnings(warnings, input.lint, input.stateStatus);
+  appendFreshnessWarnings(warnings, input.lint, input.stateStatus, input.mtimes.latestSourceMtimeMs);
   return warnings;
 }
 
@@ -315,14 +316,18 @@ function appendStructuralWarnings(
 }
 
 /**
- * Freshness warnings: corrupt state.json (fail-loud, not silent) and stale/orphaned
- * page counts from the lint cache. Missing state stays quiet — it is normal before
- * the first compile. Only corrupt state warns because it silently zeros all findings.
+ * Freshness warnings: corrupt state.json (fail-loud, not silent), stale/orphaned
+ * page counts from the lint cache, and a heuristic freshness-cache-stale warning
+ * when sources/ changed after the last lint.
+ *
+ * Missing state stays quiet — it is normal before the first compile.
+ * Only corrupt state warns because it silently zeros all findings.
  */
 function appendFreshnessWarnings(
   warnings: ProjectStateWarning[],
   lint: LintCacheStatus,
   stateStatus: "ok" | "missing" | "corrupt",
+  latestSourceMtimeMs: number | null,
 ): void {
   if (stateStatus === "corrupt") {
     warnings.push({
@@ -338,6 +343,25 @@ function appendFreshnessWarnings(
       message: `${f.stalePages} stale, ${f.orphanedPages} orphaned page(s) as of the last lint — run \`llmwiki compile\` to refresh.`,
     });
   }
+  if (lint.entry && isFreshnessCacheStale(lint.entry, latestSourceMtimeMs)) {
+    warnings.push({
+      code: "freshness-cache-stale",
+      message:
+        "sources/ changed since the last lint — freshness counts may be out of date; run `llmwiki lint` to refresh.",
+    });
+  }
+}
+
+/**
+ * Heuristic: the sources/ directory mtime is newer than the last lint run.
+ * Catches added/removed source files; may NOT detect in-place content edits on
+ * all filesystems (same limitation as the wiki-mtime lint-cache-stale check).
+ */
+function isFreshnessCacheStale(entry: LintCacheEntry, latestSourceMtimeMs: number | null): boolean {
+  if (latestSourceMtimeMs === null) return false;
+  const lintMs = Date.parse(entry.at);
+  if (Number.isNaN(lintMs)) return false;
+  return latestSourceMtimeMs > lintMs;
 }
 
 /** Cheap structural staleness: last-lint timestamp older than wiki dir mtime. */

--- a/src/viewer/assets/viewer-rail.js
+++ b/src/viewer/assets/viewer-rail.js
@@ -7,6 +7,16 @@
  * timestamps, plus a "Warnings" block fed by `payload.warnings`
  * (parser issues, unresolved citations, malformed citation entries).
  *
+ * Freshness badges (STALE, ORPHANED, CONTRADICTED, ARCHIVED) are
+ * rendered from `payload.freshness`. The design rule: badge ONLY the
+ * two actionable source-freshness states (stale, orphaned) plus the
+ * two provenance flags (contradicted, archived). `fresh` and
+ * `unverified` get NO badge — badging neutral/default states would
+ * stamp nearly the whole wiki. A "Freshness as of <generatedAt>"
+ * caption is shown on every page (keyed on the always-present
+ * `generatedAt`), anchoring the displayed freshness to snapshot/server-
+ * start time because the viewer does not live-watch the filesystem.
+ *
  * Fields render only when the frontmatter actually carries a value, so
  * a legacy page with no provenance metadata shows a compact rail
  * rather than a wall of `(none)` rows. Labels mirror `review show`
@@ -58,9 +68,11 @@ export function renderSupportRail(payload) {
   const support = document.querySelector(SUPPORT_SELECTOR);
   if (!support) return;
   support.innerHTML = "";
+  appendFreshnessBadges(support, payload);
   appendFrontmatterDl(support, extractFrontmatter(payload));
   const warnings = extractWarnings(payload);
   if (warnings.length > 0) support.appendChild(buildRailWarnings(warnings));
+  appendFreshnessCaption(support, payload);
 }
 
 /** Clear the support rail entirely (used on non-page routes). */
@@ -254,4 +266,63 @@ function buildWarningItem(warning) {
 /** Pick the best human-readable label for a warning: message → code → "". */
 function warningText(safe) {
   return safe.message || safe.code || "";
+}
+
+/**
+ * Badge specs: each entry is [modifier, label, predicate(freshness)].
+ * Only entries whose predicate is truthy produce a badge. Ordered by
+ * axis: source-freshness first (stale, orphaned), then provenance
+ * (contradicted, archived).
+ */
+const BADGE_SPECS = [
+  ["stale",       "STALE",       (f) => f.freshnessStatus === "stale"],
+  ["orphaned",    "ORPHANED",    (f) => f.freshnessStatus === "orphaned"],
+  ["contradicted","CONTRADICTED",(f) => f.contradicted],
+  ["archived",    "ARCHIVED",    (f) => f.archived],
+];
+
+/**
+ * Append freshness badges to the rail. Badges render ONLY for actionable
+ * states: STALE, ORPHANED (source-freshness axis) and CONTRADICTED,
+ * ARCHIVED (provenance axis). `fresh` and `unverified` get no badge —
+ * they are the neutral defaults and badging them would stamp nearly the
+ * whole wiki with noise.
+ */
+function appendFreshnessBadges(support, payload) {
+  const freshness = payload?.freshness;
+  if (!freshness) return;
+  const wrap = buildFreshnessBadgeWrap(freshness);
+  if (wrap) support.appendChild(wrap);
+}
+
+/** Build the badges container from the freshness object, or null if no badges apply. */
+function buildFreshnessBadgeWrap(freshness) {
+  const activeBadges = BADGE_SPECS.filter(([, , pred]) => pred(freshness));
+  if (activeBadges.length === 0) return null;
+  const wrap = document.createElement("div");
+  wrap.className = "freshness-badges";
+  for (const [modifier, label] of activeBadges) wrap.appendChild(buildBadge(modifier, label));
+  return wrap;
+}
+
+/** Build one badge `<span>` with a modifier class and text label. */
+function buildBadge(modifier, label) {
+  const span = document.createElement("span");
+  span.className = `freshness-badge badge-${modifier}`;
+  span.textContent = label;
+  return span;
+}
+
+/**
+ * Append the "Freshness as of <generatedAt>" caption when the payload
+ * carries a generatedAt timestamp. Explicitly honest: the viewer
+ * does not live-watch the filesystem, so this caption anchors the
+ * freshness data to the server-start time rather than implying live state.
+ */
+function appendFreshnessCaption(support, payload) {
+  if (!payload?.generatedAt) return;
+  const caption = document.createElement("p");
+  caption.className = "freshness-caption";
+  caption.textContent = `Freshness as of ${payload.generatedAt}`;
+  support.appendChild(caption);
 }

--- a/src/viewer/assets/viewer-sidebar.js
+++ b/src/viewer/assets/viewer-sidebar.js
@@ -11,11 +11,36 @@
  * includes `kind` so the grouping is correct from the first byte);
  * the full `/api/pages` envelope replaces the contents once it
  * arrives.
+ *
+ * A per-axis freshness filter (all / stale / orphaned / contradicted /
+ * archived) narrows the page list client-side over the already-loaded
+ * `/api/pages` rows. No new endpoint is needed — the filter is pure
+ * DOM manipulation over the in-memory page list.
  */
 
 const SIDEBAR_SELECTOR = "[data-sidebar]";
 const DEFAULT_KIND = "concept";
 const EMPTY_PLACEHOLDER_TEXT = "No pages yet — run `llmwiki compile`.";
+
+/**
+ * CSS class on the standing "Project" section. Shared between
+ * `buildProjectSection` (which sets it) and `reRenderSidebarGroups`
+ * (whose keep-selector preserves it across filter re-renders) so a
+ * rename can't silently break the re-render keep-list.
+ */
+const PROJECT_SECTION_CLASS = "sidebar-health";
+
+/** The active freshness filter. "all" means no narrowing. */
+let activeFreshnessFilter = "all";
+
+/** Available filter values and their human labels. */
+const FRESHNESS_FILTER_OPTIONS = [
+  { value: "all", label: "All" },
+  { value: "stale", label: "Stale" },
+  { value: "orphaned", label: "Orphaned" },
+  { value: "contradicted", label: "Contradicted" },
+  { value: "archived", label: "Archived" },
+];
 
 /**
  * Static (non-page) hash routes that have a dedicated sidebar link.
@@ -27,18 +52,43 @@ const STATIC_ROUTE_LINK_SELECTORS = new Map([
   ["#/health", 'a[data-route="health"]'],
 ]);
 
+/** Full page list captured at the last renderSidebar call for filter re-renders. */
+let lastPages = [];
+
 /** Render the sidebar groups + standing Health entry, then mark active. */
 export function renderSidebar(pages) {
+  lastPages = pages;
   const sidebar = document.querySelector(SIDEBAR_SELECTOR);
   if (!sidebar) return;
   sidebar.innerHTML = "";
   sidebar.appendChild(buildProjectSection());
-  const concepts = filterByDirectory(pages, "concepts");
-  const queries = filterByDirectory(pages, "queries");
+  sidebar.appendChild(buildFreshnessFilter());
+  renderFilteredGroups(sidebar, pages);
+  markActive();
+}
+
+/** Re-render only the page groups using the stored lastPages + active filter. */
+function reRenderSidebarGroups() {
+  const sidebar = document.querySelector(SIDEBAR_SELECTOR);
+  if (!sidebar) return;
+  // Remove everything after the project section and filter control.
+  const keep = sidebar.querySelectorAll(`section.${PROJECT_SECTION_CLASS}, .freshness-filter`);
+  const keepSet = new Set(Array.from(keep));
+  Array.from(sidebar.children).forEach((child) => {
+    if (!keepSet.has(child)) child.remove();
+  });
+  renderFilteredGroups(sidebar, lastPages);
+  markActive();
+}
+
+/** Append the filtered concept/query groups and the empty placeholder if needed. */
+function renderFilteredGroups(sidebar, pages) {
+  const filtered = applyFreshnessFilter(pages, activeFreshnessFilter);
+  const concepts = filterByDirectory(filtered, "concepts");
+  const queries = filterByDirectory(filtered, "queries");
   appendConceptGroups(sidebar, concepts);
   appendQueryGroup(sidebar, queries);
   appendEmptyPlaceholderIfNeeded(sidebar, concepts, queries);
-  markActive();
 }
 
 /** Filter pages to those whose `pageDirectory` matches the given bucket. */
@@ -180,7 +230,7 @@ function buildPageListItem(page) {
 /** Build the standing "Project" sidebar section with Health and Graph links. */
 function buildProjectSection() {
   const wrap = document.createElement("section");
-  wrap.className = "sidebar-health";
+  wrap.className = PROJECT_SECTION_CLASS;
   const heading = document.createElement("h2");
   heading.textContent = "Project";
   wrap.appendChild(heading);
@@ -218,4 +268,65 @@ function parseExpectedPageId(hash) {
     return null;
   }
   return `${match[1]}/${slug}`;
+}
+
+/**
+ * Build the freshness-filter `<div>` with a `<select>` control. The
+ * filter is client-side over the already-loaded page rows — no new
+ * endpoint, no query params.
+ */
+function buildFreshnessFilter() {
+  const wrap = document.createElement("div");
+  wrap.className = "freshness-filter";
+  const label = document.createElement("label");
+  label.className = "freshness-filter-label";
+  label.setAttribute("for", "freshness-filter-select");
+  label.textContent = "Filter by freshness";
+  const select = document.createElement("select");
+  select.id = "freshness-filter-select";
+  select.className = "freshness-filter-select";
+  for (const { value, label: optLabel } of FRESHNESS_FILTER_OPTIONS) {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = optLabel;
+    if (value === activeFreshnessFilter) option.selected = true;
+    select.appendChild(option);
+  }
+  select.addEventListener("change", onFreshnessFilterChange);
+  wrap.appendChild(label);
+  wrap.appendChild(select);
+  return wrap;
+}
+
+/** Handle freshness filter selection change — update state and re-render. */
+function onFreshnessFilterChange(event) {
+  activeFreshnessFilter = event.target.value;
+  reRenderSidebarGroups();
+}
+
+/**
+ * Lookup table: filter value → predicate over a freshness object.
+ * Keeps `matchesFreshnessFilter` branch-free.
+ */
+const FRESHNESS_PREDICATES = {
+  stale:       (f) => f.freshnessStatus === "stale",
+  orphaned:    (f) => f.freshnessStatus === "orphaned",
+  contradicted:(f) => f.contradicted === true,
+  archived:    (f) => f.archived === true,
+};
+
+/**
+ * Apply the active freshness filter to the page list. "all" returns all
+ * pages; other values match the corresponding freshness flag on each page.
+ */
+function applyFreshnessFilter(pages, filter) {
+  if (filter === "all") return pages;
+  return pages.filter((page) => matchesFreshnessFilter(page, filter));
+}
+
+/** True when the page's freshness satisfies the active filter. */
+function matchesFreshnessFilter(page, filter) {
+  const f = page.freshness;
+  const predicate = FRESHNESS_PREDICATES[filter];
+  return f != null && predicate != null && predicate(f);
 }

--- a/src/viewer/assets/viewer.css
+++ b/src/viewer/assets/viewer.css
@@ -314,6 +314,75 @@ a:hover, a:focus-visible { text-decoration: underline; }
   }
 }
 
+/* Freshness badges — shown in the support rail for STALE, ORPHANED,
+ * CONTRADICTED, ARCHIVED pages. fresh/unverified get no badge. */
+.freshness-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-bottom: 0.6rem;
+}
+.freshness-badge {
+  display: inline-block;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.badge-stale    { background: rgba(200, 90, 0, 0.12); color: #b85c00; }
+.badge-orphaned { background: rgba(176, 0, 32, 0.10); color: var(--missing); }
+.badge-contradicted { background: rgba(100, 0, 180, 0.10); color: #6400b4; }
+.badge-archived { background: rgba(100, 100, 110, 0.12); color: var(--fg-muted); }
+@media (prefers-color-scheme: dark) {
+  .badge-stale    { background: rgba(255, 160, 60, 0.14); color: #ffa03c; }
+  .badge-contradicted { background: rgba(180, 100, 255, 0.14); color: #b464ff; }
+}
+
+/* Freshness caption — "Freshness as of <timestamp>" — always shown
+ * when freshness data is present to be honest about the frozen snapshot. */
+.freshness-caption {
+  font-size: 0.76rem;
+  color: var(--fg-muted);
+  margin-top: 0.75rem;
+  font-style: italic;
+}
+
+/* Corrupt-state banner — shown in the health pane when stateStatus === "corrupt". */
+.corrupt-state-banner {
+  background: rgba(176, 0, 32, 0.08);
+  color: var(--missing);
+  border: 1px solid rgba(176, 0, 32, 0.2);
+  padding: 0.6rem 0.85rem;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+  font-weight: 500;
+}
+
+/* Freshness filter — sidebar select control for filtering by freshness axis. */
+.freshness-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin: 0.5rem 0 0.75rem;
+}
+.freshness-filter-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-muted);
+}
+.freshness-filter-select {
+  width: 100%;
+  padding: 0.3rem 0.5rem;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 0.9rem;
+}
+
 /* Graph pane */
 .graph-pane {
   width: 100%;

--- a/src/viewer/assets/viewer.css
+++ b/src/viewer/assets/viewer.css
@@ -349,7 +349,7 @@ a:hover, a:focus-visible { text-decoration: underline; }
   font-style: italic;
 }
 
-/* Corrupt-state banner — shown in the health pane when stateStatus === "corrupt". */
+/* Corrupt-state banner — shown globally (and in the health pane) when stateStatus === "corrupt". */
 .corrupt-state-banner {
   background: rgba(176, 0, 32, 0.08);
   color: var(--missing);

--- a/src/viewer/assets/viewer.js
+++ b/src/viewer/assets/viewer.js
@@ -57,6 +57,8 @@ const HEALTH_METRIC_ROWS = [
   ["Saved queries", "queries"],
   ["Compiled sources", "sources"],
   ["Source files", "sourceFiles"],
+  ["Stale pages", "stale"],
+  ["Orphaned pages", "orphaned"],
   ["Pending reviews", "pendingReviews"],
 ];
 

--- a/src/viewer/assets/viewer.js
+++ b/src/viewer/assets/viewer.js
@@ -268,12 +268,27 @@ async function renderHealthPane(main) {
 function buildHealthDashboard(health) {
   const wrap = document.createElement("section");
   wrap.className = "health-dashboard";
+  if (health?.stateStatus === "corrupt") wrap.prepend(buildCorruptStateBanner());
   const rows = HEALTH_METRIC_ROWS.map(([label, key]) => [label, health?.[key] ?? 0]);
   const metrics = buildDefinitionList(rows);
   metrics.className = "metric-list";
   wrap.appendChild(metrics);
   wrap.appendChild(buildLintBlock(health?.lint));
   return wrap;
+}
+
+/**
+ * Build the corrupt-state warning banner. Displayed when `/api/health`
+ * reports `stateStatus === "corrupt"`, meaning the project's state.json
+ * could not be parsed at viewer startup and freshness data is unreliable.
+ */
+function buildCorruptStateBanner() {
+  const banner = document.createElement("div");
+  banner.className = "corrupt-state-banner";
+  banner.setAttribute("role", "alert");
+  banner.textContent =
+    "Warning: state.json is corrupt. Freshness data is unavailable. Re-run `llmwiki compile` to restore.";
+  return banner;
 }
 
 /** Render the lint summary, or a "lint has not been run yet" placeholder. */

--- a/src/viewer/assets/viewer.js
+++ b/src/viewer/assets/viewer.js
@@ -332,7 +332,7 @@ function applyHomeEnvelope(envelope) {
   titleEl.textContent = projectTitle(envelope);
   renderSidebar(envelope?.pages || []);
   renderHome(envelope);
-  // Inject after renderHome so the banner survives the innerHTML clear.
+  // Inject into .app-layout (outside <main>) so the banner persists across route changes.
   injectGlobalCorruptBanner(envelope?.stateStatus);
 }
 

--- a/src/viewer/assets/viewer.js
+++ b/src/viewer/assets/viewer.js
@@ -270,13 +270,23 @@ async function renderHealthPane(main) {
 function buildHealthDashboard(health) {
   const wrap = document.createElement("section");
   wrap.className = "health-dashboard";
-  if (health?.stateStatus === "corrupt") wrap.prepend(buildCorruptStateBanner());
+  // The global banner (injected at bootstrap) covers every route including health;
+  // only add it here if bootstrap didn't already inject one (e.g. if /api/pages
+  // was not yet fetched when navigating directly to #/health).
+  prependBannerIfNeeded(wrap, health?.stateStatus);
   const rows = HEALTH_METRIC_ROWS.map(([label, key]) => [label, health?.[key] ?? 0]);
   const metrics = buildDefinitionList(rows);
   metrics.className = "metric-list";
   wrap.appendChild(metrics);
   wrap.appendChild(buildLintBlock(health?.lint));
   return wrap;
+}
+
+/** Prepend a corrupt-state banner to `container` if one is not already in the document. */
+function prependBannerIfNeeded(container, stateStatus) {
+  if (stateStatus !== "corrupt") return;
+  if (document.querySelector(".corrupt-state-banner")) return;
+  container.prepend(buildCorruptStateBanner());
 }
 
 /**
@@ -322,6 +332,21 @@ function applyHomeEnvelope(envelope) {
   titleEl.textContent = projectTitle(envelope);
   renderSidebar(envelope?.pages || []);
   renderHome(envelope);
+  // Inject after renderHome so the banner survives the innerHTML clear.
+  injectGlobalCorruptBanner(envelope?.stateStatus);
+}
+
+/**
+ * Inject the corrupt-state banner into the app-layout container (above `main`)
+ * so it persists across route changes. Runs once at app bootstrap from the
+ * /api/pages envelope. No-ops when not corrupt or already injected.
+ */
+function injectGlobalCorruptBanner(stateStatus) {
+  if (stateStatus !== "corrupt") return;
+  if (document.querySelector(".corrupt-state-banner")) return;
+  const layout = document.querySelector(".app-layout");
+  if (!layout) return;
+  layout.prepend(buildCorruptStateBanner());
 }
 
 /** Fetch /api/index and render the rendered HTML coming back from the server. */

--- a/src/viewer/assets/viewer.js
+++ b/src/viewer/assets/viewer.js
@@ -509,6 +509,12 @@ function main() {
   const embedded = readEmbeddedIndex();
   renderSidebar(embedded.pages);
   wireSearch({ fetchJson });
+  // Ensure the corrupt-state banner appears on every entry route, not just home.
+  // injectGlobalCorruptBanner is idempotent, so the home route's own /api/pages
+  // fetch won't double-render if both settle.
+  void fetchJson("/api/pages")
+    .then((env) => injectGlobalCorruptBanner(env?.stateStatus))
+    .catch(() => {});
   window.addEventListener("hashchange", () => {
     void renderRoute();
   });

--- a/src/viewer/collect.ts
+++ b/src/viewer/collect.ts
@@ -18,6 +18,7 @@ import { collectRawWikiPages, extractWikilinkSlugs, extractWikilinkTargets } fro
 import type { RawWikiPage } from "../wiki/collect.js";
 import { extractClaimCitations, slugify } from "../utils/markdown.js";
 import type { PageId, ViewerPage, ViewerWarning } from "./types.js";
+import type { PageFreshness } from "../freshness/types.js";
 
 /** Minimal page shape `resolveBareSlug` needs to find a target. */
 type PageIndexEntry = {
@@ -146,8 +147,17 @@ function buildPageShell(page: RawWikiPage): ViewerPage {
     outgoingLinks: [],
     citations: extractClaimCitations(page.body),
     warnings: warningsFromParseStatus(page),
+    // Placeholder: overwritten by attachFreshness() in buildViewerSnapshot.
+    freshness: UNVERIFIED_FRESHNESS,
   };
 }
+
+/** Default freshness placeholder — overwritten in the snapshot build. */
+const UNVERIFIED_FRESHNESS: PageFreshness = {
+  freshnessStatus: "unverified",
+  contradicted: false,
+  archived: false,
+};
 
 /** Read the `aliases` frontmatter field as a string list (empty when absent/malformed). */
 function readAliases(frontmatter: Record<string, unknown>): string[] {

--- a/src/viewer/health.ts
+++ b/src/viewer/health.ts
@@ -24,6 +24,8 @@ interface ViewerHealthResponse {
   sourceFiles: number;
   concepts: number;
   queries: number;
+  stale: number;
+  orphaned: number;
   lint: LintCacheEntry | null;
 }
 
@@ -42,6 +44,8 @@ export async function buildHealthResponse(
     sourceFiles: snapshot.counts.sourceFiles,
     concepts: snapshot.counts.concepts,
     queries: snapshot.counts.queries,
+    stale: snapshot.counts.stale,
+    orphaned: snapshot.counts.orphaned,
     lint,
   };
 }

--- a/src/viewer/health.ts
+++ b/src/viewer/health.ts
@@ -26,6 +26,8 @@ interface ViewerHealthResponse {
   queries: number;
   stale: number;
   orphaned: number;
+  /** Classification of state.json at snapshot build time. "corrupt" triggers the client-side banner. */
+  stateStatus: "ok" | "missing" | "corrupt";
   lint: LintCacheEntry | null;
 }
 
@@ -46,6 +48,7 @@ export async function buildHealthResponse(
     queries: snapshot.counts.queries,
     stale: snapshot.counts.stale,
     orphaned: snapshot.counts.orphaned,
+    stateStatus: snapshot.stateStatus,
     lint,
   };
 }

--- a/src/viewer/server.ts
+++ b/src/viewer/server.ts
@@ -330,6 +330,7 @@ function pageListRow(page: ViewerPage): Record<string, unknown> {
     updatedAt:
       typeof page.frontmatter.updatedAt === "string" ? (page.frontmatter.updatedAt as string) : "",
     warnings: page.warnings,
+    freshness: page.freshness,
   };
 }
 
@@ -461,6 +462,7 @@ function pagePayload(
     outgoingLinks: page.outgoingLinks,
     frontmatter: page.frontmatter,
     warnings: page.warnings,
+    freshness: page.freshness,
     updatedAt:
       typeof page.frontmatter.updatedAt === "string" ? (page.frontmatter.updatedAt as string) : "",
     createdAt:

--- a/src/viewer/server.ts
+++ b/src/viewer/server.ts
@@ -301,10 +301,11 @@ async function handleShell(res: ServerResponse, snapshot: ViewerSnapshot): Promi
   res.end(body);
 }
 
-/** `/api/pages` — full envelope with counts, recent pages, and page list. */
+/** `/api/pages` — full envelope with counts, recent pages, page list, and stateStatus. */
 function handleApiPages(res: ServerResponse, snapshot: ViewerSnapshot): void {
   writeJson(res, 200, {
     project: snapshot.project,
+    stateStatus: snapshot.stateStatus,
     counts: {
       concepts: snapshot.counts.concepts,
       queries: snapshot.counts.queries,

--- a/src/viewer/snapshot.ts
+++ b/src/viewer/snapshot.ts
@@ -78,6 +78,7 @@ export async function buildViewerSnapshot(root: string): Promise<ViewerSnapshot>
   return {
     root,
     generatedAt: new Date().toISOString(),
+    stateStatus: classified.status,
     project,
     counts,
     index: fullIndex,

--- a/src/viewer/snapshot.ts
+++ b/src/viewer/snapshot.ts
@@ -5,12 +5,15 @@
  * live-watch the filesystem, so post-startup mutations are intentionally
  * invisible to the running viewer until it restarts.
  *
- * The snapshot consolidates four data sources:
+ * The snapshot consolidates five data sources:
  *   - `collectViewerPages` for the decorated page list AND the
  *     concept/query counts (deriving counts from the already-confined
  *     page list means symlinked entries dropped by the collector
  *     cannot quietly inflate the counts via a second unconfined scan)
- *   - `readState` for the compiled-source count
+ *   - `readStateClassified` (read-only, never writes a `.bak`) for the
+ *     compiled-source count AND as the input to the freshness snapshot
+ *   - `buildFreshnessSnapshot` for per-page freshness and the aggregate
+ *     stale/orphaned counts (one state read + one hash pass over sources/)
  *   - `countCandidates` for the pending-reviews count
  *   - `readdir(sources/)` for the cheap source-file count
  */
@@ -19,11 +22,13 @@ import { readdir, readFile, realpath } from "fs/promises";
 import path from "path";
 import { SOURCES_DIR } from "../utils/constants.js";
 import { countCandidates } from "../compiler/candidates.js";
-import { readState } from "../utils/state.js";
+import { readStateClassified } from "../utils/state.js";
 import { collectViewerPages, resolveBareSlugList } from "./collect.js";
 import { extractWikilinkSlugs } from "../wiki/collect.js";
 import { isMalformedCitationEntry } from "../utils/markdown.js";
 import { buildGraphData } from "./graph.js";
+import { buildFreshnessSnapshot, computeFreshness } from "../freshness/index.js";
+import type { FreshnessSnapshot } from "../freshness/types.js";
 import type {
   ViewerCounts,
   ViewerIndex,
@@ -45,25 +50,15 @@ const INDEX_HREF = "/#/index";
  * `readLintCache` in `src/viewer/health.ts` is the sole exception.
  */
 export async function buildViewerSnapshot(root: string): Promise<ViewerSnapshot> {
-  const [pages, state, pendingReviews, sourceFilenames, index] = await Promise.all([
+  const [pages, classified, pendingReviews, sourceFilenames, index] = await Promise.all([
     collectViewerPages(root),
-    readState(root),
+    readStateClassified(root),
     countCandidates(root),
     listSourceFiles(root),
     readIndexFile(root),
   ]);
+  const freshnessSnapshot = await buildFreshnessSnapshot(root, classified);
   const project = buildProject(root);
-  // Concept/query counts are derived from `pages`, the already-confined
-  // viewer page list, NOT from a second unconfined directory scan.
-  // Anything the collector dropped for path-safety reasons (symlinked
-  // file or directory) is therefore also excluded from the counts.
-  const counts: ViewerCounts = {
-    concepts: pages.filter((p) => p.pageDirectory === "concepts").length,
-    queries: pages.filter((p) => p.pageDirectory === "queries").length,
-    sourceFiles: sourceFilenames.length,
-    pendingReviews,
-    compiledSources: Object.keys(state.sources).length,
-  };
   const fullIndex: ViewerIndex = {
     available: index.available,
     href: INDEX_HREF,
@@ -71,7 +66,14 @@ export async function buildViewerSnapshot(root: string): Promise<ViewerSnapshot>
     outgoingLinks: resolveBareSlugList(extractWikilinkSlugs(index.body), pages),
   };
   const sourceFileSet = new Set(sourceFilenames);
-  const annotatedPages = pages.map((page) => annotateCitationWarnings(page, sourceFileSet));
+  // Concept/query counts are derived from `pages`, the already-confined
+  // viewer page list, NOT from a second unconfined directory scan.
+  // Anything the collector dropped for path-safety reasons (symlinked
+  // file or directory) is therefore also excluded from the counts.
+  const annotatedPages = pages
+    .map((page) => annotateCitationWarnings(page, sourceFileSet))
+    .map((page) => attachFreshness(page, freshnessSnapshot));
+  const counts = buildCounts(annotatedPages, sourceFilenames, pendingReviews, classified.state);
   const graph = buildGraphData(annotatedPages);
   return {
     root,
@@ -108,6 +110,43 @@ function annotateCitationWarnings(page: ViewerPage, sourceFiles: ReadonlySet<str
   }
   if (extra.length === 0) return page;
   return { ...page, warnings: [...page.warnings, ...extra] };
+}
+
+/**
+ * Derive the frozen counts from the annotated page list, source filenames,
+ * candidates count, and state. Concept/query counts are derived from pages
+ * (the already-confined collector list) so symlinked drops don't inflate them.
+ */
+function buildCounts(
+  pages: ViewerPage[],
+  sourceFilenames: string[],
+  pendingReviews: number,
+  state: { sources: Record<string, unknown> },
+): ViewerCounts {
+  return {
+    concepts: pages.filter((p) => p.pageDirectory === "concepts").length,
+    queries: pages.filter((p) => p.pageDirectory === "queries").length,
+    sourceFiles: sourceFilenames.length,
+    pendingReviews,
+    compiledSources: Object.keys(state.sources).length,
+    stale: pages.filter((p) => p.freshness.freshnessStatus === "stale").length,
+    orphaned: pages.filter((p) => p.freshness.freshnessStatus === "orphaned").length,
+  };
+}
+
+/**
+ * Attach computed source-freshness to a page. Called once per page during
+ * snapshot build so freshness is frozen at startup alongside all other
+ * snapshot data.
+ */
+function attachFreshness(page: ViewerPage, snapshot: FreshnessSnapshot): ViewerPage {
+  return {
+    ...page,
+    freshness: computeFreshness(
+      { slug: page.slug, pageDirectory: page.pageDirectory, frontmatter: page.frontmatter },
+      snapshot,
+    ),
+  };
 }
 
 /** Classify every comma-separated entry inside one `^[…]` marker. */

--- a/src/viewer/types.ts
+++ b/src/viewer/types.ts
@@ -14,6 +14,7 @@
 
 import type { ClaimCitation } from "../utils/types.js";
 import type { PageDirectory } from "../export/types.js";
+import type { PageFreshness } from "../freshness/types.js";
 
 /**
  * Canonical page identifier: `concepts/<slug>` or `queries/<slug>`. Bare
@@ -67,6 +68,8 @@ export interface ViewerPage {
   citations: ClaimCitation[];
   /** Diagnostics surfaced for this page (parser issues, unresolved citations…). */
   warnings: ViewerWarning[];
+  /** Computed source-freshness as of snapshot build (server start). Never live-updated. */
+  freshness: PageFreshness;
 }
 
 /**
@@ -91,6 +94,9 @@ export interface ViewerCounts {
   sourceFiles: number;
   pendingReviews: number;
   compiledSources: number;
+  /** Pages computed stale/orphaned at snapshot build. */
+  stale: number;
+  orphaned: number;
 }
 
 /**

--- a/src/viewer/types.ts
+++ b/src/viewer/types.ts
@@ -164,6 +164,8 @@ export interface ViewerSnapshot {
   root: string;
   /** ISO-8601 timestamp the snapshot was built at. */
   generatedAt: string;
+  /** Classification of state.json at snapshot build time. Exposed on /api/health for the corrupt-state banner. */
+  stateStatus: "ok" | "missing" | "corrupt";
   /** Project metadata for the dashboard header. */
   project: ViewerProject;
   /** Frozen counts for `/api/pages` and `/api/health`. */

--- a/test/fixtures/next-test-helpers.ts
+++ b/test/fixtures/next-test-helpers.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared setup helpers for `llmwiki next` integration tests.
+ *
+ * Centralises the temp-dir lifecycle and the small per-test seeding
+ * primitives so `next-integration.test.ts` and `freshness-next.test.ts`
+ * don't duplicate the same boilerplate.
+ */
+
+import { mkdtemp, mkdir, writeFile, rm } from "fs/promises";
+import os from "os";
+import path from "path";
+import { beforeEach, afterEach } from "vitest";
+import { runCLI, expectCLIExit } from "./run-cli.js";
+
+/** Mutable temp-dir state populated by {@link useNextTempDir}. */
+export interface NextTempDirEnv {
+  /** Absolute path to the isolated temp root; valid inside `it` blocks. */
+  dir: string;
+}
+
+/**
+ * Wire vitest before/afterEach hooks that create and clean up a temp directory.
+ * Returns a live handle whose `dir` field refreshes before every test.
+ * @param prefix - Short label for the temp directory name.
+ */
+export function useNextTempDir(prefix: string): NextTempDirEnv {
+  const env: NextTempDirEnv = { dir: "" };
+  beforeEach(async () => {
+    env.dir = await mkdtemp(path.join(os.tmpdir(), `${prefix}-`));
+  });
+  afterEach(async () => {
+    if (env.dir) await rm(env.dir, { recursive: true, force: true });
+  });
+  return env;
+}
+
+/**
+ * Ensure `dir` exists and write a minimal markdown stub inside it.
+ * Used to seed page counts without running the full compile pipeline.
+ * @param dir - Directory to create and write into.
+ * @param name - Filename for the markdown stub.
+ */
+export async function touchMarkdown(dir: string, name: string): Promise<void> {
+  await mkdir(dir, { recursive: true });
+  await writeFile(path.join(dir, name), "# stub", "utf-8");
+}
+
+/**
+ * Run `llmwiki next --json` in `dir`, assert exit 0, and return the
+ * parsed payload. Assertion failure includes full subprocess diagnostics.
+ * @param dir - Working directory for the subprocess.
+ */
+export async function runNextJson(dir: string): Promise<Record<string, unknown>> {
+  const result = await runCLI(["next", "--json"], dir);
+  expectCLIExit(result, 0);
+  return JSON.parse(result.stdout) as Record<string, unknown>;
+}

--- a/test/fixtures/viewer-jsdom.ts
+++ b/test/fixtures/viewer-jsdom.ts
@@ -45,10 +45,14 @@ export interface MountResult {
  * Mount the viewer shell + scripts into JSDOM. Returns the dom and a
  * fetch-mock spy so tests can assert what was called. After mount, the
  * promise has been flushed past the initial microtask cycle.
+ *
+ * @param startHash - Optional initial `location.hash` value (e.g. `"#/graph"`).
+ *   Set before scripts run so `main()` sees this hash as the entry route.
  */
 export async function mountViewerDom(
   pages: EmbeddedPage[],
   responder: FetchResponder,
+  startHash?: string,
 ): Promise<MountResult> {
   const [shell, viewerSrc, searchSrc, sidebarSrc, railSrc] = await Promise.all([
     readFile(SHELL_PATH, "utf-8"),
@@ -63,8 +67,9 @@ export async function mountViewerDom(
     const response = await responder(url);
     return response ?? new Response(null, { status: 404 });
   });
+  const startUrl = startHash ? `http://127.0.0.1:0/${startHash}` : "http://127.0.0.1:0/";
   const dom = new JSDOM(html, {
-    url: "http://127.0.0.1:0/",
+    url: startUrl,
     runScripts: "outside-only",
     virtualConsole: new VirtualConsole(),
   });

--- a/test/freshness-context.test.ts
+++ b/test/freshness-context.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Integration tests for freshness fields on `ContextPrimary`.
+ *
+ * Verifies that `buildContextPack` copies `PageFreshness` signals onto each
+ * primary page entry and synthesizes a `stale-page` warning when the
+ * underlying source has changed since the last compile. Stale pages are
+ * flagged — never dropped.
+ *
+ * Fixture pattern: write a concept page + matching source state so the
+ * viewer snapshot carries a deterministic `freshnessStatus`, then assert
+ * the context pack reflects it.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { rm } from "fs/promises";
+import path from "path";
+import { makeTempRoot } from "./fixtures/temp-root.js";
+import { writePage } from "./fixtures/write-page.js";
+import { sha256Hex, writeSourceFile, writeSourceState } from "./fixtures/state-json.js";
+import { buildContextPack } from "../src/context/build.js";
+import { CONCEPTS_DIR } from "../src/utils/constants.js";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await makeTempRoot("freshness-context");
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+/**
+ * Write a concept page with a title and body that will rank against the
+ * prompt "topic" via title-match and exact-title signals.
+ */
+async function writeTopic(): Promise<void> {
+  await writePage(
+    path.join(root, CONCEPTS_DIR),
+    "topic",
+    { title: "Topic", summary: "The topic page" },
+    "A topic page body.",
+  );
+}
+
+/** Seed a fresh fixture: source on disk matches the recorded hash. */
+async function seedFresh(): Promise<void> {
+  const sourceContent = "source body";
+  await writeSourceState(root, {
+    "a.md": { hash: sha256Hex(sourceContent), concepts: ["topic"] },
+  });
+  await writeSourceFile(root, "a.md", sourceContent);
+  await writeTopic();
+}
+
+/**
+ * Build a context pack for "topic" and return the primary entry for
+ * `concepts/topic`, or `undefined` when the page did not rank.
+ */
+async function packPrimary() {
+  const pack = await buildContextPack({ root, prompt: "topic", topPages: 5 });
+  return pack.primary.find((p) => p.id === "concepts/topic");
+}
+
+describe("context pack freshness", () => {
+  it("carries freshnessStatus=fresh onto a primary page whose source matches", async () => {
+    await seedFresh();
+
+    const primary = await packPrimary();
+
+    expect(primary).toBeDefined();
+    expect(primary?.freshnessStatus).toBe("fresh");
+    expect(primary?.contradicted).toBe(false);
+    expect(primary?.archived).toBe(false);
+  });
+
+  it("flags a stale primary page (never drops it) and adds stale-page warning", async () => {
+    // State records OLD hash; disk has NEW content → stale
+    await writeSourceState(root, {
+      "a.md": { hash: sha256Hex("OLD body"), concepts: ["topic"] },
+    });
+    await writeSourceFile(root, "a.md", "NEW body");
+    await writeTopic();
+
+    const primary = await packPrimary();
+
+    expect(primary).toBeDefined();
+    expect(primary?.freshnessStatus).toBe("stale");
+    expect(primary?.warnings.some((w) => w.code === "stale-page")).toBe(true);
+  });
+
+  it("does not add stale-page warning on a fresh page", async () => {
+    await seedFresh();
+
+    const primary = await packPrimary();
+
+    expect(primary?.warnings.some((w) => w.code === "stale-page")).toBe(false);
+  });
+
+  it("carries freshnessStatus=unverified when state.json is missing", async () => {
+    // No writeSourceState call → state is missing → unverified
+    await writeTopic();
+
+    const primary = await packPrimary();
+
+    expect(primary).toBeDefined();
+    expect(primary?.freshnessStatus).toBe("unverified");
+    expect(primary?.warnings.some((w) => w.code === "stale-page")).toBe(false);
+  });
+});

--- a/test/freshness-context.test.ts
+++ b/test/freshness-context.test.ts
@@ -150,4 +150,26 @@ describe("context pack freshness", () => {
     expect(primary?.warnings.some((w) => w.code === "contradicted-page")).toBe(false);
     expect(primary?.warnings.some((w) => w.code === "archived-page")).toBe(false);
   });
+
+  it("carries BOTH stale-page and contradicted-page warnings on a stale+contradicted page", async () => {
+    // State records OLD hash; disk has NEW content → stale.
+    await writeSourceState(root, {
+      "a.md": { hash: sha256Hex("OLD body"), concepts: ["topic"] },
+    });
+    await writeSourceFile(root, "a.md", "NEW body");
+    // Page frontmatter marks it contradicted.
+    await writePage(
+      path.join(root, CONCEPTS_DIR),
+      "topic",
+      { title: "Topic", summary: "The topic page", contradictedBy: [{ slug: "other" }] },
+      "A topic page body.",
+    );
+
+    const primary = await packPrimary();
+
+    expect(primary?.freshnessStatus).toBe("stale");
+    expect(primary?.contradicted).toBe(true);
+    expect(primary?.warnings.some((w) => w.code === "stale-page")).toBe(true);
+    expect(primary?.warnings.some((w) => w.code === "contradicted-page")).toBe(true);
+  });
 });

--- a/test/freshness-context.test.ts
+++ b/test/freshness-context.test.ts
@@ -107,4 +107,47 @@ describe("context pack freshness", () => {
     expect(primary?.freshnessStatus).toBe("unverified");
     expect(primary?.warnings.some((w) => w.code === "stale-page")).toBe(false);
   });
+
+  it("adds contradicted-page warning on a contradicted primary page", async () => {
+    await seedFresh();
+    // Overwrite the page with contradictedBy frontmatter.
+    await writePage(
+      path.join(root, CONCEPTS_DIR),
+      "topic",
+      { title: "Topic", summary: "The topic page", contradictedBy: [{ slug: "other" }] },
+      "A topic page body.",
+    );
+
+    const primary = await packPrimary();
+
+    expect(primary).toBeDefined();
+    expect(primary?.contradicted).toBe(true);
+    expect(primary?.warnings.some((w) => w.code === "contradicted-page")).toBe(true);
+  });
+
+  it("adds archived-page warning on an archived primary page", async () => {
+    await seedFresh();
+    // Overwrite the page with archived frontmatter.
+    await writePage(
+      path.join(root, CONCEPTS_DIR),
+      "topic",
+      { title: "Topic", summary: "The topic page", archived: true },
+      "A topic page body.",
+    );
+
+    const primary = await packPrimary();
+
+    expect(primary).toBeDefined();
+    expect(primary?.archived).toBe(true);
+    expect(primary?.warnings.some((w) => w.code === "archived-page")).toBe(true);
+  });
+
+  it("does not add contradicted-page or archived-page warning on a fresh, non-contradicted, non-archived page", async () => {
+    await seedFresh();
+
+    const primary = await packPrimary();
+
+    expect(primary?.warnings.some((w) => w.code === "contradicted-page")).toBe(false);
+    expect(primary?.warnings.some((w) => w.code === "archived-page")).toBe(false);
+  });
 });

--- a/test/freshness-lint-next-e2e.test.ts
+++ b/test/freshness-lint-next-e2e.test.ts
@@ -1,0 +1,59 @@
+/**
+ * End-to-end subprocess test: real `llmwiki lint` writes freshness counts that
+ * real `llmwiki next` then surfaces.
+ *
+ * Prior tests covered each half in isolation — in-process unit tests for
+ * `writeLintCache`, and subprocess `next --json` tests with a hand-seeded cache.
+ * This file closes the seam: no hand-seeding, no LLM/compile. Both commands run
+ * as real subprocesses; the chain must carry freshness end-to-end on its own.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdir, writeFile } from "fs/promises";
+import path from "path";
+import { runCLI } from "./fixtures/run-cli.js";
+import { useNextTempDir } from "./fixtures/next-test-helpers.js";
+import { sha256Hex, writeSourceState } from "./fixtures/state-json.js";
+import { CONCEPTS_DIR, SOURCES_DIR } from "../src/utils/constants.js";
+
+const env = useNextTempDir("freshness-e2e");
+
+/** Build a fixture where a.md's on-disk content differs from the recorded hash. */
+async function buildStaleFixture(root: string): Promise<void> {
+  // Concept page with required frontmatter so lint schema rules pass.
+  const conceptDir = path.join(root, CONCEPTS_DIR);
+  await mkdir(conceptDir, { recursive: true });
+  const frontmatter = `---\ntitle: "Topic"\nsummary: "A topic page."\n---\n\nBody text here.\n`;
+  await writeFile(path.join(conceptDir, "topic.md"), frontmatter);
+
+  // Source on disk contains "NEW body" but state records hash of "OLD body".
+  await mkdir(path.join(root, SOURCES_DIR), { recursive: true });
+  await writeFile(path.join(root, SOURCES_DIR, "a.md"), "NEW body");
+  await writeSourceState(root, { "a.md": { hash: sha256Hex("OLD body"), concepts: ["topic"] } });
+}
+
+describe("lint → next end-to-end freshness chain (no hand-seeded cache)", () => {
+  it("real lint persists stalePages=1 and real next surfaces it", async () => {
+    await buildStaleFixture(env.dir);
+
+    // Step 1: run real lint — this writes .llmwiki/last-lint.json with freshness.
+    const lint = await runCLI(["lint"], env.dir);
+    // Stale pages emit warnings (not errors), so lint must exit 0.
+    expect(lint.code, `lint failed:\n${lint.stderr}`).toBe(0);
+
+    // Step 2: run real next --json — reads the cache lint just wrote.
+    const next = await runCLI(["next", "--json"], env.dir);
+    expect(next.code, `next failed:\n${next.stderr}`).toBe(0);
+
+    const payload = JSON.parse(next.stdout) as Record<string, unknown>;
+    const summary = payload.summary as Record<string, unknown>;
+
+    // Freshness must come from the real lint run, not null.
+    expect(summary.freshness, "freshness was null — lint did not write it or next did not read it")
+      .not.toBeNull();
+    expect((summary.freshness as Record<string, unknown>).stalePages).toBeGreaterThan(0);
+
+    const warnings = payload.warnings as Array<Record<string, unknown>>;
+    expect(warnings.some((w) => w.code === "stale-pages")).toBe(true);
+  });
+});

--- a/test/freshness-mcp-status.test.ts
+++ b/test/freshness-mcp-status.test.ts
@@ -80,6 +80,16 @@ describe("wiki_status freshness", () => {
     expect(status.pendingChanges).toEqual([]);
   });
 
+  it("reports uncompiled sources as pending on missing state (never-compiled project)", async () => {
+    // No state.json written → state is "missing". Sources on disk should appear as "new".
+    await writeSourceFile(root, "a.md", "first source");
+
+    const status = await collectStatus(root);
+
+    expect(status.stateStatus).toBe("missing");
+    expect(status.pendingChanges).toContainEqual({ file: "a.md", status: "new" });
+  });
+
   it("snapshot-derived pendingChanges: changed, new, and deleted sources all appear correctly", async () => {
     // a.md: recorded with OLD hash → changed
     const oldHash = sha256Hex("OLD content");

--- a/test/freshness-mcp-status.test.ts
+++ b/test/freshness-mcp-status.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { existsSync } from "fs";
 import { rm } from "fs/promises";
 import path from "path";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { collectStatus } from "../src/mcp/status.js";
 import { makeTempRoot } from "./fixtures/temp-root.js";
 import { writePage } from "./fixtures/write-page.js";
@@ -20,6 +21,9 @@ import {
   writeCorruptTestStateJson,
 } from "./fixtures/state-json.js";
 import { CONCEPTS_DIR } from "../src/utils/constants.js";
+import { buildServer } from "./fixtures/mcp-test-env.js";
+
+type ResourceMap = Record<string, { readCallback: (uri: URL) => Promise<{ contents: Array<{ text: string }> }> }>;
 
 let root: string;
 
@@ -63,5 +67,19 @@ describe("wiki_status freshness", () => {
 
     expect(status.stateStatus).toBe("corrupt");
     expect(existsSync(path.join(root, ".llmwiki/state.json.bak"))).toBe(false);
+  });
+});
+
+describe("llmwiki://state resource — no .bak side effect", () => {
+  it("writes no .bak file when state.json is corrupt", async () => {
+    await writeCorruptTestStateJson(root);
+
+    const server = buildServer(root);
+    const resources = (server as unknown as { _registeredResources: ResourceMap })._registeredResources;
+    const result = await resources["llmwiki://state"].readCallback(new URL("llmwiki://state"));
+
+    expect(existsSync(path.join(root, ".llmwiki/state.json.bak"))).toBe(false);
+    const parsed = JSON.parse(result.contents[0].text);
+    expect(parsed).toMatchObject({ version: 1, sources: expect.any(Object) });
   });
 });

--- a/test/freshness-mcp-status.test.ts
+++ b/test/freshness-mcp-status.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Integration tests for freshness-derived wiki_status fields.
+ *
+ * Exercises the new `stalePages`, `orphanedPages` (computed-orphaned superset),
+ * and `stateStatus` fields on `collectStatus`. Verifies that corrupt state
+ * never produces a `.bak` side-effect (the read-only contract).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync } from "fs";
+import { rm } from "fs/promises";
+import path from "path";
+import { collectStatus } from "../src/mcp/status.js";
+import { makeTempRoot } from "./fixtures/temp-root.js";
+import { writePage } from "./fixtures/write-page.js";
+import {
+  writeSourceState,
+  writeSourceFile,
+  sha256Hex,
+  writeCorruptTestStateJson,
+} from "./fixtures/state-json.js";
+import { CONCEPTS_DIR } from "../src/utils/constants.js";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await makeTempRoot("freshness-mcp");
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe("wiki_status freshness", () => {
+  it("reports stale pages from a changed source", async () => {
+    // State records a.md with OLD hash owning "topic", but disk has NEW content.
+    const oldHash = sha256Hex("OLD content");
+    await writeSourceState(root, { "a.md": { hash: oldHash, concepts: ["topic"] } });
+    await writeSourceFile(root, "a.md", "NEW content");
+    await writePage(path.join(root, CONCEPTS_DIR), "topic", { title: "Topic" }, "Body.");
+
+    const status = await collectStatus(root);
+
+    expect(status.stalePages).toContain("topic");
+    expect(status.stateStatus).toBe("ok");
+  });
+
+  it("reports orphaned pages when all owning sources are deleted", async () => {
+    // State records a.md owning "topic", but a.md is NOT on disk.
+    await writeSourceState(root, { "a.md": { hash: "xyz", concepts: ["topic"] } });
+    await writePage(path.join(root, CONCEPTS_DIR), "topic", { title: "Topic" }, "Body.");
+
+    const status = await collectStatus(root);
+
+    expect(status.orphanedPages).toContain("topic");
+  });
+
+  it("flags corrupt state distinctly and writes no .bak", async () => {
+    await writePage(path.join(root, CONCEPTS_DIR), "topic", { title: "Topic" }, "Body.");
+    await writeCorruptTestStateJson(root);
+
+    const status = await collectStatus(root);
+
+    expect(status.stateStatus).toBe("corrupt");
+    expect(existsSync(path.join(root, ".llmwiki/state.json.bak"))).toBe(false);
+  });
+});

--- a/test/freshness-mcp-status.test.ts
+++ b/test/freshness-mcp-status.test.ts
@@ -68,6 +68,17 @@ describe("wiki_status freshness", () => {
     expect(status.stateStatus).toBe("corrupt");
     expect(existsSync(path.join(root, ".llmwiki/state.json.bak"))).toBe(false);
   });
+
+  it("returns empty pendingChanges on corrupt state (no false 'new' entries)", async () => {
+    await writePage(path.join(root, CONCEPTS_DIR), "topic", { title: "Topic" }, "Body.");
+    await writeSourceFile(root, "a.md", "some content");
+    await writeCorruptTestStateJson(root);
+
+    const status = await collectStatus(root);
+
+    expect(status.stateStatus).toBe("corrupt");
+    expect(status.pendingChanges).toEqual([]);
+  });
 });
 
 describe("llmwiki://state resource — no .bak side effect", () => {

--- a/test/freshness-mcp-status.test.ts
+++ b/test/freshness-mcp-status.test.ts
@@ -11,7 +11,7 @@ import { existsSync } from "fs";
 import { rm } from "fs/promises";
 import path from "path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { collectStatus } from "../src/mcp/status.js";
+import { collectStatus, MAX_STATUS_LIST } from "../src/mcp/status.js";
 import { makeTempRoot } from "./fixtures/temp-root.js";
 import { writePage } from "./fixtures/write-page.js";
 import {
@@ -116,6 +116,24 @@ describe("wiki_status freshness", () => {
     );
     // unchanged entries must NOT appear
     expect(status.pendingChanges.some((c) => c.status === "unchanged")).toBe(false);
+  });
+});
+
+describe("wiki_status list capping", () => {
+  it("caps stalePages at MAX_STATUS_LIST and reports the true total in staleCount", async () => {
+    // One source a.md with OLD hash, on disk with NEW content, owning 101 concept slugs.
+    const totalStale = MAX_STATUS_LIST + 1;
+    const slugs = Array.from({ length: totalStale }, (_, i) => `topic-${i}`);
+    await writeSourceState(root, { "a.md": { hash: sha256Hex("OLD"), concepts: slugs } });
+    await writeSourceFile(root, "a.md", "NEW content");
+    for (const slug of slugs) {
+      await writePage(path.join(root, CONCEPTS_DIR), slug, { title: slug }, "Body.");
+    }
+
+    const status = await collectStatus(root);
+
+    expect(status.stalePages.length).toBe(MAX_STATUS_LIST);
+    expect(status.staleCount).toBe(totalStale);
   });
 });
 

--- a/test/freshness-mcp-status.test.ts
+++ b/test/freshness-mcp-status.test.ts
@@ -79,6 +79,34 @@ describe("wiki_status freshness", () => {
     expect(status.stateStatus).toBe("corrupt");
     expect(status.pendingChanges).toEqual([]);
   });
+
+  it("snapshot-derived pendingChanges: changed, new, and deleted sources all appear correctly", async () => {
+    // a.md: recorded with OLD hash → changed
+    const oldHash = sha256Hex("OLD content");
+    // b.md: in state but not on disk → deleted
+    const bHash = sha256Hex("b content");
+    await writeSourceState(root, {
+      "a.md": { hash: oldHash, concepts: [] },
+      "b.md": { hash: bHash, concepts: [] },
+    });
+    // Write a.md with new content so its hash drifts.
+    await writeSourceFile(root, "a.md", "NEW content");
+    // Write c.md on disk but NOT in state → new.
+    await writeSourceFile(root, "c.md", "c content");
+
+    const status = await collectStatus(root);
+
+    expect(status.stateStatus).toBe("ok");
+    expect(status.pendingChanges).toEqual(
+      expect.arrayContaining([
+        { file: "a.md", status: "changed" },
+        { file: "b.md", status: "deleted" },
+        { file: "c.md", status: "new" },
+      ]),
+    );
+    // unchanged entries must NOT appear
+    expect(status.pendingChanges.some((c) => c.status === "unchanged")).toBe(false);
+  });
 });
 
 describe("llmwiki://state resource — no .bak side effect", () => {

--- a/test/freshness-next.test.ts
+++ b/test/freshness-next.test.ts
@@ -31,7 +31,7 @@ async function seedLintCache(dir: string, results: LintResult[]): Promise<void> 
 }
 
 describe("llmwiki next — freshness", () => {
-  it("reports stale/orphaned counts from the lint cache in --json", async () => {
+  it("summary.lint has only {warnings,errors,at} and freshness stays top-level", async () => {
     await touchMarkdown(path.join(env.dir, CONCEPTS_DIR), "topic.md");
     await seedLintCache(env.dir, [
       { rule: "stale-page", severity: "warning", file: "topic.md", message: "stale" },
@@ -39,8 +39,14 @@ describe("llmwiki next — freshness", () => {
 
     const payload = await runNextJson(env.dir);
     const s = payload.summary as Record<string, unknown>;
+    // summary.freshness surfaced at top level of summary
     expect(s.freshness).toEqual({ stalePages: 1, orphanedPages: 0 });
-
+    // summary.lint must NOT leak the freshness field from LintCacheEntry
+    const lint = s.lint as Record<string, unknown> | null;
+    expect(lint).not.toBeNull();
+    expect("freshness" in lint!).toBe(false);
+    expect(Object.keys(lint!).sort()).toEqual(["at", "errors", "warnings"]);
+    // stale-pages warning surfaced at the top level too
     const warnings = payload.warnings as Array<Record<string, unknown>>;
     expect(warnings.some((w) => w.code === "stale-pages")).toBe(true);
   });

--- a/test/freshness-next.test.ts
+++ b/test/freshness-next.test.ts
@@ -11,12 +11,12 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { mkdir } from "fs/promises";
+import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 import { touchMarkdown, runNextJson, useNextTempDir } from "./fixtures/next-test-helpers.js";
 import { writeCorruptTestStateJson } from "./fixtures/state-json.js";
 import { writeLintCache } from "../src/linter/cache.js";
-import { CONCEPTS_DIR, LLMWIKI_DIR } from "../src/utils/constants.js";
+import { CONCEPTS_DIR, LLMWIKI_DIR, SOURCES_DIR } from "../src/utils/constants.js";
 import type { LintResult } from "../src/linter/types.js";
 
 const env = useNextTempDir("freshness-next");
@@ -78,5 +78,37 @@ describe("llmwiki next — freshness", () => {
 
     const warnings = payload.warnings as Array<Record<string, unknown>>;
     expect(warnings.some((w) => w.code === "stale-pages")).toBe(false);
+  });
+});
+
+/** Write a lint cache with an OLD timestamp and create a source file with a newer mtime. */
+async function seedStaleFreshnessCache(dir: string): Promise<void> {
+  // Write the lint cache JSON directly with an old `at` timestamp (well before "now").
+  // This guarantees the sources/ dir mtime (created after) is > Date.parse(at).
+  await mkdir(path.join(dir, LLMWIKI_DIR), { recursive: true });
+  const entry = { warnings: 0, errors: 0, at: "2020-01-01T00:00:00.000Z", freshness: { stalePages: 0, orphanedPages: 0 } };
+  await writeFile(path.join(dir, LLMWIKI_DIR, "last-lint.json"), JSON.stringify(entry), "utf-8");
+  // Create sources/ dir with a file — its mtime is "now", which is > 2020-01-01.
+  await mkdir(path.join(dir, SOURCES_DIR), { recursive: true });
+  await writeFile(path.join(dir, SOURCES_DIR, "new-source.md"), "# New", "utf-8");
+}
+
+describe("llmwiki next — freshness-cache-stale warning", () => {
+  it("emits freshness-cache-stale when sources/ is newer than the last lint", async () => {
+    await seedStaleFreshnessCache(env.dir);
+
+    const payload = await runNextJson(env.dir);
+    const warnings = payload.warnings as Array<Record<string, unknown>>;
+    expect(warnings.some((w) => w.code === "freshness-cache-stale")).toBe(true);
+  });
+
+  it("does NOT emit freshness-cache-stale when lint cache is recent (no sources/ dir)", async () => {
+    // Seed a lint cache with a recent timestamp (now), but no sources/ dir exists,
+    // so latestSourceMtimeMs is null and the heuristic does not fire.
+    await seedLintCache(env.dir, []);
+
+    const payload = await runNextJson(env.dir);
+    const warnings = payload.warnings as Array<Record<string, unknown>>;
+    expect(warnings.some((w) => w.code === "freshness-cache-stale")).toBe(false);
   });
 });

--- a/test/freshness-next.test.ts
+++ b/test/freshness-next.test.ts
@@ -93,22 +93,23 @@ async function seedStaleFreshnessCache(dir: string): Promise<void> {
   await writeFile(path.join(dir, SOURCES_DIR, "new-source.md"), "# New", "utf-8");
 }
 
+/** Run next --json and return whether warnings include a given code. */
+async function hasWarningCode(dir: string, code: string): Promise<boolean> {
+  const payload = await runNextJson(dir);
+  const warnings = payload.warnings as Array<Record<string, unknown>>;
+  return warnings.some((w) => w.code === code);
+}
+
 describe("llmwiki next — freshness-cache-stale warning", () => {
   it("emits freshness-cache-stale when sources/ is newer than the last lint", async () => {
     await seedStaleFreshnessCache(env.dir);
-
-    const payload = await runNextJson(env.dir);
-    const warnings = payload.warnings as Array<Record<string, unknown>>;
-    expect(warnings.some((w) => w.code === "freshness-cache-stale")).toBe(true);
+    expect(await hasWarningCode(env.dir, "freshness-cache-stale")).toBe(true);
   });
 
   it("does NOT emit freshness-cache-stale when lint cache is recent (no sources/ dir)", async () => {
     // Seed a lint cache with a recent timestamp (now), but no sources/ dir exists,
     // so latestSourceMtimeMs is null and the heuristic does not fire.
     await seedLintCache(env.dir, []);
-
-    const payload = await runNextJson(env.dir);
-    const warnings = payload.warnings as Array<Record<string, unknown>>;
-    expect(warnings.some((w) => w.code === "freshness-cache-stale")).toBe(false);
+    expect(await hasWarningCode(env.dir, "freshness-cache-stale")).toBe(false);
   });
 });

--- a/test/freshness-next.test.ts
+++ b/test/freshness-next.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Subprocess integration tests for freshness-surface behaviour in `llmwiki next`.
+ *
+ * Verifies that stale/orphaned counts from the lint cache appear in the
+ * `--json` envelope and that a corrupt `.llmwiki/state.json` emits the
+ * `state-unreadable` warning rather than being silently swallowed.
+ *
+ * Uses the real `writeLintCache` helper so the lint cache written here
+ * always matches the production contract (including the `freshness` field
+ * added in Task 2).
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdir } from "fs/promises";
+import path from "path";
+import { touchMarkdown, runNextJson, useNextTempDir } from "./fixtures/next-test-helpers.js";
+import { writeCorruptTestStateJson } from "./fixtures/state-json.js";
+import { writeLintCache } from "../src/linter/cache.js";
+import { CONCEPTS_DIR, LLMWIKI_DIR } from "../src/utils/constants.js";
+import type { LintResult } from "../src/linter/types.js";
+
+const env = useNextTempDir("freshness-next");
+
+/** Seed a lint cache for `dir` from the given results, deriving the severity counts. */
+async function seedLintCache(dir: string, results: LintResult[]): Promise<void> {
+  const warnings = results.filter((r) => r.severity === "warning").length;
+  const errors = results.filter((r) => r.severity === "error").length;
+  const info = results.filter((r) => r.severity === "info").length;
+  await mkdir(path.join(dir, LLMWIKI_DIR), { recursive: true });
+  await writeLintCache(dir, { errors, warnings, info, results });
+}
+
+describe("llmwiki next — freshness", () => {
+  it("reports stale/orphaned counts from the lint cache in --json", async () => {
+    await touchMarkdown(path.join(env.dir, CONCEPTS_DIR), "topic.md");
+    await seedLintCache(env.dir, [
+      { rule: "stale-page", severity: "warning", file: "topic.md", message: "stale" },
+    ]);
+
+    const payload = await runNextJson(env.dir);
+    const s = payload.summary as Record<string, unknown>;
+    expect(s.freshness).toEqual({ stalePages: 1, orphanedPages: 0 });
+
+    const warnings = payload.warnings as Array<Record<string, unknown>>;
+    expect(warnings.some((w) => w.code === "stale-pages")).toBe(true);
+  });
+
+  it("emits state-unreadable (not silence) on corrupt state.json", async () => {
+    await touchMarkdown(path.join(env.dir, CONCEPTS_DIR), "topic.md");
+    await writeCorruptTestStateJson(env.dir);
+
+    const payload = await runNextJson(env.dir);
+    const warnings = payload.warnings as Array<Record<string, unknown>>;
+    expect(warnings.some((w) => w.code === "state-unreadable")).toBe(true);
+  });
+
+  it("summary.freshness is null when no lint cache exists", async () => {
+    await touchMarkdown(path.join(env.dir, CONCEPTS_DIR), "topic.md");
+
+    const payload = await runNextJson(env.dir);
+    const s = payload.summary as Record<string, unknown>;
+    expect(s.freshness).toBeNull();
+  });
+
+  it("reports zero counts and no stale-pages warning on a clean lint cache", async () => {
+    await touchMarkdown(path.join(env.dir, CONCEPTS_DIR), "topic.md");
+    await seedLintCache(env.dir, []);
+
+    const payload = await runNextJson(env.dir);
+    const s = payload.summary as Record<string, unknown>;
+    expect(s.freshness).toEqual({ stalePages: 0, orphanedPages: 0 });
+
+    const warnings = payload.warnings as Array<Record<string, unknown>>;
+    expect(warnings.some((w) => w.code === "stale-pages")).toBe(false);
+  });
+});

--- a/test/freshness-readonly.test.ts
+++ b/test/freshness-readonly.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Read-only regression guard: `collectStatus` and `buildViewerSnapshot` must
+ * never trigger a `.bak` write. Since `.bak` is written only by `readState`,
+ * its absence under a corrupt state.json proves these surfaces never call it.
+ *
+ * Why no-bak over vi.spyOn: both surfaces import `readStateClassified`
+ * directly via named ESM binding — they never import `readState` — so a spy
+ * on the module object would trivially pass even if the invariant broke. The
+ * corrupt-state/no-bak check is deterministic and harness-independent.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync } from "fs";
+import { rm } from "fs/promises";
+import path from "path";
+import { collectStatus } from "../src/mcp/status.js";
+import { buildViewerSnapshot } from "../src/viewer/snapshot.js";
+import { makeTempRoot } from "./fixtures/temp-root.js";
+import { writePage } from "./fixtures/write-page.js";
+import { writeCorruptTestStateJson } from "./fixtures/state-json.js";
+import { CONCEPTS_DIR } from "../src/utils/constants.js";
+
+let root: string;
+const bakPath = () => path.join(root, ".llmwiki/state.json.bak");
+
+beforeEach(async () => {
+  root = await makeTempRoot("freshness-readonly");
+  await writePage(path.join(root, CONCEPTS_DIR), "topic", { title: "Topic" }, "Body.");
+  await writeCorruptTestStateJson(root);
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe("read-only surfaces never call readState", () => {
+  it("collectStatus writes no .bak on corrupt state.json", async () => {
+    await collectStatus(root);
+    expect(existsSync(bakPath())).toBe(false);
+  });
+
+  it("buildViewerSnapshot writes no .bak on corrupt state.json", async () => {
+    await buildViewerSnapshot(root);
+    expect(existsSync(bakPath())).toBe(false);
+  });
+});

--- a/test/freshness-viewer.test.ts
+++ b/test/freshness-viewer.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Viewer snapshot freshness integration tests.
+ *
+ * Verifies that `buildViewerSnapshot` attaches computed `PageFreshness` to
+ * each page (via `computeFreshness`) and surfaces aggregate stale/orphaned
+ * counts in `ViewerCounts`. Also confirms that the snapshot uses the
+ * read-only `readStateClassified` path so corrupt state never produces a
+ * `.bak` side-effect.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync } from "fs";
+import { rm } from "fs/promises";
+import path from "path";
+import { makeTempRoot } from "./fixtures/temp-root.js";
+import { writePage } from "./fixtures/write-page.js";
+import {
+  sha256Hex,
+  writeSourceFile,
+  writeSourceState,
+  writeCorruptTestStateJson,
+} from "./fixtures/state-json.js";
+import { buildViewerSnapshot } from "../src/viewer/snapshot.js";
+import { CONCEPTS_DIR } from "../src/utils/constants.js";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await makeTempRoot("freshness-viewer");
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+/** Write a minimal concept page named "topic" into the temp root. */
+async function writeTopic(r: string) {
+  await writePage(path.join(r, CONCEPTS_DIR), "topic", { title: "Topic" }, "Body.");
+}
+
+/** Build snapshot and find the "topic" page in one step. */
+async function buildAndFind(r: string) {
+  const snap = await buildViewerSnapshot(r);
+  return { snap, page: snap.pages.find((p) => p.slug === "topic") };
+}
+
+describe("viewer snapshot freshness", () => {
+  it("marks a page fresh when its source exists and the hash matches", async () => {
+    // State records a.md owning "topic" with the hash of the on-disk content.
+    await writeSourceState(root, { "a.md": { hash: sha256Hex("body"), concepts: ["topic"] } });
+    await writeSourceFile(root, "a.md", "body");
+    await writeTopic(root);
+
+    const { snap, page } = await buildAndFind(root);
+
+    expect(page?.freshness.freshnessStatus).toBe("fresh");
+    expect(snap.counts.stale).toBe(0);
+    expect(snap.counts.orphaned).toBe(0);
+  });
+
+  it("marks a page stale when its source changed", async () => {
+    // State records a.md with OLD hash owning "topic", but disk has NEW content.
+    await writeSourceState(root, { "a.md": { hash: sha256Hex("OLD body"), concepts: ["topic"] } });
+    await writeSourceFile(root, "a.md", "NEW body");
+    await writeTopic(root);
+
+    const { snap, page } = await buildAndFind(root);
+
+    expect(page?.freshness.freshnessStatus).toBe("stale");
+    expect(snap.counts.stale).toBe(1);
+    expect(snap.counts.orphaned).toBe(0);
+  });
+
+  it("marks a page orphaned when all owning sources are deleted", async () => {
+    // State records a.md owning "topic" but the source file does not exist.
+    await writeSourceState(root, { "a.md": { hash: "xyz", concepts: ["topic"] } });
+    await writeTopic(root);
+
+    const { snap, page } = await buildAndFind(root);
+
+    expect(page?.freshness.freshnessStatus).toBe("orphaned");
+    expect(snap.counts.orphaned).toBe(1);
+    expect(snap.counts.stale).toBe(0);
+  });
+
+  it("writes no .bak on corrupt state and marks pages unverified", async () => {
+    await writeTopic(root);
+    await writeCorruptTestStateJson(root);
+
+    const { snap, page } = await buildAndFind(root);
+
+    expect(page?.freshness.freshnessStatus).toBe("unverified");
+    expect(existsSync(path.join(root, ".llmwiki/state.json.bak"))).toBe(false);
+  });
+});

--- a/test/freshness.test.ts
+++ b/test/freshness.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect } from "vitest";
 import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 import { createHash } from "node:crypto";
-import { computeFreshness } from "../src/freshness/index.js";
-import { buildFreshnessSnapshot } from "../src/freshness/index.js";
+import { computeFreshness, buildFreshnessSnapshot } from "../src/freshness/index.js";
 import type { FreshnessSnapshot } from "../src/freshness/types.js";
 import { useLintTempRoot } from "./fixtures/lint-temp-root.js";
-import { writeTestStateJson } from "./fixtures/state-json.js";
+import { writeTestStateJson, writeSourceState, writeSourceFile, sha256Hex } from "./fixtures/state-json.js";
+import { readStateClassified } from "../src/utils/state.js";
 
 function snapshot(sources: FreshnessSnapshot["sources"], stateStatus: FreshnessSnapshot["stateStatus"] = "ok"): FreshnessSnapshot {
   return { stateStatus, sources };
@@ -103,5 +103,18 @@ describe("buildFreshnessSnapshot", () => {
     const snap = await buildFreshnessSnapshot(env.dir);
     expect(snap.stateStatus).toBe("missing");
     expect(snap.sources).toEqual({});
+  });
+
+  it("reuses a supplied ClassifiedState instead of re-reading", async () => {
+    await writeSourceState(env.dir, { "a.md": { hash: sha256Hex("x"), concepts: ["topic"] } });
+    await writeSourceFile(env.dir, "a.md", "x");
+
+    const classified = await readStateClassified(env.dir);
+    // Mutate state.json on disk AFTER reading; the snapshot must reflect the
+    // supplied (pre-mutation) classified state, proving it did not re-read.
+    await writeSourceState(env.dir, { "b.md": { hash: sha256Hex("y"), concepts: ["other"] } });
+
+    const snap = await buildFreshnessSnapshot(env.dir, classified);
+    expect(Object.keys(snap.sources)).toEqual(["a.md"]);
   });
 });

--- a/test/freshness.test.ts
+++ b/test/freshness.test.ts
@@ -117,4 +117,27 @@ describe("buildFreshnessSnapshot", () => {
     const snap = await buildFreshnessSnapshot(env.dir, classified);
     expect(Object.keys(snap.sources)).toEqual(["a.md"]);
   });
+
+  it("treats path-traversal keys as not-exists without throwing or reading outside sources/", async () => {
+    // State contains a traversal key and a normal key.
+    await writeSourceState(env.dir, {
+      "../escape.md": { hash: "X", concepts: ["escape"] },
+      "normal.md": { hash: sha256Hex("normal"), concepts: ["normal"] },
+    });
+    await writeSourceFile(env.dir, "normal.md", "normal");
+    // Write a file at the traversal destination to prove it is NOT read.
+    const { writeFile: wf } = await import("fs/promises");
+    await wf(path.join(env.dir, "escape.md"), "outside-sources", "utf-8");
+
+    const snap = await buildFreshnessSnapshot(env.dir);
+
+    // Traversal key: treated as non-existent, no throw.
+    expect(snap.sources["../escape.md"]).toEqual(
+      expect.objectContaining({ exists: false, currentHash: null }),
+    );
+    // Normal key: classified correctly.
+    expect(snap.sources["normal.md"]).toEqual(
+      expect.objectContaining({ exists: true, currentHash: sha256Hex("normal") }),
+    );
+  });
 });

--- a/test/freshness.test.ts
+++ b/test/freshness.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { mkdir, writeFile } from "fs/promises";
+import { mkdir, writeFile, symlink } from "fs/promises";
 import path from "path";
 import { createHash } from "node:crypto";
 import { computeFreshness, buildFreshnessSnapshot } from "../src/freshness/index.js";
@@ -116,6 +116,40 @@ describe("buildFreshnessSnapshot", () => {
 
     const snap = await buildFreshnessSnapshot(env.dir, classified);
     expect(Object.keys(snap.sources)).toEqual(["a.md"]);
+  });
+
+  it("treats a symlink that escapes sources/ as not-exists (defense-in-depth)", async () => {
+    // Write a file outside sources/ that a symlink inside sources/ would target.
+    const outsidePath = path.join(env.dir, "outside.md");
+    await writeFile(outsidePath, "secret content", "utf-8");
+    await mkdir(path.join(env.dir, "sources"), { recursive: true });
+    const symlinkPath = path.join(env.dir, "sources", "evil.md");
+    let symlinkCreated = false;
+    try {
+      await symlink(outsidePath, symlinkPath);
+      symlinkCreated = true;
+    } catch {
+      // Symlink creation not permitted in this environment — skip gracefully.
+    }
+    if (!symlinkCreated) return;
+
+    const normalContent = "normal content";
+    await writeSourceState(env.dir, {
+      "evil.md": { hash: sha256Hex("secret content"), concepts: ["evil"] },
+      "normal.md": { hash: sha256Hex(normalContent), concepts: ["normal"] },
+    });
+    await writeSourceFile(env.dir, "normal.md", normalContent);
+
+    const snap = await buildFreshnessSnapshot(env.dir);
+
+    // Symlink escaping sources/ must be treated as not-exists, never hashed.
+    expect(snap.sources["evil.md"]).toEqual(
+      expect.objectContaining({ exists: false, currentHash: null }),
+    );
+    // Normal file still classifies correctly.
+    expect(snap.sources["normal.md"]).toEqual(
+      expect.objectContaining({ exists: true, currentHash: sha256Hex(normalContent) }),
+    );
   });
 
   it("treats path-traversal keys as not-exists without throwing or reading outside sources/", async () => {

--- a/test/lint-cache.test.ts
+++ b/test/lint-cache.test.ts
@@ -64,6 +64,21 @@ describe("writeLintCache", () => {
     expect(parsed.errors).toBe(0);
     expect(parsed.warnings).toBe(0);
   });
+
+  it("persists freshness counts derived from the results to disk", async () => {
+    await writeLintCache(tmpDir, {
+      errors: 0,
+      warnings: 3,
+      info: 0,
+      results: [
+        { rule: "stale-page", severity: "warning", file: "a.md", message: "" },
+        { rule: "stale-page", severity: "warning", file: "b.md", message: "" },
+        { rule: "orphaned-page", severity: "warning", file: "c.md", message: "" },
+      ],
+    });
+    const parsed = JSON.parse(await readRawCache()) as Record<string, unknown>;
+    expect(parsed.freshness).toEqual({ stalePages: 2, orphanedPages: 1 });
+  });
 });
 
 describe("readLintCache", () => {
@@ -117,6 +132,39 @@ describe("readLintCache", () => {
     await writeRawCache(JSON.stringify({ warnings: 0, errors: 0, at: "" }));
     expect(await readLintCache(tmpDir)).toBeNull();
     await writeRawCache(JSON.stringify({ warnings: 0, errors: 0, at: "2026-05-11T00:00:00Z" }));
+    expect(await readLintCache(tmpDir)).toBeNull();
+  });
+});
+
+describe("freshness counts", () => {
+  it("persists and reads back freshness counts", async () => {
+    await writeLintCache(tmpDir, {
+      errors: 0,
+      warnings: 2,
+      info: 0,
+      results: [
+        { rule: "stale-page", severity: "warning", file: "a.md", message: "" },
+        { rule: "orphaned-page", severity: "warning", file: "b.md", message: "" },
+      ],
+    });
+    const entry = await readLintCache(tmpDir);
+    expect(entry?.freshness).toEqual({ stalePages: 1, orphanedPages: 1 });
+  });
+
+  it("reads a pre-upgrade cache (no freshness field) as undefined", async () => {
+    await writeRawCache(JSON.stringify({ warnings: 0, errors: 0, at: "2026-06-05T00:00:00.000Z" }));
+    const entry = await readLintCache(tmpDir);
+    expect(entry?.freshness).toBeUndefined();
+  });
+
+  it("rejects the whole entry when freshness is present but malformed", async () => {
+    const bad = JSON.stringify({
+      warnings: 0,
+      errors: 0,
+      at: "2026-06-05T00:00:00.000Z",
+      freshness: { stalePages: "bad", orphanedPages: 1 },
+    });
+    await writeRawCache(bad);
     expect(await readLintCache(tmpDir)).toBeNull();
   });
 });

--- a/test/mcp-context.test.ts
+++ b/test/mcp-context.test.ts
@@ -30,6 +30,11 @@ import {
   snapshotWorkspace,
   useMcpRoot,
 } from "./fixtures/mcp-test-env.js";
+import {
+  sha256Hex,
+  writeSourceFile,
+  writeSourceState,
+} from "./fixtures/state-json.js";
 
 const rootHandle = useMcpRoot("llmwiki-mcp-context");
 const rootOf = (): string => rootHandle.value;
@@ -186,5 +191,28 @@ describe("get_context_pack tool", () => {
     await callTool(server, "get_context_pack", { prompt: "alpha" });
     const afterFiles = await snapshotWorkspace(root);
     expect(afterFiles).toEqual(beforeFiles);
+  });
+
+  it("get_context_pack surfaces freshnessStatus on primary pages", async () => {
+    const root = rootOf();
+    // State records OLD hash; disk has NEW content → stale
+    await writeSourceState(root, {
+      "a.md": { hash: sha256Hex("OLD body"), concepts: ["topic"] },
+    });
+    await writeSourceFile(root, "a.md", "NEW body");
+    await writePage(
+      path.join(root, "wiki/concepts"),
+      "topic",
+      { title: "Topic", summary: "The topic page" },
+      "A topic page body.",
+    );
+    const server = buildServer(root);
+    const result = await callTool(server, "get_context_pack", { prompt: "topic" });
+    const pack = result.structuredContent?.result as {
+      primary: Array<{ id: string; freshnessStatus: string }>;
+    };
+    const primary = pack.primary.find((p) => p.id.endsWith("topic"));
+    expect(primary).toBeDefined();
+    expect(primary?.freshnessStatus).toBe("stale");
   });
 });

--- a/test/next-integration.test.ts
+++ b/test/next-integration.test.ts
@@ -14,12 +14,16 @@
  *   - human output never trips an ANSI escape into the JSON path
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, mkdir, rm, writeFile } from "fs/promises";
-import os from "os";
+import { describe, it, expect } from "vitest";
+import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 import { runCLI, expectCLIExit } from "./fixtures/run-cli.js";
 import { expectFreshDirUnchanged } from "./fixtures/project-state-helpers.js";
+import {
+  touchMarkdown,
+  runNextJson,
+  useNextTempDir,
+} from "./fixtures/next-test-helpers.js";
 import {
   SOURCES_DIR,
   CONCEPTS_DIR,
@@ -28,21 +32,7 @@ import {
   CANDIDATES_DIR,
 } from "../src/utils/constants.js";
 
-let tmpDir: string;
-
-beforeEach(async () => {
-  tmpDir = await mkdtemp(path.join(os.tmpdir(), "next-cli-"));
-});
-
-afterEach(async () => {
-  await rm(tmpDir, { recursive: true, force: true });
-});
-
-/** Ensure `dir` exists and write a tiny markdown file inside it. */
-async function touchMarkdown(dir: string, name: string): Promise<void> {
-  await mkdir(dir, { recursive: true });
-  await writeFile(path.join(dir, name), "# stub", "utf-8");
-}
+const env = useNextTempDir("next-cli");
 
 /** Seed a candidate file directly so we don't depend on the compile pipeline. */
 async function seedCandidate(root: string, id: string): Promise<void> {
@@ -66,22 +56,15 @@ async function seedLintCache(root: string, errors: number, warnings: number): Pr
   await writeFile(path.join(root, LAST_LINT_FILE), JSON.stringify(entry), "utf-8");
 }
 
-/** Run `llmwiki next --json` in `dir`, assert exit 0, return the parsed payload. */
-async function runNextJson(dir: string): Promise<Record<string, unknown>> {
-  const result = await runCLI(["next", "--json"], dir);
-  expectCLIExit(result, 0);
-  return JSON.parse(result.stdout) as Record<string, unknown>;
-}
-
 describe("`llmwiki next --json` — JSON envelope", () => {
   it("returns version 1 and state=fresh in an empty directory", async () => {
-    const payload = await runNextJson(tmpDir);
+    const payload = await runNextJson(env.dir);
     expect(payload.version).toBe(1);
     expect(payload.state).toBe("fresh");
   });
 
   it("recommends quickstart with `source` placeholder for a fresh dir", async () => {
-    const payload = await runNextJson(tmpDir);
+    const payload = await runNextJson(env.dir);
     const recommended = payload.recommended as Record<string, unknown>;
     const executable = recommended.executable as Record<string, unknown>;
     expect(executable.args).toEqual(["quickstart"]);
@@ -89,34 +72,37 @@ describe("`llmwiki next --json` — JSON envelope", () => {
   });
 
   it("classifies seeded sources as `sources-only`", async () => {
-    await touchMarkdown(path.join(tmpDir, SOURCES_DIR), "a.md");
-    expect((await runNextJson(tmpDir)).state).toBe("sources-only");
+    await touchMarkdown(path.join(env.dir, SOURCES_DIR), "a.md");
+    expect((await runNextJson(env.dir)).state).toBe("sources-only");
   });
 
   it("classifies seeded wiki pages as `wiki-ready`", async () => {
-    await touchMarkdown(path.join(tmpDir, CONCEPTS_DIR), "a.md");
-    expect((await runNextJson(tmpDir)).state).toBe("wiki-ready");
+    await touchMarkdown(path.join(env.dir, CONCEPTS_DIR), "a.md");
+    const payload = await runNextJson(env.dir);
+    expect(payload.state).toBe("wiki-ready");
+    expect((payload.summary as Record<string, unknown>).freshness).toBeNull();
   });
 
   it("classifies a seeded pending candidate as `review-pending`", async () => {
-    await touchMarkdown(path.join(tmpDir, CONCEPTS_DIR), "a.md");
-    await seedCandidate(tmpDir, "candidate-aabbccdd");
-    expect((await runNextJson(tmpDir)).state).toBe("review-pending");
+    await touchMarkdown(path.join(env.dir, CONCEPTS_DIR), "a.md");
+    await seedCandidate(env.dir, "candidate-aabbccdd");
+    expect((await runNextJson(env.dir)).state).toBe("review-pending");
   });
 
   it("classifies a lint cache with errors as `lint-attention`", async () => {
-    await touchMarkdown(path.join(tmpDir, CONCEPTS_DIR), "a.md");
-    await seedLintCache(tmpDir, 3, 1);
-    const payload = await runNextJson(tmpDir);
+    await touchMarkdown(path.join(env.dir, CONCEPTS_DIR), "a.md");
+    await seedLintCache(env.dir, 3, 1);
+    const payload = await runNextJson(env.dir);
     expect(payload.state).toBe("lint-attention");
     const summary = payload.summary as Record<string, unknown>;
     expect(summary.hasLintCache).toBe(true);
     expect(summary.lint).toEqual({ warnings: 1, errors: 3, at: expect.any(String) });
+    expect(summary.freshness).toBeNull();
   });
 
   it("emits no ANSI escapes in JSON output", async () => {
-    await touchMarkdown(path.join(tmpDir, CONCEPTS_DIR), "a.md");
-    const result = await runCLI(["next", "--json"], tmpDir);
+    await touchMarkdown(path.join(env.dir, CONCEPTS_DIR), "a.md");
+    const result = await runCLI(["next", "--json"], env.dir);
     expectCLIExit(result, 0);
     // eslint-disable-next-line no-control-regex
     expect(result.stdout).not.toMatch(/\x1b\[/);
@@ -126,21 +112,21 @@ describe("`llmwiki next --json` — JSON envelope", () => {
 
 describe("`llmwiki next` — never mutates the project directory", () => {
   it("does not create .llmwiki/ in a fresh directory", async () => {
-    const result = await runCLI(["next"], tmpDir);
+    const result = await runCLI(["next"], env.dir);
     expectCLIExit(result, 0);
-    await expectFreshDirUnchanged(tmpDir);
+    await expectFreshDirUnchanged(env.dir);
   });
 
   it("does not create .llmwiki/ when --json is requested either", async () => {
-    const result = await runCLI(["next", "--json"], tmpDir);
+    const result = await runCLI(["next", "--json"], env.dir);
     expectCLIExit(result, 0);
-    await expectFreshDirUnchanged(tmpDir);
+    await expectFreshDirUnchanged(env.dir);
   });
 });
 
 describe("`llmwiki next` — human renderer", () => {
   it("prints the header, project line, and recommended action for a fresh dir", async () => {
-    const result = await runCLI(["next"], tmpDir);
+    const result = await runCLI(["next"], env.dir);
     expectCLIExit(result, 0);
     expect(result.stdout).toContain("llmwiki next");
     expect(result.stdout).toContain("Project: ");
@@ -149,9 +135,9 @@ describe("`llmwiki next` — human renderer", () => {
   });
 
   it("prints a review-pending summary line when candidates exist", async () => {
-    await touchMarkdown(path.join(tmpDir, CONCEPTS_DIR), "a.md");
-    await seedCandidate(tmpDir, "candidate-aabbccdd");
-    const result = await runCLI(["next"], tmpDir);
+    await touchMarkdown(path.join(env.dir, CONCEPTS_DIR), "a.md");
+    await seedCandidate(env.dir, "candidate-aabbccdd");
+    const result = await runCLI(["next"], env.dir);
     expectCLIExit(result, 0);
     expect(result.stdout).toMatch(/review pending, 1 candidate\b/);
     expect(result.stdout).toContain("llmwiki review list");

--- a/test/viewer-health-dashboard.test.ts
+++ b/test/viewer-health-dashboard.test.ts
@@ -1,0 +1,73 @@
+/**
+ * DOM-level tests for the health dashboard pane rendered by viewer.js.
+ *
+ * Navigates to `#/health` via the JSDOM harness and asserts that the
+ * stale and orphaned row counts from `/api/health` are visible in the
+ * rendered `<dl class="metric-list">`.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  flushMicrotasks,
+  jsonResponse,
+  mountViewerDom,
+  type EmbeddedPage,
+  type FetchResponder,
+} from "./fixtures/viewer-jsdom.js";
+
+const EMPTY_PAGES: EmbeddedPage[] = [];
+
+/** Build a fetch responder that serves the given health payload. */
+function healthResponder(health: Record<string, unknown>): FetchResponder {
+  return (url) => {
+    if (url.endsWith("/api/pages")) {
+      return jsonResponse({ project: { title: "demo" }, counts: {}, pages: [], recentPages: [], index: { available: false } });
+    }
+    if (url.endsWith("/api/health")) return jsonResponse(health);
+    return null;
+  };
+}
+
+/** Mount the viewer, navigate to #/health, and return the main pane element. */
+async function renderHealthPane(health: Record<string, unknown>): Promise<HTMLElement> {
+  const { dom } = await mountViewerDom(EMPTY_PAGES, healthResponder(health));
+  dom.window.location.hash = "#/health";
+  await flushMicrotasks();
+  return dom.window.document.querySelector("[data-main-pane]") as HTMLElement;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("health dashboard — stale and orphaned counts", () => {
+  it("renders the 'Stale pages' row with the count from /api/health", async () => {
+    const main = await renderHealthPane({ stale: 3, orphaned: 0 });
+    expect(main.textContent).toContain("Stale pages");
+    expect(main.textContent).toContain("3");
+  });
+
+  it("renders the 'Orphaned pages' row with the count from /api/health", async () => {
+    const main = await renderHealthPane({ stale: 0, orphaned: 1 });
+    expect(main.textContent).toContain("Orphaned pages");
+    expect(main.textContent).toContain("1");
+  });
+
+  it("renders both stale and orphaned counts together", async () => {
+    const main = await renderHealthPane({ stale: 2, orphaned: 1 });
+    const metrics = main.querySelector(".metric-list") as HTMLElement;
+    const dtElements = Array.from(metrics.querySelectorAll("dt")).map((dt) => dt.textContent);
+    expect(dtElements).toContain("Stale pages");
+    expect(dtElements).toContain("Orphaned pages");
+    // Verify the values are in corresponding <dd> elements.
+    const ddElements = Array.from(metrics.querySelectorAll("dd")).map((dd) => dd.textContent);
+    expect(ddElements).toContain("2");
+    expect(ddElements).toContain("1");
+  });
+
+  it("defaults to 0 for stale and orphaned when absent from health response", async () => {
+    const main = await renderHealthPane({});
+    expect(main.textContent).toContain("Stale pages");
+    expect(main.textContent).toContain("Orphaned pages");
+  });
+});

--- a/test/viewer-health.test.ts
+++ b/test/viewer-health.test.ts
@@ -1,5 +1,6 @@
 /**
- * Count parity between `/api/health` and MCP `wiki_status`.
+ * Count parity between `/api/health` and MCP `wiki_status`, plus
+ * stateStatus surfacing for the corrupt-state banner.
  *
  * The two surfaces serve different envelopes — MCP returns
  * `{ pages: { concepts, queries, total }, sources, pendingCandidates, ... }`,
@@ -16,6 +17,7 @@ import { describe, it, expect } from "vitest";
 import path from "path";
 import { makeTempRoot } from "./fixtures/temp-root.js";
 import { writePage } from "./fixtures/write-page.js";
+import { writeCorruptTestStateJson, writeSourceState } from "./fixtures/state-json.js";
 import {
   useViewerProcessLifecycle,
   type ViewerProcessHandle,
@@ -33,6 +35,7 @@ interface ViewerHealth {
   sources: number;
   sourceFiles: number;
   pendingReviews: number;
+  stateStatus: "ok" | "missing" | "corrupt";
   lint: unknown;
 }
 
@@ -70,5 +73,35 @@ describe("/api/health count parity vs MCP wiki_status helpers", () => {
     const handle = await startViewer(root);
     const health = await fetchHealth(handle);
     expect(health.lint).toBeNull();
+  });
+});
+
+describe("/api/health stateStatus", () => {
+  it("returns stateStatus: ok for a project with valid state.json", async () => {
+    const root = await makeTempRoot("viewer-health-statestatus-ok");
+    await writePage(path.join(root, "wiki/concepts"), "alpha", { title: "Alpha" }, "Body.");
+    // Write a minimal valid state.json so readStateClassified returns "ok".
+    await writeSourceState(root, {});
+    const handle = await startViewer(root);
+    const health = await fetchHealth(handle);
+    expect(health.stateStatus).toBe("ok");
+  });
+
+  it("returns stateStatus: missing for a project with no state.json", async () => {
+    const root = await makeTempRoot("viewer-health-statestatus-missing");
+    await writePage(path.join(root, "wiki/concepts"), "alpha", { title: "Alpha" }, "Body.");
+    // No state.json written — freshness-viewer fixture confirms missing → unverified pages.
+    const handle = await startViewer(root);
+    const health = await fetchHealth(handle);
+    expect(health.stateStatus).toBe("missing");
+  });
+
+  it("returns stateStatus: corrupt for a project with corrupt state.json", async () => {
+    const root = await makeTempRoot("viewer-health-statestatus-corrupt");
+    await writePage(path.join(root, "wiki/concepts"), "alpha", { title: "Alpha" }, "Body.");
+    await writeCorruptTestStateJson(root);
+    const handle = await startViewer(root);
+    const health = await fetchHealth(handle);
+    expect(health.stateStatus).toBe("corrupt");
   });
 });

--- a/test/viewer-rail.test.ts
+++ b/test/viewer-rail.test.ts
@@ -1,10 +1,11 @@
 /**
- * Support-rail + sidebar-grouping + stale-rail-clearing tests.
+ * Support-rail + sidebar-grouping + stale-rail-clearing + freshness-badge tests.
  *
  * Mounts the real viewer assets through `mountViewerDom` and drives
  * hash-route navigation to assert the right metadata renders on the
  * right route. Covers every Slice-5 review finding that touches the
- * client's right-hand rail or the sidebar group structure.
+ * client's right-hand rail or the sidebar group structure, plus the
+ * Slice-9 freshness badges and the "Freshness as of…" caption.
  */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -267,5 +268,107 @@ describe("stale support rail clearing", () => {
   it("clears the rail when navigating to a 404 page", async () => {
     const rail = await loadStickyPageAndNavigate("#/concepts/ghost");
     expect(rail.textContent ?? "").not.toContain("sticky-marker");
+  });
+});
+
+// --- Freshness badge tests ---
+
+/** Build a page payload carrying the given freshness object. */
+function freshnessPagePayload(slug: string, freshness: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: `concepts/${slug}`,
+    pageDirectory: "concepts",
+    slug,
+    title: slug,
+    html: "<p>Body</p>",
+    citations: [],
+    outgoingLinks: [],
+    frontmatter: {},
+    warnings: [],
+    updatedAt: "",
+    createdAt: "",
+    generatedAt: "2026-05-14T00:00:00.000Z",
+    freshness,
+  };
+}
+
+/** Navigate to a concepts page with the given freshness and return the rail. */
+async function railForFreshness(slug: string, freshness: Record<string, unknown>): Promise<HTMLElement> {
+  const embedded: EmbeddedPage[] = [
+    { id: `concepts/${slug}`, pageDirectory: "concepts", slug, title: slug, kind: "concept" },
+  ];
+  const responder: FetchResponder = (url) => {
+    if (url.endsWith("/api/pages")) return pagesResponse(embedded);
+    if (url.includes(`/api/page/concepts/${slug}`)) {
+      return jsonResponse(freshnessPagePayload(slug, freshness));
+    }
+    return null;
+  };
+  const { dom } = await mountViewerDom(embedded, responder);
+  dom.window.location.hash = `#/concepts/${slug}`;
+  await flushMicrotasks();
+  return dom.window.document.querySelector("[data-support-rail]") as HTMLElement;
+}
+
+describe("freshness badges", () => {
+  it("renders .badge-stale for a stale page", async () => {
+    const rail = await railForFreshness("stale-page", {
+      freshnessStatus: "stale", contradicted: false, archived: false,
+    });
+    expect(rail.querySelector(".badge-stale")).not.toBeNull();
+    expect(rail.querySelector(".badge-orphaned")).toBeNull();
+  });
+
+  it("renders .badge-orphaned for an orphaned page", async () => {
+    const rail = await railForFreshness("orphaned-page", {
+      freshnessStatus: "orphaned", contradicted: false, archived: false,
+    });
+    expect(rail.querySelector(".badge-orphaned")).not.toBeNull();
+    expect(rail.querySelector(".badge-stale")).toBeNull();
+  });
+
+  it("renders .badge-contradicted for a contradicted page", async () => {
+    const rail = await railForFreshness("contradicted-page", {
+      freshnessStatus: "fresh", contradicted: true, archived: false,
+    });
+    expect(rail.querySelector(".badge-contradicted")).not.toBeNull();
+  });
+
+  it("renders .badge-archived for an archived page", async () => {
+    const rail = await railForFreshness("archived-page", {
+      freshnessStatus: "fresh", contradicted: false, archived: true,
+    });
+    expect(rail.querySelector(".badge-archived")).not.toBeNull();
+  });
+
+  it("renders NO freshness badge for a fresh page", async () => {
+    const rail = await railForFreshness("fresh-page", {
+      freshnessStatus: "fresh", contradicted: false, archived: false,
+    });
+    expect(rail.querySelector(".freshness-badge")).toBeNull();
+  });
+
+  it("renders NO freshness badge for an unverified (query/hand-authored) page", async () => {
+    const rail = await railForFreshness("unverified-page", {
+      freshnessStatus: "unverified", contradicted: false, archived: false,
+    });
+    expect(rail.querySelector(".freshness-badge")).toBeNull();
+  });
+
+  it("shows the 'Freshness as of' caption when generatedAt is present", async () => {
+    const rail = await railForFreshness("any-page", {
+      freshnessStatus: "fresh", contradicted: false, archived: false,
+    });
+    expect(rail.querySelector(".freshness-caption")).not.toBeNull();
+    expect(rail.textContent).toContain("Freshness as of");
+    expect(rail.textContent).toContain("2026-05-14T00:00:00.000Z");
+  });
+
+  it("stale+contradicted page shows both badges independently", async () => {
+    const rail = await railForFreshness("multi-badge-page", {
+      freshnessStatus: "stale", contradicted: true, archived: false,
+    });
+    expect(rail.querySelector(".badge-stale")).not.toBeNull();
+    expect(rail.querySelector(".badge-contradicted")).not.toBeNull();
   });
 });

--- a/test/viewer-server.test.ts
+++ b/test/viewer-server.test.ts
@@ -16,6 +16,11 @@ import { makeTempRoot } from "./fixtures/temp-root.js";
 import { writePage } from "./fixtures/write-page.js";
 import { makeOutsideDir } from "./fixtures/outside-dir.js";
 import {
+  sha256Hex,
+  writeSourceFile,
+  writeSourceState,
+} from "./fixtures/state-json.js";
+import {
   startViewerCLI,
   useViewerProcessLifecycle,
   type ViewerProcessHandle,
@@ -287,5 +292,56 @@ describe("llmwiki view — privacy gate", () => {
     const root = await makeTempRoot("viewer-server-lan-only");
     const handle = startViewerCLI(["--allow-lan", "--port", "0"], root);
     await expect(handle).rejects.toThrow(/exited before ready/);
+  });
+});
+
+describe("llmwiki view — freshness serialization", () => {
+  const { start: startViewer } = useViewerProcessLifecycle();
+
+  /** Spin up a viewer with one stale "topic" concept and return the handle. */
+  async function startWithStaleTopic(label: string): Promise<ViewerProcessHandle> {
+    const root = await makeTempRoot(label);
+    await writePage(path.join(root, "wiki/concepts"), "topic", { title: "Topic" }, "Body.");
+    // OLD hash in state + NEW content on disk → stale at snapshot build time.
+    await writeSourceState(root, { "a.md": { hash: sha256Hex("OLD"), concepts: ["topic"] } });
+    await writeSourceFile(root, "a.md", "NEW");
+    return startViewer(root);
+  }
+
+  it("/api/pages row carries freshness.freshnessStatus for a stale page", async () => {
+    const handle = await startWithStaleTopic("viewer-freshness-pages-row");
+    const { status, body } = await fetchJson(handle, "/api/pages");
+    expect(status).toBe(200);
+    const pages = (body as { pages: Array<Record<string, unknown>> }).pages;
+    const row = pages.find((p) => p.slug === "topic");
+    expect(row).toBeDefined();
+    const freshness = row?.freshness as { freshnessStatus: string };
+    expect(freshness.freshnessStatus).toBe("stale");
+  });
+
+  it("/api/page payload carries freshness.freshnessStatus for a stale page", async () => {
+    const handle = await startWithStaleTopic("viewer-freshness-page-payload");
+    const { status, body } = await fetchJson(handle, "/api/page/concepts/topic");
+    expect(status).toBe(200);
+    const page = body as Record<string, unknown>;
+    const freshness = page.freshness as { freshnessStatus: string };
+    expect(freshness.freshnessStatus).toBe("stale");
+  });
+
+  it("/api/health carries stale and orphaned counts matching the snapshot", async () => {
+    const root = await makeTempRoot("viewer-freshness-health-counts");
+    await writePage(path.join(root, "wiki/concepts"), "stale-page", { title: "Stale" }, "Body.");
+    await writePage(path.join(root, "wiki/concepts"), "orphan-page", { title: "Orphan" }, "Body.");
+    // stale-page: source exists but hash mismatches.
+    await writeSourceState(root, {
+      "a.md": { hash: sha256Hex("OLD"), concepts: ["stale-page"] },
+      "b.md": { hash: "any", concepts: ["orphan-page"] },
+    });
+    await writeSourceFile(root, "a.md", "NEW"); // b.md intentionally absent → orphaned
+    const handle = await startViewer(root);
+    const { body } = await fetchJson(handle, "/api/health");
+    const health = body as { stale: number; orphaned: number };
+    expect(health.stale).toBe(1);
+    expect(health.orphaned).toBe(1);
   });
 });

--- a/test/viewer-server.test.ts
+++ b/test/viewer-server.test.ts
@@ -19,6 +19,7 @@ import {
   sha256Hex,
   writeSourceFile,
   writeSourceState,
+  writeCorruptTestStateJson,
 } from "./fixtures/state-json.js";
 import {
   startViewerCLI,
@@ -292,6 +293,28 @@ describe("llmwiki view — privacy gate", () => {
     const root = await makeTempRoot("viewer-server-lan-only");
     const handle = startViewerCLI(["--allow-lan", "--port", "0"], root);
     await expect(handle).rejects.toThrow(/exited before ready/);
+  });
+});
+
+describe("llmwiki view — stateStatus in /api/pages", () => {
+  const { start: startViewer } = useViewerProcessLifecycle();
+
+  it("/api/pages includes stateStatus in the envelope (ok or missing, never absent)", async () => {
+    const root = await makeTempRoot("viewer-pages-statestatus-present");
+    const handle = await startViewer(root);
+    const { status, body } = await fetchJson(handle, "/api/pages");
+    expect(status).toBe(200);
+    const stateStatus = (body as Record<string, unknown>).stateStatus;
+    expect(["ok", "missing", "corrupt"]).toContain(stateStatus);
+  });
+
+  it("/api/pages includes stateStatus: corrupt for a corrupt state.json", async () => {
+    const root = await makeTempRoot("viewer-pages-statestatus-corrupt");
+    await writeCorruptTestStateJson(root);
+    const handle = await startViewer(root);
+    const { status, body } = await fetchJson(handle, "/api/pages");
+    expect(status).toBe(200);
+    expect((body as Record<string, unknown>).stateStatus).toBe("corrupt");
   });
 });
 

--- a/test/viewer-sidebar.test.ts
+++ b/test/viewer-sidebar.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Sidebar freshness-filter + corrupt-state-banner DOM tests.
+ *
+ * Mounts the real viewer assets through `mountViewerDom` and exercises
+ * the Slice-9 client surfaces that live in `viewer-sidebar.js` and
+ * `viewer.js`: the per-axis freshness `<select>` filter that narrows the
+ * loaded `/api/pages` rows client-side, and the corrupt-state banner the
+ * health dashboard renders when `/api/health.stateStatus === "corrupt"`.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  flushMicrotasks,
+  jsonResponse,
+  mountViewerDom,
+  type EmbeddedPage,
+  type FetchResponder,
+} from "./fixtures/viewer-jsdom.js";
+
+const PAGES_BASE = {
+  project: { title: "demo", rootName: "demo" },
+  counts: { concepts: 5, queries: 0, sourceFiles: 0, pendingReviews: 0 },
+  index: { available: false, href: "/#/index" },
+  recentPages: [],
+  updatedAt: "2026-05-14T00:00:00.000Z",
+};
+
+/** Freshness object shape carried on each `/api/pages` row. */
+interface Freshness {
+  freshnessStatus: "fresh" | "stale" | "orphaned" | "unverified";
+  contradicted: boolean;
+  archived: boolean;
+}
+
+/** A `/api/pages` row carrying freshness — superset of the embedded blob row. */
+interface PageRow extends EmbeddedPage {
+  freshness: Freshness;
+}
+
+/** Build a concepts row with the given slug + freshness. */
+function row(slug: string, freshness: Freshness): PageRow {
+  return {
+    id: `concepts/${slug}`,
+    pageDirectory: "concepts",
+    slug,
+    title: slug,
+    kind: "concept",
+    freshness,
+  };
+}
+
+const STALE = { freshnessStatus: "stale", contradicted: false, archived: false } as const;
+const ORPHANED = { freshnessStatus: "orphaned", contradicted: false, archived: false } as const;
+const FRESH = { freshnessStatus: "fresh", contradicted: false, archived: false } as const;
+const CONTRADICTED = { freshnessStatus: "fresh", contradicted: true, archived: false } as const;
+const ARCHIVED = { freshnessStatus: "fresh", contradicted: false, archived: true } as const;
+
+/** A mixed set of pages spanning every freshness axis. */
+const MIXED_ROWS: PageRow[] = [
+  row("stale-page", STALE),
+  row("orphaned-page", ORPHANED),
+  row("fresh-page", FRESH),
+  row("contradicted-page", CONTRADICTED),
+  row("archived-page", ARCHIVED),
+];
+
+/** Responder serving `/api/pages` with the given rows; everything else 404s. */
+function pagesResponderFor(rows: PageRow[]): FetchResponder {
+  return (url) => {
+    if (url.endsWith("/api/pages")) return jsonResponse({ ...PAGES_BASE, pages: rows });
+    return null;
+  };
+}
+
+/** Collect the slugs of every page `<li>` currently shown in the sidebar. */
+function visibleSlugs(dom: import("jsdom").JSDOM): string[] {
+  const links = dom.window.document.querySelectorAll(
+    "[data-sidebar] details[data-kind] li a[data-page-id]",
+  );
+  return Array.from(links).map((a) => (a as HTMLAnchorElement).dataset.pageId ?? "");
+}
+
+/** Fire a `change` event on the freshness `<select>` after setting its value. */
+function selectFilter(dom: import("jsdom").JSDOM, value: string): void {
+  const select = dom.window.document.querySelector(
+    "#freshness-filter-select",
+  ) as HTMLSelectElement;
+  select.value = value;
+  select.dispatchEvent(new dom.window.Event("change"));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("sidebar freshness filter", () => {
+  it("renders the filter <select> with every axis option", async () => {
+    const { dom } = await mountViewerDom(MIXED_ROWS, pagesResponderFor(MIXED_ROWS));
+    await flushMicrotasks();
+    const options = dom.window.document.querySelectorAll("#freshness-filter-select option");
+    const values = Array.from(options).map((o) => (o as HTMLOptionElement).value);
+    expect(values).toEqual(["all", "stale", "orphaned", "contradicted", "archived"]);
+  });
+
+  it("narrows to only the stale page when 'stale' is selected, then restores on 'all'", async () => {
+    const { dom } = await mountViewerDom(MIXED_ROWS, pagesResponderFor(MIXED_ROWS));
+    await flushMicrotasks();
+    expect(visibleSlugs(dom).length).toBe(5);
+
+    selectFilter(dom, "stale");
+    await flushMicrotasks();
+    expect(visibleSlugs(dom)).toEqual(["concepts/stale-page"]);
+
+    selectFilter(dom, "all");
+    await flushMicrotasks();
+    expect(visibleSlugs(dom).length).toBe(5);
+  });
+
+  it("narrows to only the contradicted page when 'contradicted' is selected", async () => {
+    const { dom } = await mountViewerDom(MIXED_ROWS, pagesResponderFor(MIXED_ROWS));
+    await flushMicrotasks();
+
+    selectFilter(dom, "contradicted");
+    await flushMicrotasks();
+    expect(visibleSlugs(dom)).toEqual(["concepts/contradicted-page"]);
+  });
+});
+
+/** Responder serving a health payload with the given stateStatus. */
+function healthResponderFor(stateStatus: string): FetchResponder {
+  return (url) => {
+    if (url.endsWith("/api/pages")) return jsonResponse({ ...PAGES_BASE, pages: [] });
+    if (url.endsWith("/api/health")) {
+      return jsonResponse({ concepts: 0, queries: 0, stateStatus, lint: null });
+    }
+    return null;
+  };
+}
+
+/** Mount the viewer, navigate to #/health, and return the corrupt-banner element (or null). */
+async function bannerForStateStatus(stateStatus: string): Promise<Element | null> {
+  const { dom } = await mountViewerDom([], healthResponderFor(stateStatus));
+  dom.window.location.hash = "#/health";
+  await flushMicrotasks();
+  return dom.window.document.querySelector(".corrupt-state-banner");
+}
+
+describe("corrupt-state banner", () => {
+  it("renders the banner when /api/health reports stateStatus: corrupt", async () => {
+    const banner = await bannerForStateStatus("corrupt");
+    expect(banner).not.toBeNull();
+    expect(banner?.getAttribute("role")).toBe("alert");
+  });
+
+  it("does NOT render the banner when /api/health reports stateStatus: ok", async () => {
+    const banner = await bannerForStateStatus("ok");
+    expect(banner).toBeNull();
+  });
+});

--- a/test/viewer-sidebar.test.ts
+++ b/test/viewer-sidebar.test.ts
@@ -135,13 +135,17 @@ function pagesWithStateStatus(stateStatus: string): FetchResponder {
   };
 }
 
+/** Assert the banner is present and has role="alert". */
+function expectCorruptBanner(banner: Element | null): void {
+  expect(banner).not.toBeNull();
+  expect(banner?.getAttribute("role")).toBe("alert");
+}
+
 describe("global corrupt-state banner (home route)", () => {
   it("renders the banner in the main pane at load when stateStatus is corrupt", async () => {
     const { dom } = await mountViewerDom([], pagesWithStateStatus("corrupt"));
     await flushMicrotasks();
-    const banner = dom.window.document.querySelector(".corrupt-state-banner");
-    expect(banner).not.toBeNull();
-    expect(banner?.getAttribute("role")).toBe("alert");
+    expectCorruptBanner(dom.window.document.querySelector(".corrupt-state-banner"));
   });
 
   it("does NOT render a global banner when stateStatus is ok", async () => {
@@ -173,9 +177,7 @@ async function bannerForStateStatus(stateStatus: string): Promise<Element | null
 
 describe("corrupt-state banner", () => {
   it("renders the banner when /api/health reports stateStatus: corrupt", async () => {
-    const banner = await bannerForStateStatus("corrupt");
-    expect(banner).not.toBeNull();
-    expect(banner?.getAttribute("role")).toBe("alert");
+    expectCorruptBanner(await bannerForStateStatus("corrupt"));
   });
 
   it("does NOT render the banner when /api/health reports stateStatus: ok", async () => {
@@ -199,9 +201,7 @@ describe("global corrupt-state banner on deep-link routes", () => {
     // The banner must still appear because main() fetches /api/pages at startup.
     const { dom } = await mountViewerDom([], deepLinkCorruptResponder("corrupt"), "#/graph");
     await flushMicrotasks();
-    const banner = dom.window.document.querySelector(".corrupt-state-banner");
-    expect(banner).not.toBeNull();
-    expect(banner?.getAttribute("role")).toBe("alert");
+    expectCorruptBanner(dom.window.document.querySelector(".corrupt-state-banner"));
   });
 
   it("does NOT render a banner on #/graph when stateStatus is ok", async () => {

--- a/test/viewer-sidebar.test.ts
+++ b/test/viewer-sidebar.test.ts
@@ -126,6 +126,32 @@ describe("sidebar freshness filter", () => {
   });
 });
 
+/** Responder serving /api/pages with stateStatus embedded in the envelope. */
+function pagesWithStateStatus(stateStatus: string): FetchResponder {
+  return (url) => {
+    if (url.endsWith("/api/pages"))
+      return jsonResponse({ ...PAGES_BASE, pages: [], stateStatus });
+    return null;
+  };
+}
+
+describe("global corrupt-state banner (home route)", () => {
+  it("renders the banner in the main pane at load when stateStatus is corrupt", async () => {
+    const { dom } = await mountViewerDom([], pagesWithStateStatus("corrupt"));
+    await flushMicrotasks();
+    const banner = dom.window.document.querySelector(".corrupt-state-banner");
+    expect(banner).not.toBeNull();
+    expect(banner?.getAttribute("role")).toBe("alert");
+  });
+
+  it("does NOT render a global banner when stateStatus is ok", async () => {
+    const { dom } = await mountViewerDom([], pagesWithStateStatus("ok"));
+    await flushMicrotasks();
+    const banner = dom.window.document.querySelector(".corrupt-state-banner");
+    expect(banner).toBeNull();
+  });
+});
+
 /** Responder serving a health payload with the given stateStatus. */
 function healthResponderFor(stateStatus: string): FetchResponder {
   return (url) => {

--- a/test/viewer-sidebar.test.ts
+++ b/test/viewer-sidebar.test.ts
@@ -183,3 +183,31 @@ describe("corrupt-state banner", () => {
     expect(banner).toBeNull();
   });
 });
+
+/** Responder for deep-link corrupt-state banner test: /api/pages returns corrupt, everything else 404s. */
+function deepLinkCorruptResponder(stateStatus: string): FetchResponder {
+  return (url) => {
+    if (url.endsWith("/api/pages"))
+      return jsonResponse({ ...PAGES_BASE, pages: [], stateStatus });
+    return null;
+  };
+}
+
+describe("global corrupt-state banner on deep-link routes", () => {
+  it("renders the banner when entry route is #/graph and stateStatus is corrupt", async () => {
+    // Bootstrap with a non-home, non-health route — the home renderer is never called.
+    // The banner must still appear because main() fetches /api/pages at startup.
+    const { dom } = await mountViewerDom([], deepLinkCorruptResponder("corrupt"), "#/graph");
+    await flushMicrotasks();
+    const banner = dom.window.document.querySelector(".corrupt-state-banner");
+    expect(banner).not.toBeNull();
+    expect(banner?.getAttribute("role")).toBe("alert");
+  });
+
+  it("does NOT render a banner on #/graph when stateStatus is ok", async () => {
+    const { dom } = await mountViewerDom([], deepLinkCorruptResponder("ok"), "#/graph");
+    await flushMicrotasks();
+    const banner = dom.window.document.querySelector(".corrupt-state-banner");
+    expect(banner).toBeNull();
+  });
+});


### PR DESCRIPTION
Wires the computed source-freshness layer (shipped in #83 for lint and the JSON export) into the remaining surfaces. Freshness is derived on demand, read-only, and never persisted.

## Surfaces

- **MCP** — `wiki_status` reports `stalePages`/`orphanedPages` and a `stateStatus` field; `get_context_pack` carries freshness on each primary page.
- **Context packs** — each primary gains `freshnessStatus`/`contradicted`/`archived`, plus a `stale-page` warning. Stale pages are flagged, never dropped.
- **Viewer** — STALE/ORPHANED/CONTRADICTED/ARCHIVED badges, a per-axis filter, stale/orphaned counts in the health pane, and a corrupt-state banner shown on every route.
- **`llmwiki next`** — stale/orphaned counts read from the lint cache (so the command stays cheap, never hashing), plus `state-unreadable` and `freshness-cache-stale` warnings.

## Also

- Closes three read-only paths that silently wrote a `.bak` on corrupt `state.json` (`wiki_status`, the `llmwiki://state` resource, and the viewer snapshot).
- Corrupt/missing state is surfaced explicitly instead of swallowed.
- `wiki_status` derives pending changes from the freshness snapshot rather than a second source-hash pass.

## Follow-ups (not in this PR)

- `refresh --stale` (targeted recompile of stale pages).
- Excluding archived pages from agent-facing surfaces.