### PR TITLE
feat(sdk): in-process createWiki SDK

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -10,7 +10,7 @@
   ],
   "overrides": [
     {
-      "files": ["src/providers/*.ts"],
+      "files": ["src/providers/*.ts", "src/utils/provider-guard.ts"],
       "rules": {
         "unused-class-members": "off"
       }

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -8,6 +8,7 @@
     "src/viewer/assets/index.html",
     "src/viewer/assets/viewer.css"
   ],
+  "ignoreExports": [{ "file": "src/utils/output.ts", "exports": ["getQuiet"] }],
   "overrides": [
     {
       "files": ["src/providers/*.ts", "src/utils/provider-guard.ts"],

--- a/package.json
+++ b/package.json
@@ -3,6 +3,16 @@
   "version": "0.8.0",
   "description": "A knowledge compiler CLI — raw sources in, interlinked wiki out",
   "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "bin": {
     "llmwiki": "dist/cli.js"
   },
@@ -16,7 +26,8 @@
     "test:watch": "vitest",
     "fallow:ci": "bash scripts/fallow-ci.sh",
     "prepublishOnly": "npm run release:check-docs:current && npm run build && npm pack --dry-run --ignore-scripts",
-    "prepare": "husky"
+    "prepare": "husky",
+    "test:pack": "vitest run test/sdk/packaging.test.ts"
   },
   "keywords": [
     "knowledge",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "fallow:ci": "bash scripts/fallow-ci.sh",
     "prepublishOnly": "npm run release:check-docs:current && npm run build && npm pack --dry-run --ignore-scripts",
     "prepare": "husky",
-    "test:pack": "vitest run test/sdk/packaging.test.ts"
+    "test:pack": "vitest run --config /dev/null test/sdk/packaging.test.ts"
   },
   "keywords": [
     "knowledge",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "A knowledge compiler CLI — raw sources in, interlinked wiki out",
   "type": "module",
   "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -20,7 +20,7 @@ import { atomicWrite } from "../utils/markdown.js";
 import * as output from "../utils/output.js";
 import { collectExportPages } from "../export/collect.js";
 import { buildLlmsTxt, buildLlmsFullTxt } from "../export/llms-txt.js";
-import { buildJsonExport } from "../export/json-export.js";
+import { buildJsonExport, buildJsonExportDocument, type JsonExportDocument } from "../export/json-export.js";
 import { validateProjectId } from "../export/project-id.js";
 import { buildJsonLd } from "../export/json-ld.js";
 import { buildGraphml } from "../export/graphml.js";
@@ -189,6 +189,24 @@ function resolveTargets(rawTarget: string | undefined): ExportTarget[] {
   }
 
   return [rawTarget];
+}
+
+/**
+ * Pure in-memory entry point — collects pages and returns the export document
+ * object without writing any files or emitting console output.
+ * @param root - Absolute path to the project root directory.
+ * @param options - Optional export options (e.g. `projectId`).
+ * @returns The JsonExportDocument object ready for programmatic consumption.
+ */
+export async function exportJson(
+  root: string,
+  options: { projectId?: string } = {},
+): Promise<JsonExportDocument> {
+  const pages = await collectExportPages(root);
+  return buildJsonExportDocument(
+    pages,
+    options.projectId !== undefined ? { projectId: options.projectId } : {},
+  );
 }
 
 /**

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -20,7 +20,12 @@ import { atomicWrite } from "../utils/markdown.js";
 import * as output from "../utils/output.js";
 import { collectExportPages } from "../export/collect.js";
 import { buildLlmsTxt, buildLlmsFullTxt } from "../export/llms-txt.js";
-import { buildJsonExport, buildJsonExportDocument, type JsonExportDocument } from "../export/json-export.js";
+import {
+  buildJsonExport,
+  buildJsonExportDocument,
+  type BuildJsonExportOptions,
+  type JsonExportDocument,
+} from "../export/json-export.js";
 import { validateProjectId } from "../export/project-id.js";
 import { buildJsonLd } from "../export/json-ld.js";
 import { buildGraphml } from "../export/graphml.js";
@@ -200,13 +205,10 @@ function resolveTargets(rawTarget: string | undefined): ExportTarget[] {
  */
 export async function exportJson(
   root: string,
-  options: { projectId?: string } = {},
+  options: BuildJsonExportOptions = {},
 ): Promise<JsonExportDocument> {
   const pages = await collectExportPages(root);
-  return buildJsonExportDocument(
-    pages,
-    options.projectId !== undefined ? { projectId: options.projectId } : {},
-  );
+  return buildJsonExportDocument(pages, options);
 }
 
 /**

--- a/src/commands/ingest-session.ts
+++ b/src/commands/ingest-session.ts
@@ -46,22 +46,27 @@ function buildSessionFrontmatter(session: NormalizedSession, sourcePath: string)
  * same title from different transcript files coexist instead of one
  * silently overwriting the other.
  */
-async function saveSessionSource(session: NormalizedSession, sourcePath: string): Promise<string> {
+async function saveSessionSource(
+  root: string,
+  session: NormalizedSession,
+  sourcePath: string,
+): Promise<string> {
   const frontmatter = buildSessionFrontmatter(session, sourcePath);
   const body = formatSessionAsMarkdown(session);
   const document = `${frontmatter}\n\n${body}\n`;
-  return saveSource(session.title, document, sourcePath);
+  return saveSource(root, session.title, document, sourcePath);
 }
 
 /**
  * Ingest a single session file.
+ * @param root - Absolute path to the wiki root directory.
  * @throws When the file is not recognised or is malformed.
  */
-export async function ingestSessionFile(filePath: string): Promise<SessionIngestResult> {
+export async function ingestSessionFile(root: string, filePath: string): Promise<SessionIngestResult> {
   output.status("*", output.info(`Ingesting session: ${filePath}`));
 
   const session = await parseSessionFile(filePath);
-  const savedPath = await saveSessionSource(session, filePath);
+  const savedPath = await saveSessionSource(root, session, filePath);
 
   output.status(
     "+",
@@ -102,7 +107,7 @@ async function listDirectoryFiles(dirPath: string): Promise<string[]> {
  * failure mode the user needs to know about — exiting 0 with "Imported
  * 0 session(s), skipped N" was easy to miss in scripts.
  */
-async function ingestDirectory(dirPath: string): Promise<void> {
+async function ingestDirectory(root: string, dirPath: string): Promise<void> {
   const files = await listDirectoryFiles(dirPath);
 
   if (files.length === 0) {
@@ -116,7 +121,7 @@ async function ingestDirectory(dirPath: string): Promise<void> {
 
   for (const file of files) {
     try {
-      await ingestSessionFile(file);
+      await ingestSessionFile(root, file);
       imported++;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -143,14 +148,15 @@ async function ingestDirectory(dirPath: string): Promise<void> {
  * Dispatches to single-file or directory import based on the target type.
  */
 export default async function ingestSession(targetPath: string): Promise<void> {
+  const root = process.cwd();
   const info = await stat(targetPath).catch(() => {
     throw new Error(`Path not found: ${targetPath}`);
   });
 
   if (info.isDirectory()) {
-    await ingestDirectory(targetPath);
+    await ingestDirectory(root, targetPath);
   } else {
-    await ingestSessionFile(targetPath);
+    await ingestSessionFile(root, targetPath);
   }
 
   output.status("→", output.dim("Next: llmwiki compile"));

--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -11,6 +11,7 @@
 
 import path from "path";
 import { readFile } from "fs/promises";
+import { createHash } from "node:crypto";
 import { buildFrontmatter } from "../utils/markdown.js";
 import { saveSource } from "../utils/source-writer.js";
 import { MAX_SOURCE_CHARS, MIN_SOURCE_CHARS, SOURCES_DIR, IMAGE_EXTENSIONS, TRANSCRIPT_EXTENSIONS } from "../utils/constants.js";
@@ -272,6 +273,35 @@ export async function ingestSource(root: string, source: string): Promise<Ingest
     truncated: result.truncated,
     source,
     sourceType,
+  };
+}
+
+/** Input shape for raw-text ingestion. */
+export interface IngestTextInput { title: string; text: string; source?: string }
+
+/**
+ * Ingest raw text directly into the wiki sources directory.
+ *
+ * When `source` is omitted a deterministic synthetic identity
+ * `manual:<sha256(title\ntext)>` is derived so that identical content is
+ * idempotent and differing content coexists (mirrors saveSource collision rules).
+ *
+ * @param root - Absolute path to the wiki root directory.
+ * @param input - Title, raw text body, and optional explicit source identity.
+ * @returns Structured ingest result with filename, char count, and source URI.
+ */
+export async function ingestTextSource(root: string, input: IngestTextInput): Promise<IngestResult> {
+  const source = input.source ?? `manual:${createHash("sha256").update(`${input.title}\n${input.text}`).digest("hex")}`;
+  const result = enforceCharLimit(input.text);
+  enforceMinContent(result.content);
+  const document = buildDocument(input.title, source, result, "file");
+  const savedPath = await saveSource(root, input.title, document, source);
+  return {
+    filename: path.basename(savedPath),
+    charCount: result.content.length,
+    truncated: result.truncated,
+    source,
+    sourceType: "file",
   };
 }
 

--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -250,6 +250,28 @@ async function fetchContent(
 }
 
 /**
+ * Append a root-bound ingest entry to the activity journal (`log.md`).
+ * Shared by `ingestSource` and `ingestTextSource` so both ingest paths journal
+ * identically: under the project `root` (not cwd) with a root-relative `Saved`
+ * path, keeping the entry portable regardless of the caller's working directory.
+ */
+async function journalIngest(
+  root: string,
+  title: string,
+  source: string,
+  savedPath: string,
+  charCount: number,
+): Promise<void> {
+  await appendLog(root, "ingest", title, {
+    details: [
+      `Source: ${source}`,
+      `Saved: ${path.join(SOURCES_DIR, path.basename(savedPath))}`,
+      `Chars: ${charCount.toLocaleString()}`,
+    ],
+  });
+}
+
+/**
  * Programmatic ingest entry point. Identical fetch + write logic to the CLI
  * command but returns a structured IngestResult instead of writing to stdout.
  * Used by the MCP server's ingest_source tool.
@@ -268,17 +290,8 @@ export async function ingestSource(root: string, source: string): Promise<Ingest
   const document = buildDocument(title, source, result, sourceType);
   const savedPath = await saveSource(root, title, document, source);
 
-  // Journal the ingest so log.md mirrors the `ingest | Article Title`
-  // convention. Covers the CLI, the MCP ingest_source tool, and the SDK.
-  // Journal under `root` (not cwd) and record the root-relative saved path so
-  // the entry is portable regardless of the caller's working directory.
-  await appendLog(root, "ingest", title, {
-    details: [
-      `Source: ${source}`,
-      `Saved: ${path.join(SOURCES_DIR, path.basename(savedPath))}`,
-      `Chars: ${result.content.length.toLocaleString()}`,
-    ],
-  });
+  // Journal the ingest (CLI, MCP ingest_source tool, and SDK all share this path).
+  await journalIngest(root, title, source, savedPath, result.content.length);
 
   return {
     filename: path.basename(savedPath),
@@ -317,6 +330,10 @@ export async function ingestTextSource(root: string, input: IngestTextInput): Pr
   enforceMinContent(result.content);
   const document = buildDocument(input.title, source, result, "file");
   const savedPath = await saveSource(root, input.title, document, source);
+
+  // Mirror ingestSource so both ingest paths journal identically.
+  await journalIngest(root, input.title, source, savedPath, result.content.length);
+
   return {
     filename: path.basename(savedPath),
     charCount: result.content.length,

--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -255,7 +255,7 @@ async function fetchContent(
  * @param source - A URL (http/https), YouTube URL, local file, PDF, or image path.
  * @returns Saved filename, character count, truncation flag, source URI, and detected source type.
  */
-export async function ingestSource(source: string): Promise<IngestResult> {
+export async function ingestSource(root: string, source: string): Promise<IngestResult> {
   const sourceType = await detectSourceType(source);
   output.status("*", output.info(`Ingesting [${sourceType}]: ${source}`));
 
@@ -264,7 +264,7 @@ export async function ingestSource(source: string): Promise<IngestResult> {
   const result = enforceCharLimit(content);
   enforceMinContent(result.content);
   const document = buildDocument(title, source, result, sourceType);
-  const savedPath = await saveSource(title, document, source);
+  const savedPath = await saveSource(root, title, document, source);
 
   return {
     filename: path.basename(savedPath),
@@ -280,8 +280,9 @@ export async function ingestSource(source: string): Promise<IngestResult> {
  * @param source - A URL (http/https), YouTube URL, local file, PDF, or image path.
  */
 export default async function ingest(source: string): Promise<void> {
-  const result = await ingestSource(source);
-  const savedPath = path.join(SOURCES_DIR, result.filename);
+  const cwd = process.cwd();
+  const result = await ingestSource(cwd, source);
+  const savedPath = path.join(cwd, SOURCES_DIR, result.filename);
 
   output.status(
     "+",

--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -283,15 +283,23 @@ export interface IngestTextInput { title: string; text: string; source?: string 
  * Ingest raw text directly into the wiki sources directory.
  *
  * When `source` is omitted a deterministic synthetic identity
- * `manual:<sha256(title\ntext)>` is derived so that identical content is
+ * `manual:<sha256(title,text)>` is derived so that identical content is
  * idempotent and differing content coexists (mirrors saveSource collision rules).
+ * The hash is fed a length-prefixed title so the title/text boundary is
+ * unambiguous — a raw separator (newline) or bare concatenation would let a
+ * boundary-shifted pair collide (e.g. title="a",text="b" vs title="ab",text="").
  *
  * @param root - Absolute path to the wiki root directory.
  * @param input - Title, raw text body, and optional explicit source identity.
  * @returns Structured ingest result with filename, char count, and source URI.
  */
 export async function ingestTextSource(root: string, input: IngestTextInput): Promise<IngestResult> {
-  const source = input.source ?? `manual:${createHash("sha256").update(`${input.title}\n${input.text}`).digest("hex")}`;
+  const digest = createHash("sha256")
+    .update(`${input.title.length}\n`)
+    .update(input.title)
+    .update(input.text)
+    .digest("hex");
+  const source = input.source ?? `manual:${digest}`;
   const result = enforceCharLimit(input.text);
   enforceMinContent(result.content);
   const document = buildDocument(input.title, source, result, "file");

--- a/src/commands/quickstart.ts
+++ b/src/commands/quickstart.ts
@@ -226,7 +226,7 @@ async function runIngestStep(source: string): Promise<IngestEnvelope> {
   output.header("llmwiki quickstart");
   output.status("*", output.info(`Ingesting ${source}`));
   try {
-    const result = await ingestSource(source);
+    const result = await ingestSource(process.cwd(), source);
     const relPath = path.join(SOURCES_DIR, result.filename);
     output.status("+", output.success(`Ingested → ${relPath}`));
     return buildIngestSuccess(result, relPath);

--- a/src/export/json-export.ts
+++ b/src/export/json-export.ts
@@ -36,7 +36,7 @@ import type { ExportPage } from "./types.js";
 export const EXPORT_SCHEMA_VERSION = 1;
 
 /** Top-level shape of the JSON export file. */
-interface JsonExportDocument {
+export interface JsonExportDocument {
   /**
    * Contract version for downstream consumers. Start at 1; increment only on
    * breaking envelope changes so consumers can pin a supported range.
@@ -59,15 +59,15 @@ export interface BuildJsonExportOptions {
 }
 
 /**
- * Build the JSON export document from a list of export pages.
+ * Build the JSON export document object from a list of export pages.
  * @param pages - Sorted array of export pages.
  * @param options - Optional bridge envelope fields (e.g. `projectId`).
- * @returns Pretty-printed JSON string.
+ * @returns The structured JsonExportDocument object (not serialized).
  */
-export function buildJsonExport(
+export function buildJsonExportDocument(
   pages: ExportPage[],
   options: BuildJsonExportOptions = {},
-): string {
+): JsonExportDocument {
   const doc: JsonExportDocument = {
     schemaVersion: EXPORT_SCHEMA_VERSION,
     exportedAt: new Date().toISOString(),
@@ -77,5 +77,18 @@ export function buildJsonExport(
   if (options.projectId !== undefined) {
     doc.projectId = validateProjectId(options.projectId);
   }
-  return JSON.stringify(doc, null, 2);
+  return doc;
+}
+
+/**
+ * Build the JSON export document from a list of export pages.
+ * @param pages - Sorted array of export pages.
+ * @param options - Optional bridge envelope fields (e.g. `projectId`).
+ * @returns Pretty-printed JSON string.
+ */
+export function buildJsonExport(
+  pages: ExportPage[],
+  options: BuildJsonExportOptions = {},
+): string {
+  return JSON.stringify(buildJsonExportDocument(pages, options), null, 2);
 }

--- a/src/export/json-export.ts
+++ b/src/export/json-export.ts
@@ -49,7 +49,7 @@ export interface JsonExportDocument {
   pages: ExportPage[];
 }
 
-/** Options accepted by {@link buildJsonExport}. */
+/** Options accepted by {@link buildJsonExportDocument}. */
 export interface BuildJsonExportOptions {
   /**
    * Optional project identifier. Validated against the bridge contract

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,28 @@
+/**
+ * @file src/index.ts
+ * @description Public SDK surface for llm-wiki-compiler.
+ *
+ * Re-exports the stable, consumer-facing types and error classes that form the
+ * library API. CLI internals (commander setup, prompts, viewer server) are
+ * intentionally excluded — they live only in src/cli.ts and are not part of
+ * the programmatic API.
+ *
+ * Consumers can import types and errors directly:
+ *   import type { Page, PageRef } from "llm-wiki-compiler";
+ *   import { ProviderUnavailableError } from "llm-wiki-compiler";
+ */
+
+export type {
+  Page,
+  PageRef,
+  PageDirectory,
+  ListPagesOptions,
+  ListPagesResult,
+} from "./pages/list.js";
+
+export type { JsonExportDocument } from "./export/json-export.js";
+
+export {
+  ProviderUnavailableError,
+  UnknownProviderError,
+} from "./utils/provider-guard.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,3 +26,6 @@ export {
   ProviderUnavailableError,
   UnknownProviderError,
 } from "./utils/provider-guard.js";
+
+export { createWiki } from "./sdk/wiki.js";
+export type { Wiki, CreateWikiOptions, SdkCompileOptions, ContextPackOptions } from "./sdk/types.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,3 +29,13 @@ export {
 
 export { createWiki } from "./sdk/wiki.js";
 export type { Wiki, CreateWikiOptions, SdkCompileOptions, ContextPackOptions } from "./sdk/types.js";
+
+// Result/input types for the Wiki facade methods, re-exported so typed
+// consumers don't have to deep-import from internal module paths.
+export type { IngestResult, CompileResult, QueryResult } from "./utils/types.js";
+export type { IngestTextInput } from "./commands/ingest.js";
+export type { LintSummary } from "./linter/types.js";
+export type { ContextPack } from "./context/types.js";
+export type { EvalReport } from "./eval/types.js";
+export type { WikiStatus } from "./status/collect.js";
+export type { PageRecord } from "./pages/read.js";

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -15,11 +15,8 @@ import { ingestSource } from "../commands/ingest.js";
 import { compileAndReport } from "../compiler/index.js";
 import { generateAnswer, selectPages } from "../commands/query.js";
 import { lint } from "../linter/index.js";
-import { collectPageSummaries, scanWikiPages } from "../compiler/indexgen.js";
-import { detectChanges } from "../compiler/hasher.js";
-import { countCandidates } from "../compiler/candidates.js";
-import { readState } from "../utils/state.js";
 import { safeReadFile, parseFrontmatter } from "../utils/markdown.js";
+import { collectStatus } from "../status/collect.js";
 import { findRelevantChunks, findRelevantPages } from "../utils/embeddings.js";
 import { buildContextPack } from "../context/build.js";
 import {
@@ -392,47 +389,6 @@ function registerEvalTool(server: McpServer, root: string): void {
   );
 }
 
-
-/** Read-only status snapshot used by the wiki_status tool. */
-async function collectStatus(root: string): Promise<WikiStatus> {
-  const concepts = await collectPageSummaries(path.join(root, CONCEPTS_DIR));
-  const queries = await collectPageSummaries(path.join(root, QUERIES_DIR));
-  const state = await readState(root);
-  const changes = await detectChanges(root, state);
-  const orphans = await findOrphanedSlugs(root);
-  const pendingCandidates = await countCandidates(root);
-  const compileTimes = Object.values(state.sources).map((s) => s.compiledAt);
-  const lastCompile = compileTimes.length > 0
-    ? compileTimes.sort().slice(-1)[0]
-    : null;
-
-  return {
-    pages: { concepts: concepts.length, queries: queries.length, total: concepts.length + queries.length },
-    sources: Object.keys(state.sources).length,
-    lastCompiledAt: lastCompile,
-    orphanedPages: orphans,
-    pendingCandidates,
-    pendingChanges: changes
-      .filter((c) => c.status !== "unchanged")
-      .map((c) => ({ file: c.file, status: c.status })),
-  };
-}
-
-interface WikiStatus {
-  pages: { concepts: number; queries: number; total: number };
-  sources: number;
-  lastCompiledAt: string | null;
-  orphanedPages: string[];
-  /** Number of compile candidates awaiting human review. */
-  pendingCandidates: number;
-  pendingChanges: Array<{ file: string; status: string }>;
-}
-
-/** Find concept slugs whose pages are flagged as orphaned. */
-async function findOrphanedSlugs(root: string): Promise<string[]> {
-  const scanned = await scanWikiPages(path.join(root, CONCEPTS_DIR));
-  return scanned.filter(({ meta }) => meta.orphaned).map(({ slug }) => slug);
-}
 
 /** Load full content for a list of slugs, skipping missing/orphaned pages. */
 async function loadPageRecords(root: string, slugs: string[]): Promise<PageRecord[]> {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -8,36 +8,18 @@
  * read-only tools always work.
  */
 
-import path from "path";
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ingestSource } from "../commands/ingest.js";
 import { compileAndReport } from "../compiler/index.js";
-import { generateAnswer, selectPages } from "../commands/query.js";
+import { generateAnswer } from "../commands/query.js";
 import { lint } from "../linter/index.js";
-import { safeReadFile, parseFrontmatter } from "../utils/markdown.js";
 import { collectStatus } from "../status/collect.js";
-import { findRelevantChunks, findRelevantPages } from "../utils/embeddings.js";
 import { buildContextPack } from "../context/build.js";
-import {
-  CONCEPTS_DIR,
-  INDEX_FILE,
-  QUERIES_DIR,
-  CHUNK_TOP_K,
-} from "../utils/constants.js";
 import { ensureProviderAvailable } from "../utils/provider-guard.js";
 import { runEval, DEFAULT_SAMPLE_SIZE } from "../eval/index.js";
-
-/** Directories searched (in priority order) when resolving a page slug. */
-const PAGE_DIRS = [CONCEPTS_DIR, QUERIES_DIR];
-
-/** Shape returned by search_pages for each matching page. */
-interface PageRecord {
-  slug: string;
-  title: string;
-  summary: string;
-  body: string;
-}
+import { readPageRecord } from "../pages/read.js";
+import { pickSearchSlugs, loadPageRecords } from "../search/retrieval.js";
 
 /**
  * Wrap an arbitrary JSON value as the standard MCP CallToolResult.
@@ -159,43 +141,6 @@ function registerSearchTool(server: McpServer, root: string): void {
   );
 }
 
-/**
- * Resolve search candidates. Tries chunk-level retrieval first (highest
- * precision), then falls back to page-level embeddings, then to LLM-driven
- * selection over the wiki index.
- */
-async function pickSearchSlugs(root: string, question: string): Promise<string[]> {
-  try {
-    const chunks = await findRelevantChunks(root, question, CHUNK_TOP_K);
-    if (chunks.length > 0) return dedupePreservingOrder(chunks.map((c) => c.chunk.slug));
-  } catch {
-    // Chunk store unavailable — fall through to page-level embeddings.
-  }
-
-  try {
-    const candidates = await findRelevantPages(root, question);
-    if (candidates.length > 0) return candidates.map((c) => c.slug);
-  } catch {
-    // Embeddings unavailable — fall through to index-based selection.
-  }
-
-  const indexContent = await safeReadFile(path.join(root, INDEX_FILE));
-  const { pages } = await selectPages(question, indexContent);
-  return pages;
-}
-
-/** Deduplicate slugs while preserving the first-seen ordering. */
-function dedupePreservingOrder(slugs: string[]): string[] {
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const slug of slugs) {
-    if (seen.has(slug)) continue;
-    seen.add(slug);
-    out.push(slug);
-  }
-  return out;
-}
-
 function registerReadTool(server: McpServer, root: string): void {
   server.registerTool(
     "read_page",
@@ -209,7 +154,7 @@ function registerReadTool(server: McpServer, root: string): void {
       },
     },
     async ({ slug }) => {
-      const page = await readPage(root, slug);
+      const page = await readPageRecord(root, slug);
       if (!page) {
         throw new Error(`Page not found: ${slug}`);
       }
@@ -390,34 +335,3 @@ function registerEvalTool(server: McpServer, root: string): void {
 }
 
 
-/** Load full content for a list of slugs, skipping missing/orphaned pages. */
-async function loadPageRecords(root: string, slugs: string[]): Promise<PageRecord[]> {
-  const records: PageRecord[] = [];
-  for (const slug of slugs) {
-    const page = await readPage(root, slug);
-    if (page) records.push(page);
-  }
-  return records;
-}
-
-/**
- * Locate a page by slug across the priority-ordered page directories,
- * skipping orphaned entries to match the query pipeline's behaviour.
- */
-export async function readPage(root: string, slug: string): Promise<PageRecord | null> {
-  for (const dir of PAGE_DIRS) {
-    const content = await safeReadFile(path.join(root, dir, `${slug}.md`));
-    if (!content) continue;
-
-    const { meta, body } = parseFrontmatter(content);
-    if (meta.orphaned) continue;
-
-    return {
-      slug,
-      title: typeof meta.title === "string" ? meta.title : slug,
-      summary: typeof meta.summary === "string" ? meta.summary : "",
-      body: body.trim(),
-    };
-  }
-  return null;
-}

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -85,14 +85,8 @@ function registerIngestTool(server: McpServer, root: string): void {
       },
     },
     async ({ source }) => {
-      const previousCwd = process.cwd();
-      try {
-        process.chdir(root);
-        const result = await ingestSource(source);
-        return jsonResult(result);
-      } finally {
-        process.chdir(previousCwd);
-      }
+      const result = await ingestSource(root, source);
+      return jsonResult(result);
     },
   );
 }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -333,5 +333,3 @@ function registerEvalTool(server: McpServer, root: string): void {
     },
   );
 }
-
-

--- a/src/pages/list.ts
+++ b/src/pages/list.ts
@@ -94,8 +94,8 @@ function buildPage(
   return {
     slug,
     pageDirectory: dir,
-    title: String(meta.title ?? slug),
-    summary: String(meta.summary ?? ""),
+    title: typeof meta.title === "string" ? meta.title : slug,
+    summary: typeof meta.summary === "string" ? meta.summary : "",
     tags: Array.isArray(meta.tags) ? meta.tags.map(String) : [],
     links: extractWikilinkSlugs(body),
     createdAt: typeof meta.createdAt === "string" ? meta.createdAt : undefined,
@@ -140,13 +140,24 @@ export async function listPages(
   root: string,
   options: ListPagesOptions = {},
 ): Promise<ListPagesResult> {
-  const all: Page[] = [];
+  const all = await collectPages(root, options);
+  all.sort(
+    (a, b) =>
+      a.pageDirectory.localeCompare(b.pageDirectory) || a.slug.localeCompare(b.slug),
+  );
+  return paginate(all, options);
+}
 
+/**
+ * Read every page from both directories, applying the archive/orphan filters.
+ * Bodies are always read so wikilinks can be extracted; they are only retained
+ * on the returned Page when `includeBody` is set.
+ */
+async function collectPages(root: string, options: ListPagesOptions): Promise<Page[]> {
+  const all: Page[] = [];
   for (const dir of PAGE_DIRECTORIES) {
     const dirPath = path.join(root, DIR_NAMES[dir]);
-    const scanned = await scanWikiPages(dirPath);
-
-    for (const { slug, meta } of scanned) {
+    for (const { slug, meta } of await scanWikiPages(dirPath)) {
       const content = await safeReadFile(path.join(dirPath, `${slug}.md`));
       const { body } = parseFrontmatter(content);
       const page = buildPage(dir, slug, meta, body, options.includeBody === true);
@@ -155,17 +166,22 @@ export async function listPages(
       all.push(page);
     }
   }
+  return all;
+}
 
-  all.sort(
-    (a, b) =>
-      a.pageDirectory.localeCompare(b.pageDirectory) || a.slug.localeCompare(b.slug),
-  );
-
-  const offset = options.cursor ? Number(options.cursor) : 0;
-  const limit = options.limit ?? all.length;
+/**
+ * Slice an already-sorted page list into a cursor-paged result. A non-positive
+ * or absent limit is treated as unbounded (avoids a `limit: 0` empty-slice loop);
+ * a non-integer or negative cursor is rejected rather than silently recycled.
+ */
+function paginate(all: Page[], options: ListPagesOptions): ListPagesResult {
+  const offset = options.cursor !== undefined ? Number(options.cursor) : 0;
+  if (!Number.isInteger(offset) || offset < 0) {
+    throw new Error(`invalid listPages cursor: ${options.cursor}`);
+  }
+  const limit = options.limit && options.limit > 0 ? options.limit : all.length;
   const slice = all.slice(offset, offset + limit);
   const nextOffset = offset + slice.length;
   const cursor = nextOffset < all.length ? String(nextOffset) : undefined;
-
   return cursor !== undefined ? { pages: slice, cursor } : { pages: slice };
 }

--- a/src/pages/list.ts
+++ b/src/pages/list.ts
@@ -1,0 +1,171 @@
+/**
+ * Path-safe page access primitives for the llmwiki in-process SDK.
+ *
+ * Exposes two public functions:
+ *   - `getPage(root, ref)` — fetch a single page by directory + slug; returns
+ *     the full `Page` shape (body included) or null when the file is absent.
+ *   - `listPages(root, options)` — scan both page directories, read each page's
+ *     body so wikilinks can be extracted, apply archive/orphan filters, sort,
+ *     and return a cursor-paged slice.
+ *
+ * Design notes:
+ *   - `links` are derived from the Markdown **body** via `extractWikilinkSlugs`,
+ *     NOT from frontmatter.
+ *   - `archived` and `orphaned` are boolean **frontmatter** flags.
+ *   - `scanWikiPages` returns `{ slug, meta }` only (no body), so `listPages`
+ *     always re-reads each file to extract body links even when `includeBody`
+ *     is false.
+ *   - Path safety is enforced at `getPage` entry via `assertSafeSlug`; symlink
+ *     confinement is handled at a lower level by `scanWikiPages`.
+ */
+
+import path from "path";
+import { scanWikiPages } from "../compiler/indexgen.js";
+import { safeReadFile, parseFrontmatter } from "../utils/markdown.js";
+import { extractWikilinkSlugs } from "../wiki/collect.js";
+import { assertSafeSlug } from "../viewer/path-safety.js";
+import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
+import type { PageDirectory } from "../export/types.js";
+
+export type { PageDirectory };
+
+/** A reference to a specific page by its directory and slug. */
+export interface PageRef {
+  pageDirectory: PageDirectory;
+  slug: string;
+}
+
+/** A fully-resolved in-memory representation of a single wiki page. */
+export interface Page {
+  slug: string;
+  pageDirectory: PageDirectory;
+  title: string;
+  summary: string;
+  tags: string[];
+  /** Slugs of pages linked via `[[wikilinks]]` in the body. */
+  links: string[];
+  createdAt?: string;
+  updatedAt?: string;
+  /** True when frontmatter contains `orphaned: true`. */
+  orphaned: boolean;
+  /** True when frontmatter contains `archived: true`. */
+  archived: boolean;
+  /** Full markdown body, present only when `includeBody` is true or via `getPage`. */
+  body?: string;
+}
+
+/** Options for filtering and paginating `listPages`. */
+export interface ListPagesOptions {
+  cursor?: string;
+  limit?: number;
+  includeBody?: boolean;
+  includeArchived?: boolean;
+  includeOrphaned?: boolean;
+}
+
+/** Result returned by `listPages`. */
+export interface ListPagesResult {
+  pages: Page[];
+  /** Opaque cursor for the next page; absent when the listing is exhausted. */
+  cursor?: string;
+}
+
+/** Maps each PageDirectory to its project-relative path. */
+const DIR_NAMES: Record<PageDirectory, string> = {
+  concepts: CONCEPTS_DIR,
+  queries: QUERIES_DIR,
+};
+
+/** All page directories in listing order. */
+const PAGE_DIRECTORIES: PageDirectory[] = ["concepts", "queries"];
+
+/**
+ * Build a Page from its directory, slug, parsed frontmatter, and body text.
+ * Links are always extracted from the body so they reflect real wikilinks,
+ * not any frontmatter list.
+ */
+function buildPage(
+  dir: PageDirectory,
+  slug: string,
+  meta: Record<string, unknown>,
+  body: string,
+  includeBody: boolean,
+): Page {
+  return {
+    slug,
+    pageDirectory: dir,
+    title: String(meta.title ?? slug),
+    summary: String(meta.summary ?? ""),
+    tags: Array.isArray(meta.tags) ? meta.tags.map(String) : [],
+    links: extractWikilinkSlugs(body),
+    createdAt: typeof meta.createdAt === "string" ? meta.createdAt : undefined,
+    updatedAt: typeof meta.updatedAt === "string" ? meta.updatedAt : undefined,
+    orphaned: meta.orphaned === true,
+    archived: meta.archived === true,
+    ...(includeBody ? { body } : {}),
+  };
+}
+
+/**
+ * Fetch a single page by directory and slug.
+ *
+ * Throws `PathSafetyError` for unsafe slug values. Returns `null` when the
+ * page does not exist on disk.
+ *
+ * @param root - Absolute path to the wiki workspace root.
+ * @param ref - Which directory and slug to load.
+ */
+export async function getPage(root: string, ref: PageRef): Promise<Page | null> {
+  assertSafeSlug(ref.slug);
+  const filePath = path.join(root, DIR_NAMES[ref.pageDirectory], `${ref.slug}.md`);
+  const content = await safeReadFile(filePath);
+  if (!content) return null;
+  const { meta, body } = parseFrontmatter(content);
+  return buildPage(ref.pageDirectory, ref.slug, meta, body, true);
+}
+
+/**
+ * List pages from both wiki directories with optional filtering and cursor
+ * pagination.
+ *
+ * Pages are sorted by `(pageDirectory, slug)` before slicing. Bodies are
+ * omitted by default; pass `includeBody: true` to include them. Orphaned
+ * and archived pages are excluded by default; pass the corresponding flag
+ * to include them.
+ *
+ * @param root - Absolute path to the wiki workspace root.
+ * @param options - Filtering, pagination, and inclusion options.
+ */
+export async function listPages(
+  root: string,
+  options: ListPagesOptions = {},
+): Promise<ListPagesResult> {
+  const all: Page[] = [];
+
+  for (const dir of PAGE_DIRECTORIES) {
+    const dirPath = path.join(root, DIR_NAMES[dir]);
+    const scanned = await scanWikiPages(dirPath);
+
+    for (const { slug, meta } of scanned) {
+      const content = await safeReadFile(path.join(dirPath, `${slug}.md`));
+      const { body } = parseFrontmatter(content);
+      const page = buildPage(dir, slug, meta, body, options.includeBody === true);
+      if (page.orphaned && !options.includeOrphaned) continue;
+      if (page.archived && !options.includeArchived) continue;
+      all.push(page);
+    }
+  }
+
+  all.sort(
+    (a, b) =>
+      a.pageDirectory.localeCompare(b.pageDirectory) || a.slug.localeCompare(b.slug),
+  );
+
+  const offset = options.cursor ? Number(options.cursor) : 0;
+  const limit = options.limit ?? all.length;
+  const slice = all.slice(offset, offset + limit);
+  const nextOffset = offset + slice.length;
+  const cursor = nextOffset < all.length ? String(nextOffset) : undefined;
+
+  return cursor !== undefined ? { pages: slice, cursor } : { pages: slice };
+}

--- a/src/pages/read.ts
+++ b/src/pages/read.ts
@@ -1,0 +1,52 @@
+/**
+ * Page-reading utilities for llmwiki.
+ *
+ * Exposes `readPageRecord`, which locates a wiki page by slug across the
+ * priority-ordered page directories (concepts first, then queries), parses
+ * its frontmatter, and returns a structured `PageRecord`. Orphaned pages are
+ * silently skipped to match the query pipeline's behaviour.
+ *
+ * This module is shared between the MCP tool layer and the in-process SDK so
+ * both consumers work from identical read semantics.
+ */
+
+import path from "path";
+import { safeReadFile, parseFrontmatter } from "../utils/markdown.js";
+import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
+
+/** Directories searched (in priority order) when resolving a page slug. */
+const PAGE_DIRS = [CONCEPTS_DIR, QUERIES_DIR];
+
+/** Shape returned by readPageRecord and search_pages for each matching page. */
+export interface PageRecord {
+  slug: string;
+  title: string;
+  summary: string;
+  body: string;
+}
+
+/**
+ * Locate a page by slug across the priority-ordered page directories,
+ * skipping orphaned entries to match the query pipeline's behaviour.
+ *
+ * @param root - Absolute path to the wiki workspace root.
+ * @param slug - Page slug without the `.md` extension.
+ * @returns The parsed page record, or `null` if not found or orphaned.
+ */
+export async function readPageRecord(root: string, slug: string): Promise<PageRecord | null> {
+  for (const dir of PAGE_DIRS) {
+    const content = await safeReadFile(path.join(root, dir, `${slug}.md`));
+    if (!content) continue;
+
+    const { meta, body } = parseFrontmatter(content);
+    if (meta.orphaned) continue;
+
+    return {
+      slug,
+      title: typeof meta.title === "string" ? meta.title : slug,
+      summary: typeof meta.summary === "string" ? meta.summary : "",
+      body: body.trim(),
+    };
+  }
+  return null;
+}

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -1,0 +1,84 @@
+/**
+ * @file src/sdk/types.ts
+ * @description Public type surface for the llmwiki in-process SDK.
+ *
+ * Defines the `Wiki` interface returned by `createWiki`, plus the
+ * option shapes that callers pass to each method. All concrete result
+ * types are imported directly from their owning modules so consumers
+ * who need deeper access can follow the same import path.
+ */
+
+import type { CompileResult, IngestResult, QueryResult } from "../utils/types.js";
+import type { IngestTextInput } from "../commands/ingest.js";
+import type { LintSummary } from "../linter/types.js";
+import type { ContextPack } from "../context/types.js";
+import type { EvalReport } from "../eval/types.js";
+import type { WikiStatus } from "../status/collect.js";
+import type { Page, PageRef, ListPagesOptions, ListPagesResult } from "../pages/list.js";
+import type { PageRecord } from "../pages/read.js";
+import type { JsonExportDocument } from "../export/json-export.js";
+
+/** Options for `createWiki`. */
+export interface CreateWikiOptions {
+  /** Absolute or relative path to the project root. Normalized once inside `createWiki`. */
+  root: string;
+}
+
+/** Compile options exposed through the SDK. Mirrors the core CompileOptions shape. */
+export interface SdkCompileOptions {
+  /** Write generated pages as candidates for review instead of mutating wiki/. */
+  review?: boolean;
+}
+
+/** Options for `getContextPack`. Maps onto the subset of BuildContextPackOptions needed externally. */
+export interface ContextPackOptions {
+  /** Free-text prompt the agent supplied. */
+  prompt: string;
+  /** Token budget (tokens ≈ chars/4). */
+  budget?: number;
+  /** Graph traversal depth (0–2). */
+  depth?: number;
+  /** Maximum primary pages to include. */
+  topPages?: number;
+  /** Maximum semantic chunks to include. */
+  topChunks?: number;
+}
+
+/**
+ * The facade object returned by `createWiki`. Every method runs silently
+ * (no console output) and normalizes all paths against the project root
+ * supplied at construction time.
+ */
+export interface Wiki {
+  /** Ingest a file path or URL as a new source document. Requires no LLM credentials. */
+  ingest(input: { source: string }): Promise<IngestResult>;
+  /** Ingest raw text as a new source document. Requires no LLM credentials. */
+  ingestText(input: IngestTextInput): Promise<IngestResult>;
+  /** Compile all pending sources into wiki pages. Requires LLM credentials. */
+  compile(options?: SdkCompileOptions): Promise<CompileResult>;
+  /** Pick and hydrate the most relevant pages for a question. Requires LLM credentials. */
+  search(question: string): Promise<PageRecord[]>;
+  /** Generate a grounded answer from the wiki. Requires LLM credentials. */
+  query(question: string, options?: { save?: boolean; debug?: boolean }): Promise<QueryResult>;
+  /** Fetch a single page by directory and slug. No LLM required. */
+  getPage(ref: PageRef): Promise<Page | null>;
+  /** List wiki pages with optional filters and cursor-based pagination. No LLM required. */
+  listPages(options?: ListPagesOptions): Promise<ListPagesResult>;
+  /** Collect a read-only status snapshot of the wiki. No LLM required. */
+  status(): Promise<WikiStatus>;
+  /** Run all lint rules and return a severity-counted summary. No LLM required. */
+  lint(): Promise<LintSummary>;
+  /**
+   * Build a v1 context pack for agent consumption. Lexical retrieval works
+   * credential-free; semantic retrieval is opportunistic (skipped when no
+   * embeddings are available).
+   */
+  getContextPack(options: ContextPackOptions): Promise<ContextPack>;
+  /** Export the wiki as a structured JSON document. No LLM required. */
+  exportJson(options?: { projectId?: string }): Promise<JsonExportDocument>;
+  /**
+   * Run the eval harness. "fast" mode is credential-free; "full" mode
+   * requires LLM credentials for citation-support judging.
+   */
+  runEval(options: { mode: "fast" | "full"; record?: boolean }): Promise<EvalReport>;
+}

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -50,16 +50,54 @@ export interface ContextPackOptions {
  * supplied at construction time.
  */
 export interface Wiki {
-  /** Ingest a file path or URL as a new source document. Requires no LLM credentials. */
+  /**
+   * Ingest a file path or URL as a new source document. Requires no LLM credentials.
+   *
+   * **Trust boundary (SSRF + local-file-read primitive):** this method fetches any URL
+   * or reads any local file path the caller supplies — server-side — and writes the
+   * resulting content into the wiki. Treat `source` as **trusted input only**. Do not
+   * pass user-supplied or otherwise untrusted strings here. For untrusted content, use
+   * `ingestText` instead (it accepts pre-extracted `{title, text}` with no fetch or
+   * file-read step).
+   *
+   * **Prompt-injection surface:** ingested content is later processed by an LLM during
+   * `compile`. Untrusted or adversarially crafted content in sources is therefore a
+   * prompt-injection vector into page generation.
+   */
   ingest(input: { source: string }): Promise<IngestResult>;
-  /** Ingest raw text as a new source document. Requires no LLM credentials. */
+  /**
+   * Ingest raw text as a new source document. Requires no LLM credentials.
+   *
+   * Safe path for untrusted content: no network fetch or local file read is performed.
+   * The caller supplies the text directly, so there is no SSRF or path-traversal risk
+   * at ingest time (prompt-injection into `compile` still applies if the text itself is
+   * adversarial).
+   */
   ingestText(input: IngestTextInput): Promise<IngestResult>;
-  /** Compile all pending sources into wiki pages. Requires LLM credentials. */
+  /**
+   * Compile all pending sources into wiki pages. Requires LLM credentials.
+   *
+   * **Data egress:** source content is sent to the configured LLM provider during
+   * compilation. Do not compile wikis that contain confidential data unless the
+   * provider's data-handling policies are acceptable for that content.
+   *
+   * **Silent operation:** progress output is suppressed by the SDK facade. There is no
+   * progress callback in v1; structured `onLog` event delivery is planned for v1.x.
+   * For long corpora this call may take several minutes with no intermediate feedback.
+   */
   compile(options?: SdkCompileOptions): Promise<CompileResult>;
-  /** Pick and hydrate the most relevant pages for a question. Requires LLM credentials. */
+  /**
+   * Pick and hydrate the most relevant pages for a question. Requires LLM credentials.
+   *
+   * **Data egress:** the question (and embedding request) is sent to the configured LLM
+   * provider. Wiki page content may also be sent during retrieval scoring.
+   */
   search(question: string): Promise<PageRecord[]>;
   /**
    * Generate a grounded answer from the wiki. Requires LLM credentials.
+   *
+   * **Data egress:** the question and relevant wiki page content are sent to the
+   * configured LLM provider to produce the answer.
    *
    * Streaming token delivery (`onToken`) is intentionally NOT exposed by the
    * facade in v1 — only `save` and `debug` are surfaced. Callers needing
@@ -70,9 +108,21 @@ export interface Wiki {
   getPage(ref: PageRef): Promise<Page | null>;
   /** List wiki pages with optional filters and cursor-based pagination. No LLM required. */
   listPages(options?: ListPagesOptions): Promise<ListPagesResult>;
-  /** Collect a read-only status snapshot of the wiki. No LLM required. */
+  /**
+   * Collect a read-only status snapshot of the wiki. No LLM required.
+   *
+   * **Per-call cost:** each call hashes and reads the full source corpus —
+   * O(total source bytes) — with no cross-call caching. Avoid calling this in a
+   * hot loop; an mtime-keyed cache is planned for v1.x.
+   */
   status(): Promise<WikiStatus>;
-  /** Run all lint rules and return a severity-counted summary. No LLM required. */
+  /**
+   * Run all lint rules and return a severity-counted summary. No LLM required.
+   *
+   * **Per-call cost:** each call hashes and reads the full source corpus —
+   * O(total source bytes) — with no cross-call caching. Avoid calling this in a
+   * hot loop; an mtime-keyed cache is planned for v1.x.
+   */
   lint(): Promise<LintSummary>;
   /**
    * Build a v1 context pack for agent consumption. Lexical retrieval works
@@ -80,11 +130,20 @@ export interface Wiki {
    * embeddings are available).
    */
   getContextPack(options: ContextPackOptions): Promise<ContextPack>;
-  /** Export the wiki as a structured JSON document. No LLM required. */
+  /**
+   * Export the wiki as a structured JSON document. No LLM required.
+   *
+   * **Per-call cost:** each call hashes and reads the full source corpus —
+   * O(total source bytes) — with no cross-call caching. Avoid calling this in a
+   * hot loop; an mtime-keyed cache is planned for v1.x.
+   */
   exportJson(options?: BuildJsonExportOptions): Promise<JsonExportDocument>;
   /**
    * Run the eval harness. "fast" mode is credential-free; "full" mode
    * requires LLM credentials for citation-support judging.
+   *
+   * **Silent operation:** the SDK suppresses all progress output. There is no
+   * progress callback in v1; structured `onLog` event delivery is planned for v1.x.
    */
   runEval(options: { mode: "fast" | "full"; record?: boolean }): Promise<EvalReport>;
 }

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -16,7 +16,7 @@ import type { EvalReport } from "../eval/types.js";
 import type { WikiStatus } from "../status/collect.js";
 import type { Page, PageRef, ListPagesOptions, ListPagesResult } from "../pages/list.js";
 import type { PageRecord } from "../pages/read.js";
-import type { JsonExportDocument } from "../export/json-export.js";
+import type { JsonExportDocument, BuildJsonExportOptions } from "../export/json-export.js";
 
 /** Options for `createWiki`. */
 export interface CreateWikiOptions {
@@ -58,7 +58,13 @@ export interface Wiki {
   compile(options?: SdkCompileOptions): Promise<CompileResult>;
   /** Pick and hydrate the most relevant pages for a question. Requires LLM credentials. */
   search(question: string): Promise<PageRecord[]>;
-  /** Generate a grounded answer from the wiki. Requires LLM credentials. */
+  /**
+   * Generate a grounded answer from the wiki. Requires LLM credentials.
+   *
+   * Streaming token delivery (`onToken`) is intentionally NOT exposed by the
+   * facade in v1 — only `save` and `debug` are surfaced. Callers needing
+   * per-token streaming should use `generateAnswer` directly.
+   */
   query(question: string, options?: { save?: boolean; debug?: boolean }): Promise<QueryResult>;
   /** Fetch a single page by directory and slug. No LLM required. */
   getPage(ref: PageRef): Promise<Page | null>;
@@ -75,7 +81,7 @@ export interface Wiki {
    */
   getContextPack(options: ContextPackOptions): Promise<ContextPack>;
   /** Export the wiki as a structured JSON document. No LLM required. */
-  exportJson(options?: { projectId?: string }): Promise<JsonExportDocument>;
+  exportJson(options?: BuildJsonExportOptions): Promise<JsonExportDocument>;
   /**
    * Run the eval harness. "fast" mode is credential-free; "full" mode
    * requires LLM credentials for citation-support judging.

--- a/src/sdk/wiki.ts
+++ b/src/sdk/wiki.ts
@@ -4,8 +4,8 @@
  *
  * `createWiki(options)` returns a `Wiki` object that delegates every
  * method to the SDK-safe core functions built across Tasks 1–9. All
- * methods run silently (no console output) by temporarily forcing the
- * shared quiet flag, restoring the caller's prior value on exit.
+ * methods run silently (no console output) by scoping quiet mode to the
+ * async call tree via AsyncLocalStorage, so concurrent calls are isolated.
  *
  * Provider-gating rules:
  *   - `compile`, `search`, `query` — always guard (throw ProviderUnavailableError if no creds)
@@ -17,7 +17,7 @@
  */
 
 import path from "node:path";
-import { setQuiet, getQuiet } from "../utils/output.js";
+import { withQuiet } from "../utils/output.js";
 import { ingestSource, ingestTextSource } from "../commands/ingest.js";
 import { compileAndReport } from "../compiler/index.js";
 import { generateAnswer } from "../commands/query.js";
@@ -32,18 +32,12 @@ import { getPage, listPages } from "../pages/list.js";
 import type { CreateWikiOptions, Wiki, SdkCompileOptions } from "./types.js";
 
 /**
- * Run `fn` with output forced quiet, restoring the prior flag on exit.
- * Never force-false: if the caller already had quiet=false, that state
- * is restored after `fn` completes.
+ * Run `fn` with output scoped quiet via AsyncLocalStorage.
+ * Concurrent calls are fully isolated — no global flag is mutated.
+ * Declared async so synchronous throws inside `fn` become rejected promises.
  */
 async function runQuiet<T>(fn: () => Promise<T>): Promise<T> {
-  const prev = getQuiet();
-  setQuiet(true);
-  try {
-    return await fn();
-  } finally {
-    setQuiet(prev);
-  }
+  return withQuiet(fn);
 }
 
 /**

--- a/src/sdk/wiki.ts
+++ b/src/sdk/wiki.ts
@@ -16,7 +16,7 @@
  * call works from an absolute path regardless of the caller's cwd.
  */
 
-import path from "path";
+import path from "node:path";
 import { setQuiet, getQuiet } from "../utils/output.js";
 import { ingestSource, ingestTextSource } from "../commands/ingest.js";
 import { compileAndReport } from "../compiler/index.js";

--- a/src/sdk/wiki.ts
+++ b/src/sdk/wiki.ts
@@ -1,0 +1,116 @@
+/**
+ * @file src/sdk/wiki.ts
+ * @description In-process SDK facade for llmwiki.
+ *
+ * `createWiki(options)` returns a `Wiki` object that delegates every
+ * method to the SDK-safe core functions built across Tasks 1–9. All
+ * methods run silently (no console output) by temporarily forcing the
+ * shared quiet flag, restoring the caller's prior value on exit.
+ *
+ * Provider-gating rules:
+ *   - `compile`, `search`, `query` — always guard (throw ProviderUnavailableError if no creds)
+ *   - `runEval({ mode: "full" })` — guards only when mode is "full"
+ *   - All other methods — no credential check; safe to call without an LLM provider
+ *
+ * The root path is normalized once via `path.resolve` so every downstream
+ * call works from an absolute path regardless of the caller's cwd.
+ */
+
+import path from "path";
+import { setQuiet, getQuiet } from "../utils/output.js";
+import { ingestSource, ingestTextSource } from "../commands/ingest.js";
+import { compileAndReport } from "../compiler/index.js";
+import { generateAnswer } from "../commands/query.js";
+import { lint } from "../linter/index.js";
+import { buildContextPack } from "../context/build.js";
+import { exportJson } from "../commands/export.js";
+import { runEval, DEFAULT_SAMPLE_SIZE } from "../eval/index.js";
+import { ensureProviderAvailable } from "../utils/provider-guard.js";
+import { collectStatus } from "../status/collect.js";
+import { pickSearchSlugs, loadPageRecords } from "../search/retrieval.js";
+import { getPage, listPages } from "../pages/list.js";
+import type { CreateWikiOptions, Wiki, SdkCompileOptions } from "./types.js";
+
+/**
+ * Run `fn` with output forced quiet, restoring the prior flag on exit.
+ * Never force-false: if the caller already had quiet=false, that state
+ * is restored after `fn` completes.
+ */
+async function runQuiet<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = getQuiet();
+  setQuiet(true);
+  try {
+    return await fn();
+  } finally {
+    setQuiet(prev);
+  }
+}
+
+/**
+ * Create an in-process wiki facade bound to the given project root.
+ *
+ * @param options - `{ root }` — path to the wiki project directory.
+ * @returns A `Wiki` facade whose methods delegate to the SDK-safe core.
+ */
+export function createWiki(options: CreateWikiOptions): Wiki {
+  // Normalize once so every delegated call works from an absolute path,
+  // independent of any subsequent cwd changes in the calling process.
+  const root = path.resolve(options.root);
+
+  return {
+    ingest: ({ source }) => runQuiet(() => ingestSource(root, source)),
+
+    ingestText: (input) => runQuiet(() => ingestTextSource(root, input)),
+
+    compile: (opts: SdkCompileOptions = {}) =>
+      runQuiet(() => {
+        ensureProviderAvailable();
+        return compileAndReport(root, opts);
+      }),
+
+    search: (question) =>
+      runQuiet(async () => {
+        ensureProviderAvailable();
+        const slugs = await pickSearchSlugs(root, question);
+        return loadPageRecords(root, slugs);
+      }),
+
+    query: (question, opts = {}) =>
+      runQuiet(() => {
+        ensureProviderAvailable();
+        return generateAnswer(root, question, opts);
+      }),
+
+    getPage: (ref) => runQuiet(() => getPage(root, ref)),
+
+    listPages: (opts) => runQuiet(() => listPages(root, opts)),
+
+    status: () => runQuiet(() => collectStatus(root)),
+
+    lint: () => runQuiet(() => lint(root)),
+
+    // buildContextPack uses `prompt`/`budget` field names (NOT question/tokenBudget).
+    // Semantic retrieval is opportunistic: falls back to lexical when no embeddings
+    // are available, so no credential guard is needed here.
+    getContextPack: (opts) =>
+      runQuiet(() =>
+        buildContextPack({
+          root,
+          prompt: opts.prompt,
+          ...(opts.budget !== undefined && { budget: opts.budget }),
+          ...(opts.depth !== undefined && { depth: opts.depth }),
+          ...(opts.topPages !== undefined && { topPages: opts.topPages }),
+          ...(opts.topChunks !== undefined && { topChunks: opts.topChunks }),
+        }),
+      ),
+
+    exportJson: (opts = {}) => runQuiet(() => exportJson(root, opts)),
+
+    // "full" mode calls the LLM judge; "fast" mode is credential-free.
+    runEval: ({ mode, record = false }) =>
+      runQuiet(() => {
+        if (mode === "full") ensureProviderAvailable();
+        return runEval(root, mode, DEFAULT_SAMPLE_SIZE, record);
+      }),
+  };
+}

--- a/src/sdk/wiki.ts
+++ b/src/sdk/wiki.ts
@@ -5,18 +5,24 @@
  * `createWiki(options)` returns a `Wiki` object that delegates every
  * method to the SDK-safe core functions built across Tasks 1–9. All
  * methods run silently (no console output) by scoping quiet mode to the
- * async call tree via AsyncLocalStorage, so concurrent calls are isolated.
+ * async call tree via AsyncLocalStorage, so concurrent calls are fully
+ * isolated — no global flag is mutated, eliminating the concurrency caveat
+ * described in earlier design drafts.
  *
  * Provider-gating rules:
  *   - `compile`, `search`, `query` — always guard (throw ProviderUnavailableError if no creds)
  *   - `runEval({ mode: "full" })` — guards only when mode is "full"
  *   - All other methods — no credential check; safe to call without an LLM provider
  *
- * The root path is normalized once via `path.resolve` so every downstream
- * call works from an absolute path regardless of the caller's cwd.
+ * Root-path validation: `createWiki` normalizes the root once via `path.resolve`.
+ * A non-existent root is accepted — `ingest`/`ingestText` create `sources/` via
+ * recursive `mkdir` on first write. If the path already exists but is NOT a
+ * directory (e.g. a regular file was passed by mistake), construction throws
+ * immediately with a clear error message.
  */
 
 import path from "node:path";
+import { existsSync, statSync } from "node:fs";
 import { withQuiet } from "../utils/output.js";
 import { ingestSource, ingestTextSource } from "../commands/ingest.js";
 import { compileAndReport } from "../compiler/index.js";
@@ -50,6 +56,12 @@ export function createWiki(options: CreateWikiOptions): Wiki {
   // Normalize once so every delegated call works from an absolute path,
   // independent of any subsequent cwd changes in the calling process.
   const root = path.resolve(options.root);
+
+  // A missing root is valid — ingest/ingestText create sources/ via recursive mkdir.
+  // But if the path already exists and is NOT a directory, it is always a caller mistake.
+  if (existsSync(root) && !statSync(root).isDirectory()) {
+    throw new Error(`createWiki: root exists but is not a directory: ${root}`);
+  }
 
   return {
     ingest: ({ source }) => runQuiet(() => ingestSource(root, source)),

--- a/src/search/retrieval.ts
+++ b/src/search/retrieval.ts
@@ -1,0 +1,76 @@
+/**
+ * Semantic and LLM-based page retrieval for llmwiki.
+ *
+ * Exports `pickSearchSlugs`, which resolves relevant page slugs for a
+ * question by trying chunk-level retrieval first (highest precision), then
+ * page-level embedding search, then LLM-driven selection over the wiki index.
+ * Exports `loadPageRecords`, which hydrates a list of slugs into full
+ * `PageRecord` objects, silently dropping missing or orphaned entries.
+ *
+ * This module is shared between the MCP tool layer and the in-process SDK.
+ */
+
+import path from "path";
+import { findRelevantChunks, findRelevantPages } from "../utils/embeddings.js";
+import { selectPages } from "../commands/query.js";
+import { safeReadFile } from "../utils/markdown.js";
+import { CHUNK_TOP_K, INDEX_FILE } from "../utils/constants.js";
+import { readPageRecord } from "../pages/read.js";
+import type { PageRecord } from "../pages/read.js";
+
+/** Deduplicate slugs while preserving the first-seen ordering. */
+function dedupePreservingOrder(slugs: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const slug of slugs) {
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    out.push(slug);
+  }
+  return out;
+}
+
+/**
+ * Resolve search candidates. Tries chunk-level retrieval first (highest
+ * precision), then falls back to page-level embeddings, then to LLM-driven
+ * selection over the wiki index.
+ *
+ * @param root - Absolute path to the wiki workspace root.
+ * @param question - The query used to rank pages.
+ * @returns Ordered list of relevant page slugs.
+ */
+export async function pickSearchSlugs(root: string, question: string): Promise<string[]> {
+  try {
+    const chunks = await findRelevantChunks(root, question, CHUNK_TOP_K);
+    if (chunks.length > 0) return dedupePreservingOrder(chunks.map((c) => c.chunk.slug));
+  } catch {
+    // Chunk store unavailable — fall through to page-level embeddings.
+  }
+
+  try {
+    const candidates = await findRelevantPages(root, question);
+    if (candidates.length > 0) return candidates.map((c) => c.slug);
+  } catch {
+    // Embeddings unavailable — fall through to index-based selection.
+  }
+
+  const indexContent = await safeReadFile(path.join(root, INDEX_FILE));
+  const { pages } = await selectPages(question, indexContent);
+  return pages;
+}
+
+/**
+ * Load full content for a list of slugs, skipping missing/orphaned pages.
+ *
+ * @param root - Absolute path to the wiki workspace root.
+ * @param slugs - List of page slugs to hydrate.
+ * @returns Populated page records for all found, non-orphaned pages.
+ */
+export async function loadPageRecords(root: string, slugs: string[]): Promise<PageRecord[]> {
+  const records: PageRecord[] = [];
+  for (const slug of slugs) {
+    const page = await readPageRecord(root, slug);
+    if (page) records.push(page);
+  }
+  return records;
+}

--- a/src/search/retrieval.ts
+++ b/src/search/retrieval.ts
@@ -15,8 +15,7 @@ import { findRelevantChunks, findRelevantPages } from "../utils/embeddings.js";
 import { selectPages } from "../commands/query.js";
 import { safeReadFile } from "../utils/markdown.js";
 import { CHUNK_TOP_K, INDEX_FILE } from "../utils/constants.js";
-import { readPageRecord } from "../pages/read.js";
-import type { PageRecord } from "../pages/read.js";
+import { readPageRecord, type PageRecord } from "../pages/read.js";
 
 /** Deduplicate slugs while preserving the first-seen ordering. */
 function dedupePreservingOrder(slugs: string[]): string[] {

--- a/src/status/collect.ts
+++ b/src/status/collect.ts
@@ -14,6 +14,13 @@ import { detectChanges } from "../compiler/hasher.js";
 import { countCandidates } from "../compiler/candidates.js";
 import { readStateClassified } from "../utils/state.js";
 import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
+import type { SourceChange } from "../utils/types.js";
+
+/**
+ * A source change that is actually pending: `"unchanged"` entries are
+ * filtered out by `collectStatus`, so only these three statuses remain.
+ */
+type PendingChange = SourceChange & { status: Exclude<SourceChange["status"], "unchanged"> };
 
 /** Read-only status snapshot returned by `collectStatus`. */
 export interface WikiStatus {
@@ -23,7 +30,7 @@ export interface WikiStatus {
   orphanedPages: string[];
   /** Number of compile candidates awaiting human review. */
   pendingCandidates: number;
-  pendingChanges: Array<{ file: string; status: string }>;
+  pendingChanges: Array<{ file: string; status: PendingChange["status"] }>;
 }
 
 /** Find concept slugs whose pages are flagged as orphaned. */
@@ -52,7 +59,7 @@ export async function collectStatus(root: string): Promise<WikiStatus> {
     orphanedPages: orphans,
     pendingCandidates,
     pendingChanges: changes
-      .filter((c) => c.status !== "unchanged")
+      .filter((c): c is PendingChange => c.status !== "unchanged")
       .map((c) => ({ file: c.file, status: c.status })),
   };
 }

--- a/src/status/collect.ts
+++ b/src/status/collect.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared read-only status collector for llmwiki.
+ *
+ * Exposes `collectStatus` (and its helpers `WikiStatus` interface and
+ * `findOrphanedSlugs`) for consumption by both the MCP server (`tools.ts`)
+ * and the in-process SDK.  This module is intentionally free of side effects:
+ * it uses `readStateClassified` instead of `readState`, so a corrupt
+ * state.json never causes a `.bak` write or a `console.warn`.
+ */
+
+import path from "path";
+import { collectPageSummaries, scanWikiPages } from "../compiler/indexgen.js";
+import { detectChanges } from "../compiler/hasher.js";
+import { countCandidates } from "../compiler/candidates.js";
+import { readStateClassified } from "../utils/state.js";
+import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
+
+/** Read-only status snapshot returned by `collectStatus`. */
+export interface WikiStatus {
+  pages: { concepts: number; queries: number; total: number };
+  sources: number;
+  lastCompiledAt: string | null;
+  orphanedPages: string[];
+  /** Number of compile candidates awaiting human review. */
+  pendingCandidates: number;
+  pendingChanges: Array<{ file: string; status: string }>;
+}
+
+/** Find concept slugs whose pages are flagged as orphaned. */
+async function findOrphanedSlugs(root: string): Promise<string[]> {
+  const scanned = await scanWikiPages(path.join(root, CONCEPTS_DIR));
+  return scanned.filter(({ meta }) => meta.orphaned).map(({ slug }) => slug);
+}
+
+/** Read-only status snapshot used by the wiki_status tool and SDK. */
+export async function collectStatus(root: string): Promise<WikiStatus> {
+  const concepts = await collectPageSummaries(path.join(root, CONCEPTS_DIR));
+  const queries = await collectPageSummaries(path.join(root, QUERIES_DIR));
+  const { state } = await readStateClassified(root);
+  const changes = await detectChanges(root, state);
+  const orphans = await findOrphanedSlugs(root);
+  const pendingCandidates = await countCandidates(root);
+  const compileTimes = Object.values(state.sources).map((s) => s.compiledAt);
+  const lastCompile = compileTimes.length > 0
+    ? compileTimes.sort().slice(-1)[0]
+    : null;
+
+  return {
+    pages: { concepts: concepts.length, queries: queries.length, total: concepts.length + queries.length },
+    sources: Object.keys(state.sources).length,
+    lastCompiledAt: lastCompile,
+    orphanedPages: orphans,
+    pendingCandidates,
+    pendingChanges: changes
+      .filter((c) => c.status !== "unchanged")
+      .map((c) => ({ file: c.file, status: c.status })),
+  };
+}

--- a/src/utils/llm.ts
+++ b/src/utils/llm.ts
@@ -9,6 +9,7 @@
 import { RETRY_COUNT, RETRY_BASE_MS, RETRY_MULTIPLIER } from "./constants.js";
 import { getProvider } from "./provider.js";
 import type { LLMMessage, LLMTool } from "./provider.js";
+import { note } from "./output.js";
 
 /** Sleep for a given number of milliseconds. */
 function sleep(ms: number): Promise<void> {
@@ -59,8 +60,8 @@ export async function callClaude(options: CallClaudeOptions): Promise<string> {
 
       const delayMs = RETRY_BASE_MS * Math.pow(RETRY_MULTIPLIER, attempt);
       const errMsg = error instanceof Error ? error.message : String(error);
-      console.warn(`⚠ API call failed (attempt ${attempt + 1}/${RETRY_COUNT + 1}): ${errMsg}`);
-      console.warn(`  Retrying in ${delayMs / 1000}s...`);
+      note(`⚠ API call failed (attempt ${attempt + 1}/${RETRY_COUNT + 1}): ${errMsg}`);
+      note(`  Retrying in ${delayMs / 1000}s...`);
       await sleep(delayMs);
     }
   }

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -71,7 +71,11 @@ export function header(title: string): void {
   console.log(dim("─".repeat(Math.min(title.length + 4, 60))));
 }
 
-/** Quiet-aware warning line (stderr-style notices). No-op while quiet. */
+/**
+ * Quiet-aware warning line (stderr-style notices). No-op while quiet.
+ * Writes to stderr via `console.warn` — distinct from `status()`/`header()`,
+ * which write progress to stdout via `console.log`.
+ */
 export function note(message: string): void {
   if (quietMode) return;
   console.warn(message);

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -2,7 +2,16 @@
  * ANSI colored terminal output helpers.
  * Provides consistent styling for compilation progress, status messages,
  * and streaming token display.
+ *
+ * Quiet-mode is scoped per async call tree via AsyncLocalStorage so that
+ * concurrent SDK calls (e.g. `Promise.all([wiki.lint(), wiki.search()])`)
+ * never corrupt each other's quiet state. The process-wide `quietMode` flag
+ * is preserved for the `quickstart --json` code path that calls `setQuiet`
+ * directly; `isQuiet()` checks the scoped value first and falls back to the
+ * global flag.
  */
+
+import { AsyncLocalStorage } from "node:async_hooks";
 
 const RESET = "\x1b[0m";
 const BOLD = "\x1b[1m";
@@ -48,10 +57,30 @@ export function source(text: string): string {
  * call short-circuits while the flag is set.
  *
  * Default is false, preserving byte-for-byte behaviour for every other
- * command. Callers are responsible for restoring the flag in a `finally`
- * block if they need partial silence.
+ * command. SDK callers should use `withQuiet` instead of mutating this
+ * flag directly, to avoid concurrent call corruption.
  */
 let quietMode = false;
+
+/** ALS store scopes quietness to a single async call tree. */
+const quietScope = new AsyncLocalStorage<boolean>();
+
+/**
+ * Run `fn` with quiet mode scoped to the current async call tree.
+ * Concurrent calls are fully isolated — no global flag is mutated.
+ * Returns whatever `fn` returns (preserves Promise for async functions).
+ */
+export function withQuiet<T>(fn: () => T): T {
+  return quietScope.run(true, fn);
+}
+
+/**
+ * Returns true if the current async context is quiet (via ALS scope)
+ * or the process-wide quiet flag is set. The scoped value takes priority.
+ */
+export function isQuiet(): boolean {
+  return quietScope.getStore() ?? quietMode;
+}
 
 /** Toggle the process-wide quiet flag. */
 export function setQuiet(quiet: boolean): void {
@@ -60,13 +89,13 @@ export function setQuiet(quiet: boolean): void {
 
 /** Print a status line with an icon. No-op while quiet mode is enabled. */
 export function status(icon: string, message: string): void {
-  if (quietMode) return;
+  if (isQuiet()) return;
   console.log(`${icon} ${message}`);
 }
 
 /** Print a section header. No-op while quiet mode is enabled. */
 export function header(title: string): void {
-  if (quietMode) return;
+  if (isQuiet()) return;
   console.log(`\n${BOLD}${title}${RESET}`);
   console.log(dim("─".repeat(Math.min(title.length + 4, 60))));
 }
@@ -77,11 +106,11 @@ export function header(title: string): void {
  * which write progress to stdout via `console.log`.
  */
 export function note(message: string): void {
-  if (quietMode) return;
+  if (isQuiet()) return;
   console.warn(message);
 }
 
-/** Read the current quiet flag so callers can save/restore it. */
+/** Read the current process-wide quiet flag. */
 export function getQuiet(): boolean {
   return quietMode;
 }

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -70,3 +70,14 @@ export function header(title: string): void {
   console.log(`\n${BOLD}${title}${RESET}`);
   console.log(dim("─".repeat(Math.min(title.length + 4, 60))));
 }
+
+/** Quiet-aware warning line (stderr-style notices). No-op while quiet. */
+export function note(message: string): void {
+  if (quietMode) return;
+  console.warn(message);
+}
+
+/** Read the current quiet flag so callers can save/restore it. */
+export function getQuiet(): boolean {
+  return quietMode;
+}

--- a/src/utils/provider-guard.ts
+++ b/src/utils/provider-guard.ts
@@ -71,11 +71,11 @@ export function ensureProviderAvailable(): void {
 
   const keyVar = PROVIDER_KEY_VARS[provider];
   if (keyVar === undefined) {
+    const supported = Object.keys(PROVIDER_KEY_VARS);
     throw new UnknownProviderError(
       provider,
-      Object.keys(PROVIDER_KEY_VARS),
-      `Unknown provider "${provider}".\n` +
-        `  Supported: ${Object.keys(PROVIDER_KEY_VARS).join(", ")}`,
+      supported,
+      `Unknown provider "${provider}".\n` + `  Supported: ${supported.join(", ")}`,
     );
   }
 

--- a/src/utils/provider-guard.ts
+++ b/src/utils/provider-guard.ts
@@ -20,6 +20,24 @@
 import { DEFAULT_PROVIDER } from "./constants.js";
 import { resolveAnthropicAuthFromEnv } from "./claude-settings.js";
 
+/** Thrown when the active provider has no usable credentials. */
+export class ProviderUnavailableError extends Error {
+  readonly code = "provider_unavailable" as const;
+  constructor(readonly provider: string, readonly missing: string[], message: string) {
+    super(message);
+    this.name = "ProviderUnavailableError";
+  }
+}
+
+/** Thrown when LLMWIKI_PROVIDER names an unsupported provider. */
+export class UnknownProviderError extends Error {
+  readonly code = "unknown_provider" as const;
+  constructor(readonly provider: string, readonly supported: string[], message: string) {
+    super(message);
+    this.name = "UnknownProviderError";
+  }
+}
+
 /** Map of provider name to the env var that satisfies it. Null = no key needed. */
 const PROVIDER_KEY_VARS: Record<string, string | null> = {
   anthropic: "ANTHROPIC_API_KEY",
@@ -41,7 +59,9 @@ export function ensureProviderAvailable(): void {
   if (provider === "anthropic") {
     const auth = resolveAnthropicAuthFromEnv();
     if (!auth.apiKey && !auth.authToken) {
-      throw new Error(
+      throw new ProviderUnavailableError(
+        "anthropic",
+        ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"],
         `Anthropic credentials are required for the "anthropic" provider.\n` +
           `  Set one of: export ANTHROPIC_API_KEY=<your-key> OR export ANTHROPIC_AUTH_TOKEN=<your-token>`,
       );
@@ -51,14 +71,18 @@ export function ensureProviderAvailable(): void {
 
   const keyVar = PROVIDER_KEY_VARS[provider];
   if (keyVar === undefined) {
-    throw new Error(
+    throw new UnknownProviderError(
+      provider,
+      Object.keys(PROVIDER_KEY_VARS),
       `Unknown provider "${provider}".\n` +
         `  Supported: ${Object.keys(PROVIDER_KEY_VARS).join(", ")}`,
     );
   }
 
   if (keyVar && !process.env[keyVar]) {
-    throw new Error(
+    throw new ProviderUnavailableError(
+      provider,
+      [keyVar],
       `${keyVar} environment variable is required for the "${provider}" provider.\n` +
         `  Set it with: export ${keyVar}=<your-key>`,
     );

--- a/src/utils/source-writer.ts
+++ b/src/utils/source-writer.ts
@@ -43,9 +43,13 @@ function shortHashOfSource(source: string): string {
  *   share a basename coexist instead of one silently overwriting the
  *   other.
  */
-async function resolveCollisionFreeFilename(slug: string, source: string): Promise<string> {
+async function resolveCollisionFreeFilename(
+  sourcesDir: string,
+  slug: string,
+  source: string,
+): Promise<string> {
   const candidate = `${slug}.md`;
-  const candidatePath = path.join(SOURCES_DIR, candidate);
+  const candidatePath = path.join(sourcesDir, candidate);
   let existing: string;
   try {
     existing = await readFile(candidatePath, "utf-8");
@@ -72,6 +76,7 @@ async function resolveCollisionFreeFilename(slug: string, source: string): Promi
  *                 collision disambiguation and idempotency on re-ingest.
  */
 export async function saveSource(
+  root: string,
   title: string,
   document: string,
   source: string,
@@ -87,9 +92,10 @@ export async function saveSource(
         `Rename the source file to one with at least one letter or digit.`,
     );
   }
-  await mkdir(SOURCES_DIR, { recursive: true });
-  const filename = await resolveCollisionFreeFilename(slug, source);
-  const destPath = path.join(SOURCES_DIR, filename);
+  const sourcesDir = path.join(root, SOURCES_DIR);
+  await mkdir(sourcesDir, { recursive: true });
+  const filename = await resolveCollisionFreeFilename(sourcesDir, slug, source);
+  const destPath = path.join(sourcesDir, filename);
   await writeFile(destPath, document, "utf-8");
   return destPath;
 }

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -11,6 +11,7 @@ import { readFile, writeFile, rename, mkdir, copyFile } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
 import { LLMWIKI_DIR, STATE_FILE } from "./constants.js";
+import { note } from "./output.js";
 import type { WikiState, SourceState } from "./types.js";
 
 function emptyState(): WikiState {
@@ -45,7 +46,7 @@ export async function readState(root: string): Promise<WikiState> {
   if (classified.status === "corrupt") {
     const filePath = path.join(root, STATE_FILE);
     const bakPath = filePath + ".bak";
-    console.warn(`⚠ Corrupt state.json — backed up to ${bakPath}, starting fresh.`);
+    note(`⚠ Corrupt state.json — backed up to ${bakPath}, starting fresh.`);
     await copyFile(filePath, bakPath);
   }
   return classified.state;

--- a/test/commands/ingest-text.test.ts
+++ b/test/commands/ingest-text.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { ingestTextSource } from "../../src/commands/ingest.js";
+
+describe("ingestTextSource identity", () => {
+  it("is idempotent for same title+text, coexists for same title+different text", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-text-"));
+    await ingestTextSource(root, { title: "Note", text: "alpha" });
+    await ingestTextSource(root, { title: "Note", text: "alpha" }); // same → idempotent
+    let files = await readdir(path.join(root, "sources"));
+    expect(files.length).toBe(1);
+    await ingestTextSource(root, { title: "Note", text: "beta" });  // diff → coexist
+    files = await readdir(path.join(root, "sources"));
+    expect(files.length).toBe(2);
+  });
+});

--- a/test/commands/ingest-text.test.ts
+++ b/test/commands/ingest-text.test.ts
@@ -15,4 +15,18 @@ describe("ingestTextSource identity", () => {
     files = await readdir(path.join(root, "sources"));
     expect(files.length).toBe(2);
   });
+
+  it("uses explicit source when provided", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-text-"));
+    const result = await ingestTextSource(root, { title: "Note", text: "alpha", source: "manual:custom-id" });
+    expect(result.source).toBe("manual:custom-id");
+  });
+
+  it("does not collide when the title/text boundary shifts", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-text-"));
+    await ingestTextSource(root, { title: "ab", text: "cde" });
+    await ingestTextSource(root, { title: "abc", text: "de" });
+    const files = await readdir(path.join(root, "sources"));
+    expect(files.length).toBe(2);
+  });
 });

--- a/test/export/export-json.test.ts
+++ b/test/export/export-json.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Tests for the in-memory exportJson entry point.
+ *
+ * Verifies that exportJson returns a JsonExportDocument object (not a string)
+ * with no file I/O side effects, and that an empty wiki root yields an empty
+ * pages array rather than throwing.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { exportJson } from "../../src/commands/export.js";
+
+describe("exportJson returns an in-memory object", () => {
+  it("returns a JsonExportDocument object (not a string) with no file writes", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-exp-"));
+    const doc = await exportJson(root);
+    expect(typeof doc).toBe("object");
+    expect(doc.schemaVersion).toBe(1);
+    expect(Array.isArray(doc.pages)).toBe(true);
+    expect(typeof doc.exportedAt).toBe("string");
+  });
+});

--- a/test/ingest-session.test.ts
+++ b/test/ingest-session.test.ts
@@ -226,7 +226,7 @@ describe("ingestSessionFile", () => {
 
   // Restore cwd after each test so we do not pollute the test environment.
   it("saves a Claude session to sources/ and returns correct metadata", async () => {
-    const result = await ingestSessionFile(claudeFile);
+    const result = await ingestSessionFile(tempRoot, claudeFile);
     expect(result.adapter).toBe("claude");
     expect(result.filename.endsWith(".md")).toBe(true);
     expect(result.title).toBe("How do I implement a binary search tree in TypeScript?");
@@ -238,7 +238,7 @@ describe("ingestSessionFile", () => {
   });
 
   it("saves a Codex session to sources/ and returns correct metadata", async () => {
-    const result = await ingestSessionFile(codexFile);
+    const result = await ingestSessionFile(tempRoot, codexFile);
     expect(result.adapter).toBe("codex");
     expect(result.filename.endsWith(".md")).toBe(true);
 
@@ -246,7 +246,7 @@ describe("ingestSessionFile", () => {
   });
 
   it("saves a Cursor session to sources/ and returns correct metadata", async () => {
-    const result = await ingestSessionFile(cursorFile);
+    const result = await ingestSessionFile(tempRoot, cursorFile);
     expect(result.adapter).toBe("cursor");
     expect(result.filename.endsWith(".md")).toBe(true);
 

--- a/test/ingest-session.test.ts
+++ b/test/ingest-session.test.ts
@@ -7,7 +7,7 @@
  *   - End-to-end write to sources/ via ingestSessionFile
  */
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import path from "path";
 import os from "os";
 import { mkdir, readdir } from "fs/promises";
@@ -221,10 +221,12 @@ describe("ingestSessionFile", () => {
     );
     await mkdir(tempRoot, { recursive: true });
     originalCwd = process.cwd();
-    process.chdir(tempRoot);
   });
 
-  // Restore cwd after each test so we do not pollute the test environment.
+  // Restore cwd after each test so a test that changes it cannot leak a stale
+  // working directory into the rest of the suite, even when it throws.
+  afterEach(() => process.chdir(originalCwd));
+
   it("saves a Claude session to sources/ and returns correct metadata", async () => {
     const result = await ingestSessionFile(tempRoot, claudeFile);
     expect(result.adapter).toBe("claude");
@@ -233,23 +235,17 @@ describe("ingestSessionFile", () => {
 
     const files = await readdir(path.join(tempRoot, "sources"));
     expect(files).toContain(result.filename);
-
-    process.chdir(originalCwd);
   });
 
   it("saves a Codex session to sources/ and returns correct metadata", async () => {
     const result = await ingestSessionFile(tempRoot, codexFile);
     expect(result.adapter).toBe("codex");
     expect(result.filename.endsWith(".md")).toBe(true);
-
-    process.chdir(originalCwd);
   });
 
   it("saves a Cursor session to sources/ and returns correct metadata", async () => {
     const result = await ingestSessionFile(tempRoot, cursorFile);
     expect(result.adapter).toBe("cursor");
     expect(result.filename.endsWith(".md")).toBe(true);
-
-    process.chdir(originalCwd);
   });
 });

--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { readPage } from "../src/mcp/tools.js";
+import { readPageRecord } from "../src/pages/read.js";
 import { writePage } from "./fixtures/write-page.js";
 import {
   buildServer as buildSharedServer,
@@ -135,7 +135,7 @@ describe("compile_wiki tool", () => {
   });
 });
 
-describe("read_page tool and helper", () => {
+describe("read_page tool and readPageRecord helper", () => {
   it("reads a concept page", async () => {
     await writePage(
       path.join(root, "wiki/concepts"),
@@ -144,7 +144,7 @@ describe("read_page tool and helper", () => {
       "Deep learning basics.",
     );
 
-    const page = await readPage(root, "neural-networks");
+    const page = await readPageRecord(root, "neural-networks");
     expect(page).toEqual({
       slug: "neural-networks",
       title: "Neural Networks",
@@ -161,13 +161,13 @@ describe("read_page tool and helper", () => {
       "Saved query body.",
     );
 
-    const page = await readPage(root, "what-is-x");
+    const page = await readPageRecord(root, "what-is-x");
     expect(page?.title).toBe("What is X?");
     expect(page?.body).toBe("Saved query body.");
   });
 
   it("returns null when slug exists in neither directory", async () => {
-    expect(await readPage(root, "missing")).toBeNull();
+    expect(await readPageRecord(root, "missing")).toBeNull();
   });
 
   it("read_page tool throws an error for missing pages", async () => {

--- a/test/mcp/ingest-root.test.ts
+++ b/test/mcp/ingest-root.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { ingestSource } from "../../src/commands/ingest.js";
+
+describe("ingestSource is root-explicit", () => {
+  const cwd = process.cwd();
+  afterEach(() => process.chdir(cwd));
+
+  it("writes under the passed root even when process.cwd() is elsewhere", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-root-"));
+    const foreign = await mkdtemp(path.join(tmpdir(), "wiki-cwd-"));
+    process.chdir(foreign);
+    const local = path.join(root, "fixture.txt");
+    await writeFile(local, "hello body text", "utf-8");
+    await ingestSource(root, local);
+    const files = await readdir(path.join(root, "sources"));
+    expect(files.some((f) => f.endsWith(".md"))).toBe(true);
+    await expect(readdir(path.join(foreign, "sources"))).rejects.toThrow();
+  });
+});

--- a/test/pages/list.test.ts
+++ b/test/pages/list.test.ts
@@ -12,18 +12,14 @@ import path from "node:path";
 import { getPage, listPages } from "../../src/pages/list.js";
 import { PathSafetyError } from "../../src/viewer/path-safety.js";
 
-async function seed(root: string) {
+async function writeConcept(root: string, slug: string, content: string) {
   await mkdir(path.join(root, "wiki/concepts"), { recursive: true });
-  await writeFile(
-    path.join(root, "wiki/concepts/b.md"),
-    "---\ntitle: B\nsummary: sb\ntags: [x]\n---\nbody-b [[a]]",
-    "utf-8",
-  );
-  await writeFile(
-    path.join(root, "wiki/concepts/a.md"),
-    "---\ntitle: A\nsummary: sa\n---\nbody-a",
-    "utf-8",
-  );
+  await writeFile(path.join(root, `wiki/concepts/${slug}.md`), content, "utf-8");
+}
+
+async function seed(root: string) {
+  await writeConcept(root, "b", "---\ntitle: B\nsummary: sb\ntags: [x]\n---\nbody-b [[a]]");
+  await writeConcept(root, "a", "---\ntitle: A\nsummary: sa\n---\nbody-a");
 }
 
 describe("getPage / listPages", () => {
@@ -43,5 +39,60 @@ describe("getPage / listPages", () => {
     expect(pages.find((p) => p.slug === "b")?.links).toContain("a"); // [[a]] in body-b
     const withBody = await getPage(root, { pageDirectory: "concepts", slug: "a" });
     expect(withBody?.body).toContain("body-a");
+  });
+
+  it("getPage returns null for a missing slug", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-list3-"));
+    const page = await getPage(root, { pageDirectory: "concepts", slug: "nope" });
+    expect(page).toBeNull();
+  });
+
+  it("excludes archived pages by default, includes them with includeArchived", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-list4-"));
+    await writeConcept(root, "live", "---\ntitle: Live\n---\nbody");
+    await writeConcept(root, "old", "---\ntitle: Old\narchived: true\n---\nbody");
+    const def = await listPages(root);
+    expect(def.pages.map((p) => p.slug)).toEqual(["live"]);
+    const all = await listPages(root, { includeArchived: true });
+    expect(all.pages.map((p) => p.slug)).toEqual(["live", "old"]);
+  });
+
+  it("excludes orphaned pages by default, includes them with includeOrphaned", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-list5-"));
+    await writeConcept(root, "live", "---\ntitle: Live\n---\nbody");
+    await writeConcept(root, "ghost", "---\ntitle: Ghost\norphaned: true\n---\nbody");
+    const def = await listPages(root);
+    expect(def.pages.map((p) => p.slug)).toEqual(["live"]);
+    const all = await listPages(root, { includeOrphaned: true });
+    expect(all.pages.map((p) => p.slug)).toEqual(["ghost", "live"]);
+  });
+
+  it("paginates with limit and cursor", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-list6-"));
+    await writeConcept(root, "a", "---\ntitle: A\n---\nbody");
+    await writeConcept(root, "b", "---\ntitle: B\n---\nbody");
+    await writeConcept(root, "c", "---\ntitle: C\n---\nbody");
+    const first = await listPages(root, { limit: 2 });
+    expect(first.pages.map((p) => p.slug)).toEqual(["a", "b"]);
+    expect(first.cursor).toBeDefined();
+    const second = await listPages(root, { limit: 2, cursor: first.cursor });
+    expect(second.pages.map((p) => p.slug)).toEqual(["c"]);
+    expect(second.cursor).toBeUndefined();
+  });
+
+  it("includeBody populates body; default omits it", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-list7-"));
+    await seed(root);
+    const def = await listPages(root);
+    expect(def.pages[0].body).toBeUndefined();
+    const withBody = await listPages(root, { includeBody: true });
+    expect(withBody.pages.find((p) => p.slug === "a")?.body).toContain("body-a");
+  });
+
+  it("throws on an invalid cursor", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-list8-"));
+    await seed(root);
+    await expect(listPages(root, { cursor: "abc" })).rejects.toThrow(/invalid listPages cursor/);
+    await expect(listPages(root, { cursor: "-2" })).rejects.toThrow(/invalid listPages cursor/);
   });
 });

--- a/test/pages/list.test.ts
+++ b/test/pages/list.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for getPage / listPages in src/pages/list.ts.
+ *
+ * Covers: path-safety rejection, sorted listing, body omitted by default,
+ * links derived from the page body (not frontmatter), and getPage with body.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { getPage, listPages } from "../../src/pages/list.js";
+import { PathSafetyError } from "../../src/viewer/path-safety.js";
+
+async function seed(root: string) {
+  await mkdir(path.join(root, "wiki/concepts"), { recursive: true });
+  await writeFile(
+    path.join(root, "wiki/concepts/b.md"),
+    "---\ntitle: B\nsummary: sb\ntags: [x]\n---\nbody-b [[a]]",
+    "utf-8",
+  );
+  await writeFile(
+    path.join(root, "wiki/concepts/a.md"),
+    "---\ntitle: A\nsummary: sa\n---\nbody-a",
+    "utf-8",
+  );
+}
+
+describe("getPage / listPages", () => {
+  it("rejects unsafe slugs", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-list-"));
+    await expect(
+      getPage(root, { pageDirectory: "concepts", slug: "../secret" }),
+    ).rejects.toBeInstanceOf(PathSafetyError);
+  });
+
+  it("lists pages sorted by {pageDirectory, slug}, bodies omitted by default, links from body", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-list2-"));
+    await seed(root);
+    const { pages } = await listPages(root);
+    expect(pages.map((p) => p.slug)).toEqual(["a", "b"]);
+    expect(pages[0].body).toBeUndefined();
+    expect(pages.find((p) => p.slug === "b")?.links).toContain("a"); // [[a]] in body-b
+    const withBody = await getPage(root, { pageDirectory: "concepts", slug: "a" });
+    expect(withBody?.body).toContain("body-a");
+  });
+});

--- a/test/pages/read.test.ts
+++ b/test/pages/read.test.ts
@@ -5,12 +5,19 @@ import path from "node:path";
 import { readPageRecord } from "../../src/pages/read.js";
 
 describe("readPageRecord", () => {
-  it("reads a concept page and skips orphaned pages", async () => {
+  it("reads a concept page", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "wiki-read-"));
     await mkdir(path.join(root, "wiki/concepts"), { recursive: true });
     await writeFile(path.join(root, "wiki/concepts/foo.md"), "---\ntitle: Foo\nsummary: s\n---\nbody", "utf-8");
     const page = await readPageRecord(root, "foo");
     expect(page?.title).toBe("Foo");
     expect(page?.body).toContain("body");
+  });
+
+  it("skips orphaned pages, returning null", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-read-"));
+    await mkdir(path.join(root, "wiki/concepts"), { recursive: true });
+    await writeFile(path.join(root, "wiki/concepts/gone.md"), "---\ntitle: Gone\norphaned: true\n---\nbody", "utf-8");
+    expect(await readPageRecord(root, "gone")).toBeNull();
   });
 });

--- a/test/pages/read.test.ts
+++ b/test/pages/read.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { readPageRecord } from "../../src/pages/read.js";
+
+describe("readPageRecord", () => {
+  it("reads a concept page and skips orphaned pages", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-read-"));
+    await mkdir(path.join(root, "wiki/concepts"), { recursive: true });
+    await writeFile(path.join(root, "wiki/concepts/foo.md"), "---\ntitle: Foo\nsummary: s\n---\nbody", "utf-8");
+    const page = await readPageRecord(root, "foo");
+    expect(page?.title).toBe("Foo");
+    expect(page?.body).toContain("body");
+  });
+});

--- a/test/sdk/acceptance.test.ts
+++ b/test/sdk/acceptance.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @file test/sdk/acceptance.test.ts
+ * @description Acceptance tests for the `createWiki` SDK facade (Task 11).
+ *
+ * These tests are MANDATORY deterministic gates — they run without LLM
+ * credentials and exercise the provider-gating contract, root isolation,
+ * and schema shape of the exported document.  No real API calls are made.
+ *
+ * Credential removal strategy: deleting the explicit env vars is not
+ * sufficient on its own because `resolveAnthropicAuthFromEnv` also falls
+ * back to `~/.claude/settings.json`.  Each test that needs credential-free
+ * execution also sets `LLMWIKI_CLAUDE_SETTINGS_PATH` to a non-existent
+ * path so the file-read returns undefined and the fallback chain is severed.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createWiki } from "../../src/sdk/wiki.js";
+import { ProviderUnavailableError, UnknownProviderError } from "../../src/utils/provider-guard.js";
+
+const saved = { ...process.env };
+afterEach(() => {
+  process.env = { ...saved };
+});
+
+/** Remove all Anthropic credentials and sever the Claude settings file fallback. */
+function stripAnthropicCreds(): void {
+  process.env.LLMWIKI_PROVIDER = "anthropic";
+  delete process.env.ANTHROPIC_API_KEY;
+  delete process.env.ANTHROPIC_AUTH_TOKEN;
+  // Sever the ~/.claude/settings.json fallback so CI passes without a settings file.
+  process.env.LLMWIKI_CLAUDE_SETTINGS_PATH = path.join(tmpdir(), "no-such-settings-llmwiki-test.json");
+}
+
+/** Assert that a promise does NOT reject with `ProviderUnavailableError`.
+ *  If it rejects for an unrelated reason (e.g. empty root, missing index) that is
+ *  acceptable — we only care that the credential guard was not the cause. */
+async function expectNotProviderUnavailable(promise: Promise<unknown>): Promise<void> {
+  try {
+    await promise;
+  } catch (err) {
+    expect(err).not.toBeInstanceOf(ProviderUnavailableError);
+  }
+}
+
+describe("SDK acceptance", () => {
+  it("compile throws ProviderUnavailableError without creds (mandatory gate)", async () => {
+    stripAnthropicCreds();
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-acc-"));
+    await expect(createWiki({ root }).compile()).rejects.toBeInstanceOf(ProviderUnavailableError);
+  });
+
+  it("search throws ProviderUnavailableError without creds (mandatory gate)", async () => {
+    stripAnthropicCreds();
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-search-"));
+    await expect(createWiki({ root }).search("any question")).rejects.toBeInstanceOf(ProviderUnavailableError);
+  });
+
+  it("query throws ProviderUnavailableError without creds (mandatory gate)", async () => {
+    stripAnthropicCreds();
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-query-"));
+    await expect(createWiki({ root }).query("any question")).rejects.toBeInstanceOf(ProviderUnavailableError);
+  });
+
+  it("runEval({ mode: 'full' }) throws ProviderUnavailableError without creds (mandatory gate)", async () => {
+    stripAnthropicCreds();
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-eval-full-"));
+    await expect(createWiki({ root }).runEval({ mode: "full" })).rejects.toBeInstanceOf(ProviderUnavailableError);
+  });
+
+  it("runEval({ mode: 'fast' }) does NOT throw ProviderUnavailableError (credential-free)", async () => {
+    stripAnthropicCreds();
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-eval-fast-"));
+    // Fast mode is not provider-gated; may fail for unrelated reasons on an empty root.
+    await expectNotProviderUnavailable(createWiki({ root }).runEval({ mode: "fast" }));
+  });
+
+  it("compile throws UnknownProviderError for an unsupported provider", async () => {
+    process.env.LLMWIKI_PROVIDER = "bogus";
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-unknown-prov-"));
+    await expect(createWiki({ root }).compile()).rejects.toBeInstanceOf(UnknownProviderError);
+  });
+
+  it("getContextPack does NOT throw ProviderUnavailableError (lexical fallback)", async () => {
+    stripAnthropicCreds();
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-ctx-"));
+    // Lexical retrieval works credential-free; may resolve to an empty pack or
+    // reject for an unrelated reason (no compiled index) on an empty root.
+    await expectNotProviderUnavailable(createWiki({ root }).getContextPack({ prompt: "x" }));
+  });
+
+  it("two clients on different roots do not cross-write (root isolation)", async () => {
+    const a = await mkdtemp(path.join(tmpdir(), "wiki-a-"));
+    const b = await mkdtemp(path.join(tmpdir(), "wiki-b-"));
+    await createWiki({ root: a }).ingestText({ title: "A", text: "x" });
+    await createWiki({ root: b }).ingestText({ title: "B", text: "y" });
+    expect((await readdir(path.join(a, "sources"))).length).toBe(1);
+    expect((await readdir(path.join(b, "sources"))).length).toBe(1);
+  });
+
+  it("exportJson returns a typed object", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-exp2-"));
+    const doc = await createWiki({ root }).exportJson();
+    expect(doc).toMatchObject({ schemaVersion: 1, pageCount: expect.any(Number) });
+    expect(Array.isArray(doc.pages)).toBe(true);
+  });
+});

--- a/test/sdk/create-wiki-root.test.ts
+++ b/test/sdk/create-wiki-root.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @file test/sdk/create-wiki-root.test.ts
+ * @description Tests for createWiki root-path validation.
+ *
+ * Covers two contract cases:
+ *  1. A non-existent root is VALID — ingestText will create `sources/` via recursive mkdir.
+ *  2. A root that exists but is NOT a directory (e.g. a regular file) must THROW
+ *     synchronously with a clear message during construction.
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdtemp, writeFile, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createWiki } from "../../src/sdk/wiki.js";
+
+describe("createWiki root validation", () => {
+  it("accepts a non-existent root and ingestText creates sources/ under it", async () => {
+    const base = await mkdtemp(path.join(tmpdir(), "wiki-sdk-root-missing-"));
+    // Use a sub-path that does not exist yet
+    const root = path.join(base, "fresh-wiki");
+
+    // Construction must not throw
+    const wiki = createWiki({ root });
+
+    // ingestText writes into root/sources/, creating the directory tree
+    await wiki.ingestText({ title: "Hello", text: "world content here" });
+
+    const files = await readdir(path.join(root, "sources"));
+    expect(files.length).toBe(1);
+  });
+
+  it("throws when root exists but is a file, not a directory", async () => {
+    const base = await mkdtemp(path.join(tmpdir(), "wiki-sdk-root-file-"));
+    const filePath = path.join(base, "not-a-dir.txt");
+    await writeFile(filePath, "I am a file", "utf-8");
+
+    expect(() => createWiki({ root: filePath })).toThrowError(
+      /not a directory/i,
+    );
+  });
+});

--- a/test/sdk/facade.test.ts
+++ b/test/sdk/facade.test.ts
@@ -10,6 +10,7 @@ describe("createWiki facade (non-LLM)", () => {
     await mkdir(path.join(root, "wiki/concepts"), { recursive: true });
     await writeFile(path.join(root, "wiki/concepts/a.md"), "---\ntitle: A\nsummary: s\n---\nbody", "utf-8");
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const wiki = createWiki({ root });
     await wiki.ingestText({ title: "Note", text: "hello" });
     const { pages } = await wiki.listPages();
@@ -18,6 +19,8 @@ describe("createWiki facade (non-LLM)", () => {
     expect(pages.map((p) => p.slug)).toContain("a");
     expect(doc.schemaVersion).toBe(1);
     expect(logSpy).not.toHaveBeenCalled(); // quiet by default
+    expect(warnSpy).not.toHaveBeenCalled(); // note() routes to console.warn
     logSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 });

--- a/test/sdk/facade.test.ts
+++ b/test/sdk/facade.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from "vitest";
+import { mkdtemp, mkdir, writeFile, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createWiki } from "../../src/sdk/wiki.js";
+
+describe("createWiki facade (non-LLM)", () => {
+  it("ingests, lists seeded pages, exports — silently — under a normalized root", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-sdk-"));
+    await mkdir(path.join(root, "wiki/concepts"), { recursive: true });
+    await writeFile(path.join(root, "wiki/concepts/a.md"), "---\ntitle: A\nsummary: s\n---\nbody", "utf-8");
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const wiki = createWiki({ root });
+    await wiki.ingestText({ title: "Note", text: "hello" });
+    const { pages } = await wiki.listPages();
+    const doc = await wiki.exportJson();
+    expect((await readdir(path.join(root, "sources"))).length).toBe(1);
+    expect(pages.map((p) => p.slug)).toContain("a");
+    expect(doc.schemaVersion).toBe(1);
+    expect(logSpy).not.toHaveBeenCalled(); // quiet by default
+    logSpy.mockRestore();
+  });
+});

--- a/test/sdk/ingest-journal.test.ts
+++ b/test/sdk/ingest-journal.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Regression test for the SDK ingest activity-journal contract.
+ *
+ * The #85 activity journal lives inside `ingestSource`, which the SDK's
+ * `wiki.ingest()` calls. After the root-explicit ingest change, the journal
+ * must be written under the bound project `root` (not `process.cwd()`) and
+ * record a root-relative `Saved:` path. The CLI activity-log test cannot catch
+ * a root-vs-cwd regression because there cwd === root; this test drives the SDK
+ * with cwd deliberately set ELSEWHERE so the distinction is exercised.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, writeFile, readFile, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createWiki } from "../../src/sdk/wiki.js";
+import { LOG_FILE } from "../../src/utils/constants.js";
+
+describe("SDK ingest journaling is root-bound", () => {
+  const originalCwd = process.cwd();
+  afterEach(() => process.chdir(originalCwd));
+
+  it("wiki.ingest writes log.md under root (not cwd) with a relative Saved path", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-jrnl-root-"));
+    const foreignCwd = await mkdtemp(path.join(tmpdir(), "wiki-jrnl-cwd-"));
+    const srcFile = path.join(root, "note.md");
+    // >= MIN_SOURCE_CHARS (50) so ingest doesn't reject the content.
+    await writeFile(srcFile, "Source body content for the SDK journaling regression test.", "utf-8");
+
+    process.chdir(foreignCwd); // cwd != root — the case the CLI test can't cover
+    await createWiki({ root }).ingest({ source: srcFile });
+
+    // Journal lands under ROOT, never under the foreign cwd.
+    expect(existsSync(path.join(root, LOG_FILE))).toBe(true);
+    expect(existsSync(path.join(foreignCwd, LOG_FILE))).toBe(false);
+
+    const log = await readFile(path.join(root, LOG_FILE), "utf-8");
+    expect(log).toMatch(/^## \[.+Z\] ingest \| /m);
+    expect(log).toContain("- Saved: sources/"); // root-relative, not an absolute path
+    expect(log).not.toMatch(/- Saved: \//); // never an absolute /... path
+
+    await rm(root, { recursive: true, force: true });
+    await rm(foreignCwd, { recursive: true, force: true });
+  });
+});

--- a/test/sdk/ingest-journal.test.ts
+++ b/test/sdk/ingest-journal.test.ts
@@ -43,4 +43,19 @@ describe("SDK ingest journaling is root-bound", () => {
     await rm(root, { recursive: true, force: true });
     await rm(foreignCwd, { recursive: true, force: true });
   });
+
+  it("wiki.ingestText also journals the ingest under root with a relative Saved path", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-jrnl-text-"));
+    await createWiki({ root }).ingestText({
+      title: "My Note",
+      text: "Enough inline body content to satisfy the minimum source length requirement.",
+    });
+
+    expect(existsSync(path.join(root, LOG_FILE))).toBe(true);
+    const log = await readFile(path.join(root, LOG_FILE), "utf-8");
+    expect(log).toMatch(/^## \[.+Z\] ingest \| My Note/m);
+    expect(log).toContain("- Saved: sources/");
+
+    await rm(root, { recursive: true, force: true });
+  });
 });

--- a/test/sdk/packaging.test.ts
+++ b/test/sdk/packaging.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @file test/sdk/packaging.test.ts
+ * @description Install-from-tarball packaging smoke test for the SDK library entry.
+ *
+ * Validates the full publish contract by running `npm pack`, installing the
+ * resulting tarball into a throwaway ESM fixture project, and importing
+ * `createWiki` from the installed package via a probe script.
+ *
+ * This catches mistakes that a local `dist/` import would miss:
+ *   - Wrong/missing `exports` map entries
+ *   - Files accidentally excluded from the `files` field
+ *   - A shebang on the library bundle that would break `import`
+ *   - Missing type declarations (`.d.ts`)
+ *
+ * Slow test — excluded from the default `npm test` run.
+ * Run explicitly with: `npm run test:pack`
+ */
+
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, writeFile, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+describe("packaging (slow; run via `npm run test:pack`)", () => {
+  it("library entry imports from a packed tarball, no shebang, types emitted", async () => {
+    const repo = process.cwd();
+    execFileSync("npm", ["run", "build"], { stdio: "ignore", cwd: repo });
+    expect((await readFile(path.join(repo, "dist/index.js"), "utf-8")).startsWith("#!")).toBe(false);
+    await readFile(path.join(repo, "dist/index.d.ts"), "utf-8"); // throws if missing
+
+    const out = await mkdtemp(path.join(tmpdir(), "wiki-pack-"));    // pack INTO temp
+    const fixture = await mkdtemp(path.join(tmpdir(), "wiki-fix-"));
+    try {
+      const packOutput = execFileSync("npm", ["pack", "--silent", "--pack-destination", out], { cwd: repo }).toString();
+      // Take the last non-empty line that ends with .tgz to guard against any
+      // npm noise that --silent doesn't suppress in all npm versions.
+      const name = packOutput
+        .split("\n")
+        .map((l) => l.trim())
+        .filter((l) => l.endsWith(".tgz"))
+        .at(-1)!;
+      await writeFile(path.join(fixture, "package.json"), JSON.stringify({ name: "f", type: "module" }));
+      execFileSync("npm", ["install", path.join(out, name)], { cwd: fixture, stdio: "ignore" });
+      await writeFile(path.join(fixture, "probe.mjs"), `import { createWiki } from "llm-wiki-compiler"; if (typeof createWiki !== "function") process.exit(2);`);
+      execFileSync("node", ["probe.mjs"], { cwd: fixture, stdio: "ignore" });
+    } finally {
+      await rm(out, { recursive: true, force: true });   // no .tgz left in the repo
+      await rm(fixture, { recursive: true, force: true });
+    }
+    expect(true).toBe(true);
+  }, 180_000);
+});

--- a/test/sdk/packaging.test.ts
+++ b/test/sdk/packaging.test.ts
@@ -12,7 +12,9 @@
  *   - A shebang on the library bundle that would break `import`
  *   - Missing type declarations (`.d.ts`)
  *
- * Slow test — excluded from the default `npm test` run.
+ * Network-dependent: `npm install <tarball>` resolves llmwiki's ~17 runtime
+ * deps fresh from the registry, so this is a developer-invoked `test:pack`
+ * smoke test excluded from the default/CI `npm test` run.
  * Run explicitly with: `npm run test:pack`
  */
 
@@ -40,6 +42,7 @@ describe("packaging (slow; run via `npm run test:pack`)", () => {
         .map((l) => l.trim())
         .filter((l) => l.endsWith(".tgz"))
         .at(-1)!;
+      expect(name).toMatch(/\.tgz$/);
       await writeFile(path.join(fixture, "package.json"), JSON.stringify({ name: "f", type: "module" }));
       execFileSync("npm", ["install", path.join(out, name)], { cwd: fixture, stdio: "ignore" });
       await writeFile(path.join(fixture, "probe.mjs"), `import { createWiki } from "llm-wiki-compiler"; if (typeof createWiki !== "function") process.exit(2);`);
@@ -48,6 +51,5 @@ describe("packaging (slow; run via `npm run test:pack`)", () => {
       await rm(out, { recursive: true, force: true });   // no .tgz left in the repo
       await rm(fixture, { recursive: true, force: true });
     }
-    expect(true).toBe(true);
   }, 180_000);
 });

--- a/test/sdk/quiet-concurrency.test.ts
+++ b/test/sdk/quiet-concurrency.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Regression test for concurrent SDK quiet-scoping via AsyncLocalStorage.
+ *
+ * Exercises the contract that two overlapping `withQuiet(async () => ...)`
+ * calls (simulated with timers) never corrupt the global quiet flag and
+ * each sees `isQuiet() === true` for the duration of its own run.
+ */
+
+import { describe, it, expect } from "vitest";
+import { withQuiet, isQuiet, getQuiet } from "../../src/utils/output.js";
+
+const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+describe("withQuiet concurrent isolation", () => {
+  it("concurrent scoped-quiet calls never corrupt the global flag", async () => {
+    const seen: boolean[] = [];
+
+    await Promise.all([
+      withQuiet(async () => {
+        await delay(10);
+        seen.push(isQuiet());
+      }),
+      withQuiet(async () => {
+        await delay(30);
+        seen.push(isQuiet());
+      }),
+    ]);
+
+    // Both calls must have seen quiet === true during their own run
+    expect(seen).toEqual([true, true]);
+    // The global flag must not be stuck-on after both finish
+    expect(getQuiet()).toBe(false);
+    // No ALS scope is active after all calls complete
+    expect(isQuiet()).toBe(false);
+  });
+
+  it("isQuiet propagates across nested awaits inside withQuiet", async () => {
+    async function deeplyNested(): Promise<boolean> {
+      await delay(1);
+      await delay(1);
+      return isQuiet();
+    }
+
+    const result = await withQuiet(() => deeplyNested());
+    expect(result).toBe(true);
+    expect(isQuiet()).toBe(false);
+  });
+});

--- a/test/status/collect.test.ts
+++ b/test/status/collect.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { collectStatus, type WikiStatus } from "../../src/status/collect.js";
+
+describe("collectStatus", () => {
+  it("returns a typed status snapshot for an empty project root", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-status-"));
+    const status: WikiStatus = await collectStatus(root);
+    expect(status.pages.total).toBe(0);
+    expect(Array.isArray(status.orphanedPages)).toBe(true);
+    expect(status.lastCompiledAt).toBeNull();
+  });
+
+  it("does not write a .bak file when state.json is corrupt", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "wiki-status-corrupt-"));
+    const llmwikiDir = path.join(root, ".llmwiki");
+    await mkdir(llmwikiDir, { recursive: true });
+    const stateFile = path.join(llmwikiDir, "state.json");
+    await writeFile(stateFile, "{ invalid json !!!", "utf-8");
+
+    const status: WikiStatus = await collectStatus(root);
+
+    expect(existsSync(path.join(llmwikiDir, "state.json.bak"))).toBe(false);
+    expect(status.pages.total).toBe(0);
+    expect(Array.isArray(status.orphanedPages)).toBe(true);
+  });
+});

--- a/test/utils/provider-guard.test.ts
+++ b/test/utils/provider-guard.test.ts
@@ -19,6 +19,19 @@ describe("ensureProviderAvailable error taxonomy", () => {
     }
   });
 
+  it("throws ProviderUnavailableError for a non-anthropic provider missing its key", () => {
+    process.env.LLMWIKI_PROVIDER = "openai";
+    delete process.env.OPENAI_API_KEY;
+    try { ensureProviderAvailable(); throw new Error("did not throw"); }
+    catch (e) {
+      expect(e).toBeInstanceOf(ProviderUnavailableError);
+      const err = e as ProviderUnavailableError;
+      expect(err.code).toBe("provider_unavailable");
+      expect(err.provider).toBe("openai");
+      expect(err.missing).toContain("OPENAI_API_KEY");
+    }
+  });
+
   it("throws UnknownProviderError for an unsupported provider", () => {
     process.env.LLMWIKI_PROVIDER = "bogus";
     try { ensureProviderAvailable(); throw new Error("did not throw"); }

--- a/test/utils/provider-guard.test.ts
+++ b/test/utils/provider-guard.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { ensureProviderAvailable, ProviderUnavailableError, UnknownProviderError } from "../../src/utils/provider-guard.js";
+
+describe("ensureProviderAvailable error taxonomy", () => {
+  const saved = { ...process.env };
+  afterEach(() => { process.env = { ...saved }; });
+
+  it("throws ProviderUnavailableError with structured fields when creds missing", () => {
+    process.env.LLMWIKI_PROVIDER = "anthropic";
+    delete process.env.ANTHROPIC_API_KEY; delete process.env.ANTHROPIC_AUTH_TOKEN;
+    try { ensureProviderAvailable(); throw new Error("did not throw"); }
+    catch (e) {
+      expect(e).toBeInstanceOf(ProviderUnavailableError);
+      const err = e as ProviderUnavailableError;
+      expect(err.code).toBe("provider_unavailable");
+      expect(err.provider).toBe("anthropic");
+      expect(err.missing).toContain("ANTHROPIC_API_KEY");
+      expect(err.missing.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("throws UnknownProviderError for an unsupported provider", () => {
+    process.env.LLMWIKI_PROVIDER = "bogus";
+    try { ensureProviderAvailable(); throw new Error("did not throw"); }
+    catch (e) {
+      expect(e).toBeInstanceOf(UnknownProviderError);
+      const err = e as UnknownProviderError;
+      expect(err.code).toBe("unknown_provider");
+      expect(err.provider).toBe("bogus");
+      expect(err.supported).toContain("anthropic");
+    }
+  });
+});

--- a/test/utils/provider-guard.test.ts
+++ b/test/utils/provider-guard.test.ts
@@ -1,6 +1,25 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { ensureProviderAvailable, ProviderUnavailableError, UnknownProviderError } from "../../src/utils/provider-guard.js";
 
+/** Call ensureProviderAvailable() and return the caught error, or throw if it does not throw. */
+function catchGuardError(): unknown {
+  try {
+    ensureProviderAvailable();
+    throw new Error("did not throw");
+  } catch (e) {
+    return e;
+  }
+}
+
+/** Assert the error is a ProviderUnavailableError with the given provider and return it. */
+function assertUnavailableError(e: unknown, provider: string): ProviderUnavailableError {
+  expect(e).toBeInstanceOf(ProviderUnavailableError);
+  const err = e as ProviderUnavailableError;
+  expect(err.code).toBe("provider_unavailable");
+  expect(err.provider).toBe(provider);
+  return err;
+}
+
 describe("ensureProviderAvailable error taxonomy", () => {
   const saved = { ...process.env };
   afterEach(() => { process.env = { ...saved }; });
@@ -8,39 +27,25 @@ describe("ensureProviderAvailable error taxonomy", () => {
   it("throws ProviderUnavailableError with structured fields when creds missing", () => {
     process.env.LLMWIKI_PROVIDER = "anthropic";
     delete process.env.ANTHROPIC_API_KEY; delete process.env.ANTHROPIC_AUTH_TOKEN;
-    try { ensureProviderAvailable(); throw new Error("did not throw"); }
-    catch (e) {
-      expect(e).toBeInstanceOf(ProviderUnavailableError);
-      const err = e as ProviderUnavailableError;
-      expect(err.code).toBe("provider_unavailable");
-      expect(err.provider).toBe("anthropic");
-      expect(err.missing).toContain("ANTHROPIC_API_KEY");
-      expect(err.missing.length).toBeGreaterThan(0);
-    }
+    const err = assertUnavailableError(catchGuardError(), "anthropic");
+    expect(err.missing).toContain("ANTHROPIC_API_KEY");
+    expect(err.missing.length).toBeGreaterThan(0);
   });
 
   it("throws ProviderUnavailableError for a non-anthropic provider missing its key", () => {
     process.env.LLMWIKI_PROVIDER = "openai";
     delete process.env.OPENAI_API_KEY;
-    try { ensureProviderAvailable(); throw new Error("did not throw"); }
-    catch (e) {
-      expect(e).toBeInstanceOf(ProviderUnavailableError);
-      const err = e as ProviderUnavailableError;
-      expect(err.code).toBe("provider_unavailable");
-      expect(err.provider).toBe("openai");
-      expect(err.missing).toContain("OPENAI_API_KEY");
-    }
+    const err = assertUnavailableError(catchGuardError(), "openai");
+    expect(err.missing).toContain("OPENAI_API_KEY");
   });
 
   it("throws UnknownProviderError for an unsupported provider", () => {
     process.env.LLMWIKI_PROVIDER = "bogus";
-    try { ensureProviderAvailable(); throw new Error("did not throw"); }
-    catch (e) {
-      expect(e).toBeInstanceOf(UnknownProviderError);
-      const err = e as UnknownProviderError;
-      expect(err.code).toBe("unknown_provider");
-      expect(err.provider).toBe("bogus");
-      expect(err.supported).toContain("anthropic");
-    }
+    const e = catchGuardError();
+    expect(e).toBeInstanceOf(UnknownProviderError);
+    const err = e as UnknownProviderError;
+    expect(err.code).toBe("unknown_provider");
+    expect(err.provider).toBe("bogus");
+    expect(err.supported).toContain("anthropic");
   });
 });

--- a/test/utils/quiet.test.ts
+++ b/test/utils/quiet.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Tests for the quiet-aware note() output helper.
+ *
+ * Verifies that note() routes through console.warn and is a no-op
+ * while the process-wide quiet flag is set.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { setQuiet, note } from "../../src/utils/output.js";
+
+describe("output.note respects quiet flag", () => {
+  afterEach(() => setQuiet(false));
+  it("emits nothing while quiet", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    setQuiet(true);
+    note("retrying soon");
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/test/utils/quiet.test.ts
+++ b/test/utils/quiet.test.ts
@@ -6,15 +6,36 @@
  */
 
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { setQuiet, note } from "../../src/utils/output.js";
+import { setQuiet, getQuiet, note } from "../../src/utils/output.js";
 
 describe("output.note respects quiet flag", () => {
   afterEach(() => setQuiet(false));
+
   it("emits nothing while quiet", () => {
     const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
     setQuiet(true);
     note("retrying soon");
     expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();
+  });
+
+  it("writes to console.warn when not quiet", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    setQuiet(false);
+    note("hi");
+    expect(spy).toHaveBeenCalledWith("hi");
+    spy.mockRestore();
+  });
+});
+
+describe("output.getQuiet round-trips setQuiet", () => {
+  afterEach(() => setQuiet(false));
+
+  it("reflects the current quiet flag", () => {
+    expect(getQuiet()).toBe(false);
+    setQuiet(true);
+    expect(getQuiet()).toBe(true);
+    setQuiet(false);
+    expect(getQuiet()).toBe(false);
   });
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,19 +1,31 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
-  entry: ["src/cli.ts"],
-  format: ["esm"],
-  target: "node24",
-  outDir: "dist",
-  clean: true,
-  splitting: false,
-  sourcemap: true,
-  banner: {
-    js: "#!/usr/bin/env node",
+export default defineConfig([
+  {
+    entry: ["src/cli.ts"],
+    format: ["esm"],
+    target: "node24",
+    outDir: "dist",
+    clean: true,
+    splitting: false,
+    sourcemap: true,
+    banner: {
+      js: "#!/usr/bin/env node",
+    },
+    // Mirror the viewer's static assets (shell template, stylesheet, client
+    // script) into dist/viewer/assets/ so they ship with the published
+    // npm package. The Slice 3 viewer server reads the template at runtime
+    // and serves /assets/* from this directory.
+    onSuccess: "node scripts/copy-viewer-assets.mjs",
   },
-  // Mirror the viewer's static assets (shell template, stylesheet, client
-  // script) into dist/viewer/assets/ so they ship with the published
-  // npm package. The Slice 3 viewer server reads the template at runtime
-  // and serves /assets/* from this directory.
-  onSuccess: "node scripts/copy-viewer-assets.mjs",
-});
+  {
+    entry: ["src/index.ts"],
+    format: ["esm"],
+    target: "node24",
+    outDir: "dist",
+    splitting: false,
+    sourcemap: true,
+    dts: true,
+    // No banner — library bundle must not include a shebang line.
+  },
+]);

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,14 +1,24 @@
-import { defineConfig } from "tsup";
+import { defineConfig, type Options } from "tsup";
+
+// Fields shared by both bundles. Extracted into one base object so the CLI and
+// library entries can't drift on format/target/output settings.
+const shared = {
+  format: ["esm"],
+  target: "node24",
+  outDir: "dist",
+  splitting: false,
+  sourcemap: true,
+} satisfies Options;
 
 export default defineConfig([
   {
+    ...shared,
     entry: ["src/cli.ts"],
-    format: ["esm"],
-    target: "node24",
-    outDir: "dist",
-    clean: true,
-    splitting: false,
-    sourcemap: true,
+    // Per-entry targeted clean: only wipe this bundle's own outputs. A blanket
+    // `clean: true` here would race the library entry's writes (tsup runs array
+    // entries in parallel) and could delete dist/index.* on watch/incremental
+    // rebuilds.
+    clean: ["dist/cli.js", "dist/cli.js.map"],
     banner: {
       js: "#!/usr/bin/env node",
     },
@@ -19,12 +29,10 @@ export default defineConfig([
     onSuccess: "node scripts/copy-viewer-assets.mjs",
   },
   {
+    ...shared,
     entry: ["src/index.ts"],
-    format: ["esm"],
-    target: "node24",
-    outDir: "dist",
-    splitting: false,
-    sourcemap: true,
+    // Per-entry targeted clean: only this bundle's own outputs, never the CLI's.
+    clean: ["dist/index.js", "dist/index.js.map", "dist/index.d.ts"],
     dts: true,
     // No banner — library bundle must not include a shebang line.
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, configDefaults } from "vitest/config";
 
 const TEST_TIMEOUT_MS = 30_000;
 const HOOK_TIMEOUT_MS = 60_000;
@@ -19,7 +19,13 @@ export default defineConfig({
     // Don't pick up tests from sibling worktrees living under local worktree dirs.
     // Worktrees share the parent's working directory tree, so without this
     // exclude vitest discovers and runs every feature branch's tests.
-    exclude: ["**/node_modules/**", "**/dist/**", ".claude/**", ".worktrees/**"],
+    exclude: [
+      ...configDefaults.exclude,
+      "**/dist/**",
+      ".claude/**",
+      ".worktrees/**",
+      "test/sdk/packaging.test.ts",
+    ],
     // Build dist/ once globally so parallel test workers don't race on
     // tsup's clean+write cycle (multiple beforeAll(npx tsup) calls were
     // wiping dist/cli.js mid-test).

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,7 +21,6 @@ export default defineConfig({
     // exclude vitest discovers and runs every feature branch's tests.
     exclude: [
       ...configDefaults.exclude,
-      "**/dist/**",
       ".claude/**",
       ".worktrees/**",
       "test/sdk/packaging.test.ts",


### PR DESCRIPTION
## Summary

Adds a first-class, in-process TypeScript SDK for llmwiki.

Consumers can now import `createWiki` from `llm-wiki-compiler` and drive a project directly as a library instead of shelling out to the CLI or running an MCP server:

```ts
import { createWiki } from "llm-wiki-compiler";

const wiki = createWiki({ root: "/path/to/project" });

await wiki.ingest({ source });
await wiki.ingestText({ title, text });
await wiki.compile();
await wiki.search(query);
await wiki.query(question);
await wiki.getPage({ pageDirectory: "concepts", slug });
await wiki.listPages();
await wiki.status();
await wiki.lint();
await wiki.getContextPack(options);
await wiki.exportJson();
await wiki.runEval({ mode: "fast" });
```

## What Changed

- Added the public SDK entry point: `createWiki({ root })`.
- Added typed SDK methods for the 9 MCP-tool capabilities, plus `exportJson` and `listPages`.
- Added a typed package library export via `exports`, while keeping the existing `llmwiki` CLI bin.
- Emitted declaration files and verified the built package through an install-from-tarball smoke test.

## SDK-Safe Core Work

This PR also extracts and hardens the internals needed for a safe in-process SDK:

- Makes source writing root-explicit, removing the MCP `process.chdir(root)` workaround.
- Adds `ingestText` with a synthetic manual source identity.
- Adds an in-memory `exportJson` path that returns the JSON export as data, not a file.
- Extracts shared status, page-read, page-list, and retrieval helpers out of MCP-only code.
- Adds structured provider errors: `ProviderUnavailableError` and `UnknownProviderError`.
- Scopes quiet output with `AsyncLocalStorage` so concurrent SDK calls do not leak CLI output or interfere with each other.
- Documents trust boundaries for ingest and LLM-backed methods.

## Scope Notes

- The SDK uses ambient provider/model/credential resolution, matching CLI and MCP behavior.
- LLM-backed methods still require the configured provider; credential-less callers get typed provider errors.
- `ingest` is a trusted-input primitive: it reads or fetches the source path/URL supplied by the caller.
- Rule-candidate surfacing is intentionally deferred to a later generic `wiki.rules` namespace.

## Verification

- `build-and-test (24)` passes.
- `codebase-health` passes.
- Added real-execution SDK coverage for provider gating, root isolation, quiet output under concurrency, ingest journaling, page listing/reading, in-memory export, and package import from a packed tarball.
