### PR TITLE
fix(eval): surface source warnings, make the report frame-safe, add source_warnings_max gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,9 @@ health_score: 85
 citation_coverage_percent: 70
 citation_precision_percent: 90
 citation_support_mean: 1.4   # only checked when --suite full
+source_utilization_rate: 0.9 # min fraction of valid sources cited by a page
+source_warnings_max: 0       # max excluded sources (out-of-tree symlinks, etc.)
+claim_level_citation_rate: 0.5 # min fraction of citations with line ranges
 ```
 
 Threshold violations are listed in the report. Exit code is non-zero when any threshold is breached, suitable for CI gating.

--- a/src/eval/report.ts
+++ b/src/eval/report.ts
@@ -14,10 +14,30 @@ import type { CacheSummary } from "./cache.js";
 const MAX_LISTED_WARNINGS = 5;
 
 const BOX_WIDTH = 49;
+const INNER_WIDTH = BOX_WIDTH - 2;
 const HORIZONTAL = "─".repeat(BOX_WIDTH);
 
+/** Matches ANSI color escape sequences so width is measured on visible text. */
+const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
+
+/** Visible character width of a string, ignoring ANSI color escapes. */
+function visibleWidth(text: string): number {
+  return text.replace(ANSI_PATTERN, "").length;
+}
+
+/**
+ * Render one boxed line. Pads to the inner width using the *visible* length
+ * (so color escapes don't skew alignment) and truncates over-long content with
+ * an ellipsis so the frame stays intact regardless of what the caller passes.
+ * Truncated lines drop color; the full text remains in the JSON report.
+ */
 function line(content = ""): string {
-  return `│ ${content.padEnd(BOX_WIDTH - 2)} │`;
+  const visible = visibleWidth(content);
+  if (visible > INNER_WIDTH) {
+    const plain = content.replace(ANSI_PATTERN, "");
+    return `│ ${plain.slice(0, INNER_WIDTH - 1)}… │`;
+  }
+  return `│ ${content}${" ".repeat(INNER_WIDTH - visible)} │`;
 }
 
 function top(): string {

--- a/src/eval/report.ts
+++ b/src/eval/report.ts
@@ -6,9 +6,12 @@
  * formatJsonReport serialises the raw EvalReport for machine consumption.
  */
 
-import { bold, dim, error as colorError } from "../utils/output.js";
+import { bold, dim, warn as colorWarn, error as colorError } from "../utils/output.js";
 import type { EvalReport, EvalDelta, HealthRuleResult, CitationJudgement } from "./types.js";
 import type { CacheSummary } from "./cache.js";
+
+/** Max source-utilization warnings listed before the rest are summarized. */
+const MAX_LISTED_WARNINGS = 5;
 
 const BOX_WIDTH = 49;
 const HORIZONTAL = "─".repeat(BOX_WIDTH);
@@ -104,10 +107,27 @@ function formatCitationDepth(report: EvalReport): string[] {
   ];
 }
 
+/**
+ * Render source-inventory warnings (e.g. an out-of-tree symlink excluded from
+ * the count) so they are visible in the terminal, not just the JSON report.
+ * Returns no rows when there are no warnings.
+ */
+function warningRows(warnings: string[]): string[] {
+  if (warnings.length === 0) return [];
+  const rows = [line(colorWarn('  ' + warnings.length + ' source warning(s):'))];
+  for (const w of warnings.slice(0, MAX_LISTED_WARNINGS)) {
+    rows.push(line(dim('    ! ' + w)));
+  }
+  if (warnings.length > MAX_LISTED_WARNINGS) {
+    rows.push(line(dim('    ... and ' + String(warnings.length - MAX_LISTED_WARNINGS) + ' more')));
+  }
+  return rows;
+}
+
 function formatSourceUtilization(report: EvalReport): string[] {
   const u = report.sourceUtilization;
   if (u.totalSources === 0) {
-    return [line(), line('Source Utilization:  N/A (no sources)')];
+    return [line(), line('Source Utilization:  N/A (no sources)'), ...warningRows(u.warnings)];
   }
   const pct = u.utilizationRate !== null ? (u.utilizationRate * 100).toFixed(0) + "%" : "N/A";
   const rows = [
@@ -128,6 +148,7 @@ function formatSourceUtilization(report: EvalReport): string[] {
     }
     rows.push(line(dim('  Tip: re-run llmwiki compile to extract concepts from uncited sources.')));
   }
+  rows.push(...warningRows(u.warnings));
   return rows;
 }
 

--- a/src/eval/source-utilization.ts
+++ b/src/eval/source-utilization.ts
@@ -14,7 +14,7 @@
  * ("not measured").
  */
 
-import { readdir } from "fs/promises";
+import { readdir, lstat } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
 import { collectAllPages } from "../linter/rules.js";
@@ -62,6 +62,18 @@ interface InventoryResult {
  * and cited/uncited counts from the returned validFiles, never from the
  * raw readdir() result.
  */
+/**
+ * Explain why a source file was excluded from the inventory. The common case is
+ * a symlink whose target is missing or resolves outside the sources tree;
+ * everything else (bad path, unreadable) collapses to a generic reason.
+ */
+async function exclusionReason(sourcesDir: string, file: string): Promise<string> {
+  const stat = await lstat(path.join(sourcesDir, file)).catch(() => null);
+  return stat?.isSymbolicLink()
+    ? "symlink target missing or outside sources/ (excluded)"
+    : "could not be resolved (excluded)";
+}
+
 async function resolveSourceInventory(
   sourcesDir: string,
   sourceFiles: string[],
@@ -72,7 +84,9 @@ async function resolveSourceInventory(
   for (const f of sourceFiles) {
     const resolved = await resolveSourceFile(sourcesDir, f);
     if (resolved === null) {
-      warnings.push("Unresolvable source file excluded from inventory: " + f);
+      // Filename first so the actionable detail survives any display
+      // truncation; distinguish the common symlink case from other failures.
+      warnings.push(`${f}: ${await exclusionReason(sourcesDir, f)}`);
     } else {
       fileToReal.set(f, resolved);
       validFiles.push(f);

--- a/src/eval/thresholds.ts
+++ b/src/eval/thresholds.ts
@@ -11,6 +11,7 @@
  *   citation_precision_percent — minimum citation precision (0–100)
  *   citation_support_mean     — minimum mean judge score (0.0–2.0)
  *   source_utilization_rate   — minimum fraction of sources cited (0.0–1.0)
+ *   source_warnings_max       — maximum source-inventory warnings allowed (integer)
  *   claim_level_citation_rate — minimum fraction of citations with line ranges (0.0–1.0)
  */
 
@@ -31,6 +32,13 @@ interface ThresholdConfig {
   citation_judge_error_max?: number;
   /** Minimum fraction of sources cited by ≥1 wiki page (0.0–1.0). */
   source_utilization_rate?: number;
+  /**
+   * Maximum source-inventory warnings allowed (e.g. out-of-tree symlinks or
+   * unresolvable files excluded from the count). Gates inventory health, which
+   * is distinct from utilization — an excluded source is an invalid entry, not
+   * an uncited one. 0 = any excluded source fails CI.
+   */
+  source_warnings_max?: number;
   claim_level_citation_rate?: number;
 }
 
@@ -42,13 +50,38 @@ async function loadThresholds(root: string): Promise<ThresholdConfig> {
   return (yaml.load(raw) as ThresholdConfig) ?? {};
 }
 
-/** Check source-utilization and citation-depth thresholds. */
+/** Check the source-utilization and citation-depth thresholds. */
 function checkNewThresholds(
   violations: string[],
   config: ThresholdConfig,
   report: EvalReport,
 ): void {
-  checkNewThresholds(violations, config, report);
+  const util = report.sourceUtilization;
+  if (
+    config.source_utilization_rate !== undefined &&
+    util.utilizationRate !== null &&
+    util.totalSources > 0 &&
+    util.utilizationRate < config.source_utilization_rate
+  ) {
+    violations.push(
+      `source_utilization_rate ${(util.utilizationRate * 100).toFixed(1)}% is below threshold ${(config.source_utilization_rate * 100).toFixed(1)}%`,
+    );
+  }
+
+  if (config.source_warnings_max !== undefined && util.warnings.length > config.source_warnings_max) {
+    violations.push(
+      `source_warnings ${util.warnings.length} exceeds max ${config.source_warnings_max}`,
+    );
+  }
+
+  if (
+    config.claim_level_citation_rate !== undefined &&
+    report.citationDepth.claimLevelRate < config.claim_level_citation_rate
+  ) {
+    violations.push(
+      `claim_level_citation_rate ${(report.citationDepth.claimLevelRate * 100).toFixed(1)}% is below threshold ${(config.claim_level_citation_rate * 100).toFixed(1)}%`,
+    );
+  }
 }
 
 /**
@@ -108,25 +141,7 @@ export async function checkThresholds(
     );
   }
 
-  if (
-    config.source_utilization_rate !== undefined &&
-    report.sourceUtilization.utilizationRate !== null &&
-    report.sourceUtilization.totalSources > 0 &&
-    report.sourceUtilization.utilizationRate < config.source_utilization_rate
-  ) {
-    violations.push(
-      `source_utilization_rate ${(report.sourceUtilization.utilizationRate * 100).toFixed(1)}% is below threshold ${(config.source_utilization_rate * 100).toFixed(1)}%`,
-    );
-  }
-
-  if (
-    config.claim_level_citation_rate !== undefined &&
-    report.citationDepth.claimLevelRate < config.claim_level_citation_rate
-  ) {
-    violations.push(
-      `claim_level_citation_rate ${(report.citationDepth.claimLevelRate * 100).toFixed(1)}% is below threshold ${(config.claim_level_citation_rate * 100).toFixed(1)}%`,
-    );
-  }
+  checkNewThresholds(violations, config, report);
 
   return violations;
 }

--- a/test/eval-formatters.test.ts
+++ b/test/eval-formatters.test.ts
@@ -257,4 +257,28 @@ describe("formatTerminalReport", () => {
     expect(output).toContain("Citation Depth:");
     expect(output).toContain("Claim-level");
   });
+
+  it("surfaces source-inventory warnings in the terminal report", () => {
+    const report = makeReport({
+      sourceUtilization: {
+        totalSources: 1, citedSources: 1, uncitedSources: 0, utilizationRate: 1, perSource: [],
+        warnings: ["Unresolvable source file excluded from inventory: ghost.md"],
+      },
+    });
+    const output = formatTerminalReport(report);
+    expect(output).toContain("source warning(s):");
+    expect(output).toContain("ghost.md");
+  });
+
+  it("surfaces warnings even when no sources are measured", () => {
+    const report = makeReport({
+      sourceUtilization: {
+        totalSources: 0, citedSources: 0, uncitedSources: 0, utilizationRate: null, perSource: [],
+        warnings: ["Unresolvable source file excluded from inventory: dangling.md"],
+      },
+    });
+    const output = formatTerminalReport(report);
+    expect(output).toContain("N/A (no sources)");
+    expect(output).toContain("dangling.md");
+  });
 });

--- a/test/eval-formatters.test.ts
+++ b/test/eval-formatters.test.ts
@@ -262,23 +262,40 @@ describe("formatTerminalReport", () => {
     const report = makeReport({
       sourceUtilization: {
         totalSources: 1, citedSources: 1, uncitedSources: 0, utilizationRate: 1, perSource: [],
-        warnings: ["Unresolvable source file excluded from inventory: ghost.md"],
+        warnings: ["ghost.md: symlink target missing or outside sources/ (excluded)"],
       },
     });
     const output = formatTerminalReport(report);
     expect(output).toContain("source warning(s):");
-    expect(output).toContain("ghost.md");
+    expect(output).toContain("ghost.md"); // filename is front-loaded, survives truncation
   });
 
   it("surfaces warnings even when no sources are measured", () => {
     const report = makeReport({
       sourceUtilization: {
         totalSources: 0, citedSources: 0, uncitedSources: 0, utilizationRate: null, perSource: [],
-        warnings: ["Unresolvable source file excluded from inventory: dangling.md"],
+        warnings: ["dangling.md: could not be resolved (excluded)"],
       },
     });
     const output = formatTerminalReport(report);
     expect(output).toContain("N/A (no sources)");
     expect(output).toContain("dangling.md");
+  });
+
+  it("keeps every boxed line at the frame width even with overflowing content", () => {
+    const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+    const report = makeReport({
+      thresholdViolations: ["source_utilization_rate 12.5% is far below the configured threshold 95.0%"],
+      sourceUtilization: {
+        totalSources: 1, citedSources: 0, uncitedSources: 1, utilizationRate: 0,
+        perSource: [{ sourceFile: "a-very-long-source-filename-that-overflows-the-box.md", citingPageCount: 0, citingPages: [] }],
+        warnings: ["a-really-long-source-name.md: symlink target missing or outside sources/ (excluded)"],
+      },
+    });
+    const lines = formatTerminalReport(report).split("\n").filter(Boolean);
+    const frameWidth = stripAnsi(lines[0]).length;
+    for (const l of lines) {
+      expect(stripAnsi(l).length).toBe(frameWidth);
+    }
   });
 });

--- a/test/eval-thresholds.test.ts
+++ b/test/eval-thresholds.test.ts
@@ -144,4 +144,27 @@ describe("checkThresholds", () => {
     expect(violations.some((v) => v.includes("health_score"))).toBe(true);
     expect(violations.some((v) => v.includes("citation_coverage_percent"))).toBe(true);
   });
+
+  function makeReportWithWarnings(warnings: string[]) {
+    return makeReport({
+      sourceUtilization: { totalSources: 2, citedSources: 2, uncitedSources: 0, utilizationRate: 1, perSource: [], warnings },
+    });
+  }
+
+  it("flags source_warnings_max when excluded sources exceed the limit", async () => {
+    await writeThresholds(env.dir, { source_warnings_max: 0 });
+    const report = makeReportWithWarnings(["ghost.md: symlink target missing or outside sources/ (excluded)"]);
+
+    const violations = await checkThresholds(report, env.dir);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain("source_warnings");
+    expect(violations[0]).toContain("exceeds max 0");
+  });
+
+  it("passes source_warnings_max when warnings are within the limit", async () => {
+    await writeThresholds(env.dir, { source_warnings_max: 2 });
+    const report = makeReportWithWarnings(["one.md: could not be resolved (excluded)"]);
+
+    expect(await checkThresholds(report, env.dir)).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Completes the source-utilization warnings story end to end.

**Surfacing** — the source-inventory `warnings` (e.g. an out-of-tree symlink excluded from the count) now appear in the terminal `eval` output, not just the JSON report. Messages are filename-first with the symlink case distinguished, so the actionable detail survives truncation.

**Frame-safety** — a self-audit found the box renderer was unsafe: `line()` padded by raw string length, so ANSI color codes skewed alignment (every colored line's right border was pulled left) and long content overflowed the frame. `line()` now measures *visible* width and truncates overflow, so the box is well-formed by construction — also repairing the pre-existing misalignment across the whole report (scores, threshold violations, …). A test asserts every boxed line stays at the frame width.

**Integrity gate** — an excluded source dropped out of `source_utilization_rate`'s denominator and never failed CI. New `source_warnings_max` threshold gates `sourceUtilization.warnings.length` — inventory health, kept distinct from utilization (an excluded source is an invalid entry, not an uncited one). Strict projects can pair `source_utilization_rate: 0.9` with `source_warnings_max: 0`.

Also fixes a latent bug surfaced along the way: `checkNewThresholds` was dead and infinitely self-recursive (the self-reference hid it from dead-code detection); it now owns the source/citation-depth checks. README's threshold example is brought current with all keys.