### PR TITLE
feat(sdk): source API on createWiki — writeStatus + listSources/getSource/deleteSource

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -8,10 +8,7 @@
     "src/viewer/assets/index.html",
     "src/viewer/assets/viewer.css"
   ],
-  "ignoreExports": [
-    { "file": "src/utils/output.ts", "exports": ["getQuiet"] },
-    { "file": "src/sources/store.ts", "exports": ["assertSafeSourceId"] }
-  ],
+  "ignoreExports": [{ "file": "src/utils/output.ts", "exports": ["getQuiet"] }],
   "overrides": [
     {
       "files": ["src/providers/*.ts", "src/utils/provider-guard.ts"],

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -8,7 +8,10 @@
     "src/viewer/assets/index.html",
     "src/viewer/assets/viewer.css"
   ],
-  "ignoreExports": [{ "file": "src/utils/output.ts", "exports": ["getQuiet"] }],
+  "ignoreExports": [
+    { "file": "src/utils/output.ts", "exports": ["getQuiet"] },
+    { "file": "src/sources/store.ts", "exports": ["assertSafeSourceId"] }
+  ],
   "overrides": [
     {
       "files": ["src/providers/*.ts", "src/utils/provider-guard.ts"],

--- a/src/commands/ingest-session.ts
+++ b/src/commands/ingest-session.ts
@@ -54,7 +54,7 @@ async function saveSessionSource(
   const frontmatter = buildSessionFrontmatter(session, sourcePath);
   const body = formatSessionAsMarkdown(session);
   const document = `${frontmatter}\n\n${body}\n`;
-  return saveSource(root, session.title, document, sourcePath);
+  return (await saveSource(root, session.title, document, sourcePath)).path;
 }
 
 /**

--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -288,10 +288,12 @@ export async function ingestSource(root: string, source: string): Promise<Ingest
   const result = enforceCharLimit(content);
   enforceMinContent(result.content);
   const document = buildDocument(title, source, result, sourceType);
-  const { path: savedPath } = await saveSource(root, title, document, source);
+  const { path: savedPath, writeStatus } = await saveSource(root, title, document, source);
 
-  // Journal the ingest (CLI, MCP ingest_source tool, and SDK all share this path).
-  await journalIngest(root, title, source, savedPath, result.content.length);
+  // Journal only real writes — a no-op re-ingest must not append a log line.
+  if (writeStatus !== "unchanged") {
+    await journalIngest(root, title, source, savedPath, result.content.length);
+  }
 
   return {
     filename: path.basename(savedPath),
@@ -299,6 +301,7 @@ export async function ingestSource(root: string, source: string): Promise<Ingest
     truncated: result.truncated,
     source,
     sourceType,
+    writeStatus,
   };
 }
 
@@ -329,10 +332,13 @@ export async function ingestTextSource(root: string, input: IngestTextInput): Pr
   const result = enforceCharLimit(input.text);
   enforceMinContent(result.content);
   const document = buildDocument(input.title, source, result, "file");
-  const { path: savedPath } = await saveSource(root, input.title, document, source);
+  const { path: savedPath, writeStatus } = await saveSource(root, input.title, document, source);
 
-  // Mirror ingestSource so both ingest paths journal identically.
-  await journalIngest(root, input.title, source, savedPath, result.content.length);
+  // Mirror ingestSource so both ingest paths journal identically;
+  // a no-op re-ingest must not append a log line.
+  if (writeStatus !== "unchanged") {
+    await journalIngest(root, input.title, source, savedPath, result.content.length);
+  }
 
   return {
     filename: path.basename(savedPath),
@@ -340,6 +346,7 @@ export async function ingestTextSource(root: string, input: IngestTextInput): Pr
     truncated: result.truncated,
     source,
     sourceType: "file",
+    writeStatus,
   };
 }
 

--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -334,8 +334,7 @@ export async function ingestTextSource(root: string, input: IngestTextInput): Pr
   const document = buildDocument(input.title, source, result, "file");
   const { path: savedPath, writeStatus } = await saveSource(root, input.title, document, source);
 
-  // Mirror ingestSource so both ingest paths journal identically;
-  // a no-op re-ingest must not append a log line.
+  // Journal only real writes — a no-op re-ingest must not append a log line.
   if (writeStatus !== "unchanged") {
     await journalIngest(root, input.title, source, savedPath, result.content.length);
   }

--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -288,7 +288,7 @@ export async function ingestSource(root: string, source: string): Promise<Ingest
   const result = enforceCharLimit(content);
   enforceMinContent(result.content);
   const document = buildDocument(title, source, result, sourceType);
-  const savedPath = await saveSource(root, title, document, source);
+  const { path: savedPath } = await saveSource(root, title, document, source);
 
   // Journal the ingest (CLI, MCP ingest_source tool, and SDK all share this path).
   await journalIngest(root, title, source, savedPath, result.content.length);
@@ -329,7 +329,7 @@ export async function ingestTextSource(root: string, input: IngestTextInput): Pr
   const result = enforceCharLimit(input.text);
   enforceMinContent(result.content);
   const document = buildDocument(input.title, source, result, "file");
-  const savedPath = await saveSource(root, input.title, document, source);
+  const { path: savedPath } = await saveSource(root, input.title, document, source);
 
   // Mirror ingestSource so both ingest paths journal identically.
   await journalIngest(root, input.title, source, savedPath, result.content.length);

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,4 +40,5 @@ export type { EvalReport } from "./eval/types.js";
 export type { WikiStatus } from "./status/collect.js";
 export type { PageRecord } from "./pages/read.js";
 export type { SourceRecord, ListSourcesOptions, ListSourcesResult } from "./sources/store.js";
+// WriteStatus is part of IngestResult — re-exported so callers needn't deep-import utils/types.
 export type { WriteStatus } from "./utils/types.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,3 +39,5 @@ export type { ContextPack } from "./context/types.js";
 export type { EvalReport } from "./eval/types.js";
 export type { WikiStatus } from "./status/collect.js";
 export type { PageRecord } from "./pages/read.js";
+export type { SourceRecord, ListSourcesOptions, ListSourcesResult } from "./sources/store.js";
+export type { WriteStatus } from "./utils/types.js";

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -109,11 +109,13 @@ export interface Wiki {
   getPage(ref: PageRef): Promise<Page | null>;
   /** List wiki pages with optional filters and cursor-based pagination. No LLM required. */
   listPages(options?: ListPagesOptions): Promise<ListPagesResult>;
-  /** List source files under `sources/` with optional pagination and body inclusion. No LLM required. */
+  /** List source files under `sources/` with optional cursor pagination. Bodies are opt-in via `includeBody`. No LLM required. */
   listSources(options?: ListSourcesOptions): Promise<ListSourcesResult>;
-  /** Fetch a single source record by its basename id (e.g. "note.md"). No LLM required. */
+  /** Fetch a single source record by its basename id (e.g. "note.md"); returns null if absent. Always includes body. No LLM required. */
   getSource(id: string): Promise<SourceRecord | null>;
-  /** Delete the source file for the given id. Returns true if deleted, false if not found. No LLM required. */
+  /** Delete the source file for the given id (the id is the `IngestResult.filename`, e.g. "note.md").
+   *  Returns true if deleted, false if not found. The compiled page in `wiki/` is NOT removed
+   *  immediately — reconciliation happens on the next `compile()`. No LLM required. */
   deleteSource(id: string): Promise<boolean>;
   /**
    * Collect a read-only status snapshot of the wiki. No LLM required.

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -17,6 +17,7 @@ import type { WikiStatus } from "../status/collect.js";
 import type { Page, PageRef, ListPagesOptions, ListPagesResult } from "../pages/list.js";
 import type { PageRecord } from "../pages/read.js";
 import type { JsonExportDocument, BuildJsonExportOptions } from "../export/json-export.js";
+import type { SourceRecord, ListSourcesOptions, ListSourcesResult } from "../sources/store.js";
 
 /** Options for `createWiki`. */
 export interface CreateWikiOptions {
@@ -108,6 +109,12 @@ export interface Wiki {
   getPage(ref: PageRef): Promise<Page | null>;
   /** List wiki pages with optional filters and cursor-based pagination. No LLM required. */
   listPages(options?: ListPagesOptions): Promise<ListPagesResult>;
+  /** List source files under `sources/` with optional pagination and body inclusion. No LLM required. */
+  listSources(options?: ListSourcesOptions): Promise<ListSourcesResult>;
+  /** Fetch a single source record by its basename id (e.g. "note.md"). No LLM required. */
+  getSource(id: string): Promise<SourceRecord | null>;
+  /** Delete the source file for the given id. Returns true if deleted, false if not found. No LLM required. */
+  deleteSource(id: string): Promise<boolean>;
   /**
    * Collect a read-only status snapshot of the wiki. No LLM required.
    *

--- a/src/sdk/wiki.ts
+++ b/src/sdk/wiki.ts
@@ -35,6 +35,7 @@ import { ensureProviderAvailable } from "../utils/provider-guard.js";
 import { collectStatus } from "../status/collect.js";
 import { pickSearchSlugs, loadPageRecords } from "../search/retrieval.js";
 import { getPage, listPages } from "../pages/list.js";
+import { listSources, getSource, deleteSource } from "../sources/store.js";
 import type { CreateWikiOptions, Wiki, SdkCompileOptions } from "./types.js";
 
 /**
@@ -90,6 +91,12 @@ export function createWiki(options: CreateWikiOptions): Wiki {
     getPage: (ref) => runQuiet(() => getPage(root, ref)),
 
     listPages: (opts) => runQuiet(() => listPages(root, opts)),
+
+    listSources: (opts) => runQuiet(() => listSources(root, opts)),
+
+    getSource: (id) => runQuiet(() => getSource(root, id)),
+
+    deleteSource: (id) => runQuiet(() => deleteSource(root, id)),
 
     status: () => runQuiet(() => collectStatus(root)),
 

--- a/src/sources/store.ts
+++ b/src/sources/store.ts
@@ -1,0 +1,75 @@
+/**
+ * Source-store API for the llmwiki SDK: list / get sources under `sources/`.
+ * Source IDs are bare basenames including `.md` (e.g. "note.md") — opaque,
+ * path-safe, never joined with an extra extension. Read-only, no LLM.
+ */
+import path from "path";
+import { readdir, readFile } from "fs/promises";
+import { parseFrontmatter } from "../utils/markdown.js";
+import { PathSafetyError } from "../viewer/path-safety.js";
+import { SOURCES_DIR } from "../utils/constants.js";
+
+export interface SourceRecord {
+  id: string;          // basename incl. ".md"
+  title: string;
+  source: string;      // frontmatter `source` identity
+  sourceType: string;
+  ingestedAt?: string;
+  body?: string;
+}
+export interface ListSourcesOptions { cursor?: string; limit?: number; includeBody?: boolean }
+export interface ListSourcesResult { sources: SourceRecord[]; cursor?: string }
+
+/** Reject anything that isn't a bare `sources/` basename ending in `.md`. */
+export function assertSafeSourceId(id: string): void {
+  if (typeof id !== "string" || id.length === 0) throw new PathSafetyError("source id must be a non-empty string");
+  if (!id.endsWith(".md")) throw new PathSafetyError(`source id must end in .md: "${id}"`);
+  if (id.includes("/") || id.includes("\\") || id.includes("\0") || id.includes(".."))
+    throw new PathSafetyError(`source id must be a bare basename: "${id}"`);
+}
+
+function toRecord(id: string, content: string, includeBody: boolean): SourceRecord {
+  const { meta, body } = parseFrontmatter(content);
+  return {
+    id,
+    title: typeof meta.title === "string" ? meta.title : id,
+    source: typeof meta.source === "string" ? meta.source : "",
+    sourceType: typeof meta.sourceType === "string" ? meta.sourceType : "file",
+    ingestedAt: typeof meta.ingestedAt === "string" ? meta.ingestedAt : undefined,
+    ...(includeBody ? { body } : {}),
+  };
+}
+
+export async function listSources(root: string, options: ListSourcesOptions = {}): Promise<ListSourcesResult> {
+  const dir = path.join(root, SOURCES_DIR);
+  let files: string[];
+  try {
+    files = (await readdir(dir)).filter((f) => f.endsWith(".md")).sort();
+  } catch (err) {
+    if ((err as { code?: string }).code === "ENOENT") return { sources: [] };
+    throw err;
+  }
+  const offset = options.cursor !== undefined ? Number(options.cursor) : 0;
+  if (!Number.isInteger(offset) || offset < 0) throw new Error(`invalid listSources cursor: ${options.cursor}`);
+  const limit = options.limit && options.limit > 0 ? options.limit : files.length;
+  const page = files.slice(offset, offset + limit);
+  const sources: SourceRecord[] = [];
+  for (const id of page) {
+    const content = await readFile(path.join(dir, id), "utf-8");
+    sources.push(toRecord(id, content, options.includeBody === true));
+  }
+  const next = offset + page.length < files.length ? String(offset + page.length) : undefined;
+  return next !== undefined ? { sources, cursor: next } : { sources };
+}
+
+export async function getSource(root: string, id: string): Promise<SourceRecord | null> {
+  assertSafeSourceId(id);
+  let content: string;
+  try {
+    content = await readFile(path.join(root, SOURCES_DIR, id), "utf-8");
+  } catch (err) {
+    if ((err as { code?: string }).code === "ENOENT") return null;
+    throw err;
+  }
+  return toRecord(id, content, true);
+}

--- a/src/sources/store.ts
+++ b/src/sources/store.ts
@@ -8,6 +8,7 @@ import { readdir, readFile, unlink } from "fs/promises";
 import { parseFrontmatter } from "../utils/markdown.js";
 import { PathSafetyError } from "../viewer/path-safety.js";
 import { SOURCES_DIR } from "../utils/constants.js";
+import { safeRealpath, isInsideDir } from "../utils/path-confine.js";
 
 /** A single source file under `sources/`, with frontmatter metadata. */
 export interface SourceRecord {
@@ -50,6 +51,8 @@ function toRecord(id: string, content: string, includeBody: boolean): SourceReco
 
 export async function listSources(root: string, options: ListSourcesOptions = {}): Promise<ListSourcesResult> {
   const dir = path.join(root, SOURCES_DIR);
+  const canonicalDir = await safeRealpath(dir);
+  if (canonicalDir === null) return { sources: [] };
   let files: string[];
   try {
     files = (await readdir(dir)).filter((f) => f.endsWith(".md")).sort();
@@ -63,7 +66,10 @@ export async function listSources(root: string, options: ListSourcesOptions = {}
   const page = files.slice(offset, offset + limit);
   const sources: SourceRecord[] = [];
   for (const id of page) {
-    const content = await readFile(path.join(dir, id), "utf-8");
+    // Skip any entry whose realpath escapes sources/ (e.g. a symlink planted inside the dir).
+    const real = await safeRealpath(path.join(dir, id));
+    if (real === null || !isInsideDir(real, canonicalDir)) continue;
+    const content = await readFile(real, "utf-8");
     sources.push(toRecord(id, content, options.includeBody === true));
   }
   const next = offset + page.length < files.length ? String(offset + page.length) : undefined;
@@ -80,6 +86,7 @@ export async function listSources(root: string, options: ListSourcesOptions = {}
 export async function deleteSource(root: string, id: string): Promise<boolean> {
   assertSafeSourceId(id);
   try {
+    // unlink removes the entry (incl. a symlink) itself, never a symlink target — safe.
     await unlink(path.join(root, SOURCES_DIR, id));
     return true;
   } catch (err) {
@@ -90,9 +97,13 @@ export async function deleteSource(root: string, id: string): Promise<boolean> {
 
 export async function getSource(root: string, id: string): Promise<SourceRecord | null> {
   assertSafeSourceId(id);
+  const dir = path.join(root, SOURCES_DIR);
+  const canonicalDir = await safeRealpath(dir);
+  const real = canonicalDir === null ? null : await safeRealpath(path.join(dir, id));
+  if (real === null || canonicalDir === null || !isInsideDir(real, canonicalDir)) return null;
   let content: string;
   try {
-    content = await readFile(path.join(root, SOURCES_DIR, id), "utf-8");
+    content = await readFile(real, "utf-8");
   } catch (err) {
     if ((err as { code?: string }).code === "ENOENT") return null;
     throw err;

--- a/src/sources/store.ts
+++ b/src/sources/store.ts
@@ -4,7 +4,7 @@
  * path-safe, never joined with an extra extension. Read-only, no LLM.
  */
 import path from "path";
-import { readdir, readFile } from "fs/promises";
+import { readdir, readFile, unlink } from "fs/promises";
 import { parseFrontmatter } from "../utils/markdown.js";
 import { PathSafetyError } from "../viewer/path-safety.js";
 import { SOURCES_DIR } from "../utils/constants.js";
@@ -68,6 +68,24 @@ export async function listSources(root: string, options: ListSourcesOptions = {}
   }
   const next = offset + page.length < files.length ? String(offset + page.length) : undefined;
   return next !== undefined ? { sources, cursor: next } : { sources };
+}
+
+/**
+ * Delete the source file `sources/<id>` (the id already includes `.md`).
+ * Returns `true` if a file was removed, `false` if the (valid) id had no file.
+ * Reconciliation of the now-orphaned compiled page is deferred to the next
+ * `compile`, consistent with how llmwiki already handles deleted sources —
+ * this does not touch `wiki/`.
+ */
+export async function deleteSource(root: string, id: string): Promise<boolean> {
+  assertSafeSourceId(id);
+  try {
+    await unlink(path.join(root, SOURCES_DIR, id));
+    return true;
+  } catch (err) {
+    if ((err as { code?: string }).code === "ENOENT") return false;
+    throw err;
+  }
 }
 
 export async function getSource(root: string, id: string): Promise<SourceRecord | null> {

--- a/src/sources/store.ts
+++ b/src/sources/store.ts
@@ -7,8 +7,7 @@ import path from "path";
 import { readdir, readFile, unlink } from "fs/promises";
 import { parseFrontmatter } from "../utils/markdown.js";
 import { PathSafetyError } from "../viewer/path-safety.js";
-import { SOURCES_DIR } from "../utils/constants.js";
-import { safeRealpath, isInsideDir } from "../utils/path-confine.js";
+import { safeRealpath, isInsideDir, resolveSourcesDir } from "../utils/path-confine.js";
 
 /** A single source file under `sources/`, with frontmatter metadata. */
 export interface SourceRecord {
@@ -50,9 +49,8 @@ function toRecord(id: string, content: string, includeBody: boolean): SourceReco
 }
 
 export async function listSources(root: string, options: ListSourcesOptions = {}): Promise<ListSourcesResult> {
-  const dir = path.join(root, SOURCES_DIR);
-  const canonicalDir = await safeRealpath(dir);
-  if (canonicalDir === null) return { sources: [] };
+  const dir = await resolveSourcesDir(root);
+  if (dir === null) return { sources: [] };
   let files: string[];
   try {
     files = (await readdir(dir)).filter((f) => f.endsWith(".md")).sort();
@@ -68,7 +66,7 @@ export async function listSources(root: string, options: ListSourcesOptions = {}
   for (const id of page) {
     // Skip any entry whose realpath escapes sources/ (e.g. a symlink planted inside the dir).
     const real = await safeRealpath(path.join(dir, id));
-    if (real === null || !isInsideDir(real, canonicalDir)) continue;
+    if (real === null || !isInsideDir(real, dir)) continue;
     const content = await readFile(real, "utf-8");
     sources.push(toRecord(id, content, options.includeBody === true));
   }
@@ -85,13 +83,13 @@ export async function listSources(root: string, options: ListSourcesOptions = {}
  */
 export async function deleteSource(root: string, id: string): Promise<boolean> {
   assertSafeSourceId(id);
-  const dir = path.join(root, SOURCES_DIR);
+  const dir = await resolveSourcesDir(root);
+  if (dir === null) return false;
   const filePath = path.join(dir, id);
-  const canonicalDir = await safeRealpath(dir);
-  const real = canonicalDir === null ? null : await safeRealpath(filePath);
+  const real = await safeRealpath(filePath);
   // Not a valid in-tree source (missing, broken, or a symlink escaping sources/) →
   // nothing to delete. Keeps delete coherent with getSource/listSources.
-  if (real === null || canonicalDir === null || !isInsideDir(real, canonicalDir)) return false;
+  if (real === null || !isInsideDir(real, dir)) return false;
   try {
     // Unlink the entry by its own path (removes a regular file, or an intra-sources
     // symlink entry — never via the resolved target).
@@ -105,10 +103,10 @@ export async function deleteSource(root: string, id: string): Promise<boolean> {
 
 export async function getSource(root: string, id: string): Promise<SourceRecord | null> {
   assertSafeSourceId(id);
-  const dir = path.join(root, SOURCES_DIR);
-  const canonicalDir = await safeRealpath(dir);
-  const real = canonicalDir === null ? null : await safeRealpath(path.join(dir, id));
-  if (real === null || canonicalDir === null || !isInsideDir(real, canonicalDir)) return null;
+  const dir = await resolveSourcesDir(root);
+  if (dir === null) return null;
+  const real = await safeRealpath(path.join(dir, id));
+  if (real === null || !isInsideDir(real, dir)) return null;
   let content: string;
   try {
     content = await readFile(real, "utf-8");

--- a/src/sources/store.ts
+++ b/src/sources/store.ts
@@ -9,6 +9,7 @@ import { parseFrontmatter } from "../utils/markdown.js";
 import { PathSafetyError } from "../viewer/path-safety.js";
 import { SOURCES_DIR } from "../utils/constants.js";
 
+/** A single source file under `sources/`, with frontmatter metadata. */
 export interface SourceRecord {
   id: string;          // basename incl. ".md"
   title: string;
@@ -17,13 +18,20 @@ export interface SourceRecord {
   ingestedAt?: string;
   body?: string;
 }
+
+/** Options for paginating `listSources` and opting into source bodies. */
 export interface ListSourcesOptions { cursor?: string; limit?: number; includeBody?: boolean }
+
+/** Result returned by `listSources`. */
 export interface ListSourcesResult { sources: SourceRecord[]; cursor?: string }
 
 /** Reject anything that isn't a bare `sources/` basename ending in `.md`. */
-export function assertSafeSourceId(id: string): void {
+function assertSafeSourceId(id: string): void {
   if (typeof id !== "string" || id.length === 0) throw new PathSafetyError("source id must be a non-empty string");
   if (!id.endsWith(".md")) throw new PathSafetyError(`source id must end in .md: "${id}"`);
+  // Conservative: real source IDs are `slug-<hex>.md` (slugified title + collision
+  // hash) and never contain `..`, so rejecting any `..` substring is safe and
+  // simpler than component-level normalization.
   if (id.includes("/") || id.includes("\\") || id.includes("\0") || id.includes(".."))
     throw new PathSafetyError(`source id must be a bare basename: "${id}"`);
 }

--- a/src/sources/store.ts
+++ b/src/sources/store.ts
@@ -85,9 +85,17 @@ export async function listSources(root: string, options: ListSourcesOptions = {}
  */
 export async function deleteSource(root: string, id: string): Promise<boolean> {
   assertSafeSourceId(id);
+  const dir = path.join(root, SOURCES_DIR);
+  const filePath = path.join(dir, id);
+  const canonicalDir = await safeRealpath(dir);
+  const real = canonicalDir === null ? null : await safeRealpath(filePath);
+  // Not a valid in-tree source (missing, broken, or a symlink escaping sources/) →
+  // nothing to delete. Keeps delete coherent with getSource/listSources.
+  if (real === null || canonicalDir === null || !isInsideDir(real, canonicalDir)) return false;
   try {
-    // unlink removes the entry (incl. a symlink) itself, never a symlink target — safe.
-    await unlink(path.join(root, SOURCES_DIR, id));
+    // Unlink the entry by its own path (removes a regular file, or an intra-sources
+    // symlink entry — never via the resolved target).
+    await unlink(filePath);
     return true;
   } catch (err) {
     if ((err as { code?: string }).code === "ENOENT") return false;

--- a/src/sources/store.ts
+++ b/src/sources/store.ts
@@ -7,7 +7,7 @@ import path from "path";
 import { readdir, readFile, unlink } from "fs/promises";
 import { parseFrontmatter } from "../utils/markdown.js";
 import { PathSafetyError } from "../viewer/path-safety.js";
-import { safeRealpath, isInsideDir, resolveSourcesDir } from "../utils/path-confine.js";
+import { confinedRegularFile, resolveSourcesDir } from "../utils/path-confine.js";
 
 /** A single source file under `sources/`, with frontmatter metadata. */
 export interface SourceRecord {
@@ -64,9 +64,10 @@ export async function listSources(root: string, options: ListSourcesOptions = {}
   const page = files.slice(offset, offset + limit);
   const sources: SourceRecord[] = [];
   for (const id of page) {
-    // Skip any entry whose realpath escapes sources/ (e.g. a symlink planted inside the dir).
-    const real = await safeRealpath(path.join(dir, id));
-    if (real === null || !isInsideDir(real, dir)) continue;
+    // Skip any entry that is not a confined regular file (symlinks — whether
+    // escaping or in-tree aliases — are never sources).
+    const real = await confinedRegularFile(dir, id);
+    if (real === null) continue;
     const content = await readFile(real, "utf-8");
     sources.push(toRecord(id, content, options.includeBody === true));
   }
@@ -85,15 +86,12 @@ export async function deleteSource(root: string, id: string): Promise<boolean> {
   assertSafeSourceId(id);
   const dir = await resolveSourcesDir(root);
   if (dir === null) return false;
-  const filePath = path.join(dir, id);
-  const real = await safeRealpath(filePath);
-  // Not a valid in-tree source (missing, broken, or a symlink escaping sources/) →
-  // nothing to delete. Keeps delete coherent with getSource/listSources.
-  if (real === null || !isInsideDir(real, dir)) return false;
+  // Not a confined regular file (missing, symlink, or directory) → nothing to delete.
+  // Keeps delete coherent with getSource/listSources.
+  const real = await confinedRegularFile(dir, id);
+  if (real === null) return false;
   try {
-    // Unlink the entry by its own path (removes a regular file, or an intra-sources
-    // symlink entry — never via the resolved target).
-    await unlink(filePath);
+    await unlink(path.join(dir, id));
     return true;
   } catch (err) {
     if ((err as { code?: string }).code === "ENOENT") return false;
@@ -105,8 +103,9 @@ export async function getSource(root: string, id: string): Promise<SourceRecord 
   assertSafeSourceId(id);
   const dir = await resolveSourcesDir(root);
   if (dir === null) return null;
-  const real = await safeRealpath(path.join(dir, id));
-  if (real === null || !isInsideDir(real, dir)) return null;
+  // Only confined regular files are valid sources (symlinks — in-tree or escaping — are not).
+  const real = await confinedRegularFile(dir, id);
+  if (real === null) return null;
   let content: string;
   try {
     content = await readFile(real, "utf-8");

--- a/src/utils/path-confine.ts
+++ b/src/utils/path-confine.ts
@@ -4,7 +4,9 @@
  * `sources/leak.md` pointing outside the project), preventing local-file-read.
  *
  * Also exports `resolveSourcesDir` which additionally guards against the
- * `sources/` directory itself being a symlink to an outside location.
+ * `sources/` directory itself being a symlink to an outside location, and
+ * `confinedRegularFile` — the single definition of "a source file" used by
+ * the scan, list, get, and delete paths to stay in agreement.
  */
 import { realpath, lstat } from "fs/promises";
 import path from "path";
@@ -24,6 +26,27 @@ export function isInsideDir(child: string, dir: string): boolean {
   if (child === dir) return true;
   const prefix = dir.endsWith(path.sep) ? dir : dir + path.sep;
   return child.startsWith(prefix);
+}
+
+/**
+ * Resolve `dir`/`name` to its real path IF it is a confined REGULAR FILE — i.e.
+ * a real file (not a symlink, not a directory) whose realpath stays within `dir`.
+ * Returns null otherwise. This is the single definition of "a source file": a
+ * symlink in `sources/` (whether escaping or an in-tree alias) is never a source,
+ * keeping reads, the identity scan, and writes in agreement.
+ */
+export async function confinedRegularFile(dir: string, name: string): Promise<string | null> {
+  const entryPath = path.join(dir, name);
+  let st;
+  try {
+    st = await lstat(entryPath); // lstat: do NOT follow — a symlink must be rejected
+  } catch {
+    return null;
+  }
+  if (!st.isFile()) return null; // symlink / directory / other → not a source
+  const real = await safeRealpath(entryPath);
+  if (real === null || !isInsideDir(real, dir)) return null; // defense-in-depth
+  return real;
 }
 
 /**

--- a/src/utils/path-confine.ts
+++ b/src/utils/path-confine.ts
@@ -1,0 +1,23 @@
+/**
+ * Path-confinement helpers shared by source/wiki readers. Used to drop any
+ * entry whose `realpath` escapes its intended directory (e.g. a symlinked
+ * `sources/leak.md` pointing outside the project), preventing local-file-read.
+ */
+import { realpath } from "fs/promises";
+import path from "path";
+
+/** `realpath` that returns null instead of throwing on missing/broken paths. */
+export async function safeRealpath(p: string): Promise<string | null> {
+  try {
+    return await realpath(p);
+  } catch {
+    return null;
+  }
+}
+
+/** True when `child` equals `dir` or sits beneath it. */
+export function isInsideDir(child: string, dir: string): boolean {
+  if (child === dir) return true;
+  const prefix = dir.endsWith(path.sep) ? dir : dir + path.sep;
+  return child.startsWith(prefix);
+}

--- a/src/utils/path-confine.ts
+++ b/src/utils/path-confine.ts
@@ -2,9 +2,13 @@
  * Path-confinement helpers shared by source/wiki readers. Used to drop any
  * entry whose `realpath` escapes its intended directory (e.g. a symlinked
  * `sources/leak.md` pointing outside the project), preventing local-file-read.
+ *
+ * Also exports `resolveSourcesDir` which additionally guards against the
+ * `sources/` directory itself being a symlink to an outside location.
  */
-import { realpath } from "fs/promises";
+import { realpath, lstat } from "fs/promises";
 import path from "path";
+import { SOURCES_DIR } from "./constants.js";
 
 /** `realpath` that returns null instead of throwing on missing/broken paths. */
 export async function safeRealpath(p: string): Promise<string | null> {
@@ -20,4 +24,23 @@ export function isInsideDir(child: string, dir: string): boolean {
   if (child === dir) return true;
   const prefix = dir.endsWith(path.sep) ? dir : dir + path.sep;
   return child.startsWith(prefix);
+}
+
+/**
+ * Resolve the trusted on-disk sources directory for `root`: `<realpath(root)>/sources`,
+ * requiring `sources/` to be a REAL directory at that literal path. A symlinked
+ * `sources/` (which would redirect every read/write outside the project) yields null.
+ * Returns null when root is missing or `sources/` is absent / not a real directory.
+ */
+export async function resolveSourcesDir(root: string): Promise<string | null> {
+  const canonicalRoot = await safeRealpath(root);
+  if (canonicalRoot === null) return null;
+  const sourcesDir = path.join(canonicalRoot, SOURCES_DIR);
+  try {
+    const st = await lstat(sourcesDir);
+    if (!st.isDirectory()) return null; // symlink or non-dir → not trusted
+  } catch {
+    return null; // missing
+  }
+  return sourcesDir;
 }

--- a/src/utils/source-writer.ts
+++ b/src/utils/source-writer.ts
@@ -18,6 +18,7 @@ import { mkdir, readdir, readFile, writeFile } from "fs/promises";
 import path from "path";
 import { createHash } from "crypto";
 import { parseFrontmatter, slugify } from "./markdown.js";
+import { safeRealpath, isInsideDir } from "./path-confine.js";
 import { SOURCES_DIR } from "./constants.js";
 import type { WriteStatus } from "./types.js";
 
@@ -35,14 +36,14 @@ function shortHashOfSource(source: string): string {
 }
 
 /**
- * Resolve the destination filename for a slug + source identity:
+ * Resolve the destination filename for a slug + source identity when no
+ * existing file owns this source (source-identity matching is handled upstream
+ * by `findFileBySourceIdentity` before this is called):
  *
  * - When `${slug}.md` does not exist, return `${slug}.md`.
- * - When it exists and its frontmatter `source` matches the incoming
- *   source, return `${slug}.md` so re-ingest stays idempotent.
- * - Otherwise return `${slug}-<hash>.md` so two distinct sources that
- *   share a basename coexist instead of one silently overwriting the
- *   other.
+ * - When it exists (necessarily owned by a DIFFERENT source), return
+ *   `${slug}-<hash>.md` so two distinct sources that share a basename
+ *   coexist instead of one silently overwriting the other.
  */
 async function resolveCollisionFreeFilename(
   sourcesDir: string,
@@ -51,18 +52,14 @@ async function resolveCollisionFreeFilename(
 ): Promise<string> {
   const candidate = `${slug}.md`;
   const candidatePath = path.join(sourcesDir, candidate);
-  let existing: string;
   try {
-    existing = await readFile(candidatePath, "utf-8");
+    await readFile(candidatePath, "utf-8");
   } catch (err) {
     const e = err as { code?: string };
     if (e.code === "ENOENT") return candidate;
     throw err;
   }
-  const { meta } = parseFrontmatter(existing);
-  if (typeof meta.source === "string" && meta.source === source) {
-    return candidate;
-  }
+  // File exists and is owned by a different source — append a stable hash suffix.
   return `${slug}-${shortHashOfSource(source)}.md`;
 }
 
@@ -71,6 +68,10 @@ async function resolveCollisionFreeFilename(
  * regardless of its title-derived filename — the source identity is the key,
  * so re-ingesting under a renamed title updates the same file instead of
  * forking. O(number of sources): reads each file's frontmatter.
+ *
+ * Realpath-confined: entries whose resolved path escapes `sourcesDir` (e.g. a
+ * planted symlink) are silently skipped, preventing both arbitrary-file-reads
+ * and confused-deputy write-through via `saveSource`.
  */
 async function findFileBySourceIdentity(sourcesDir: string, source: string): Promise<string | null> {
   let names: string[];
@@ -80,8 +81,14 @@ async function findFileBySourceIdentity(sourcesDir: string, source: string): Pro
     if ((err as { code?: string }).code === "ENOENT") return null;
     throw err;
   }
+  const canonicalDir = await safeRealpath(sourcesDir);
+  if (canonicalDir === null) return null;
   for (const name of names) {
-    const { meta } = parseFrontmatter(await readFile(path.join(sourcesDir, name), "utf-8"));
+    // Realpath-confine: skip entries whose target escapes sources/ (e.g. a planted
+    // symlink), so we never read — or, via saveSource's writeFile, write — through them.
+    const real = await safeRealpath(path.join(sourcesDir, name));
+    if (real === null || !isInsideDir(real, canonicalDir)) continue;
+    const { meta } = parseFrontmatter(await readFile(real, "utf-8"));
     if (typeof meta.source === "string" && meta.source === source) return name;
   }
   return null;

--- a/src/utils/source-writer.ts
+++ b/src/utils/source-writer.ts
@@ -149,11 +149,15 @@ export async function saveSource(
         `Rename the source file to one with at least one letter or digit.`,
     );
   }
+  // Create <root>/sources first — recursive mkdir creates a missing root + sources as
+  // real dirs (the SDK contract: a fresh, not-yet-existing root is accepted on first
+  // ingest). mkdir never follows a trailing symlink, so it won't write through a
+  // symlinked sources/.
+  await mkdir(path.join(root, SOURCES_DIR), { recursive: true });
+  // Canonicalize root and re-derive the TRUSTED sources path; reject a symlinked-away sources/.
   const canonicalRoot = await safeRealpath(root);
-  if (canonicalRoot === null) throw new PathSafetyError(`root does not exist: ${root}`);
+  if (canonicalRoot === null) throw new PathSafetyError(`root does not exist: ${root}`); // defensive; mkdir created it
   const sourcesDir = path.join(canonicalRoot, SOURCES_DIR);
-  await mkdir(sourcesDir, { recursive: true });
-  // sources/ must be a real directory — refuse to write into a symlinked-away sources/.
   if (!(await lstat(sourcesDir)).isDirectory()) {
     throw new PathSafetyError(`sources/ must be a real directory, not a symlink`);
   }

--- a/src/utils/source-writer.ts
+++ b/src/utils/source-writer.ts
@@ -76,6 +76,10 @@ async function resolveCollisionFreeFilename(
  * a phantom write. When the body is unchanged the write is skipped and
  * `writeStatus` is `"unchanged"`, preserving the file's mtime.
  *
+ * The body comparison is exact, so callers must use a consistent
+ * trailing-newline convention — a body differing only by a trailing `\n`
+ * counts as `"updated"`. `buildDocument` already appends `\n` consistently.
+ *
  * @param title - Human-readable title used to derive the filename.
  * @param document - Full markdown content (frontmatter + body) to write.
  * @param source - Source identity (URL, file path, etc.) used both for

--- a/src/utils/source-writer.ts
+++ b/src/utils/source-writer.ts
@@ -75,9 +75,10 @@ async function resolveCollisionFreeFilename(
  * bulk ingest is O(n^2); a `source`->filename manifest index is the planned
  * v1.x remedy for large source sets.
  *
- * Realpath-confined: entries whose resolved path escapes `sourcesDir` (e.g. a
- * planted symlink) are silently skipped, preventing both arbitrary-file-reads
- * and confused-deputy write-through via `saveSource`.
+ * Regular files only (via `confinedRegularFile`): any symlink entry — whether
+ * escaping `sourcesDir` or an in-tree alias — is skipped, keeping the scan
+ * consistent with list/get/delete and preventing arbitrary-file-reads and
+ * confused-deputy write-through via `saveSource`.
  */
 async function findFileBySourceIdentity(sourcesDir: string, source: string): Promise<string | null> {
   let names: string[];

--- a/src/utils/source-writer.ts
+++ b/src/utils/source-writer.ts
@@ -14,7 +14,7 @@
  *    `source` field is consulted before suffixing.
  */
 
-import { mkdir, readFile, writeFile } from "fs/promises";
+import { mkdir, readdir, readFile, writeFile } from "fs/promises";
 import path from "path";
 import { createHash } from "crypto";
 import { parseFrontmatter, slugify } from "./markdown.js";
@@ -67,23 +67,58 @@ async function resolveCollisionFreeFilename(
 }
 
 /**
+ * Find the existing source file whose frontmatter `source` matches `source`,
+ * regardless of its title-derived filename — the source identity is the key,
+ * so re-ingesting under a renamed title updates the same file instead of
+ * forking. O(number of sources): reads each file's frontmatter.
+ */
+async function findFileBySourceIdentity(sourcesDir: string, source: string): Promise<string | null> {
+  let names: string[];
+  try {
+    names = (await readdir(sourcesDir)).filter((f) => f.endsWith(".md")).sort();
+  } catch (err) {
+    if ((err as { code?: string }).code === "ENOENT") return null;
+    throw err;
+  }
+  for (const name of names) {
+    const { meta } = parseFrontmatter(await readFile(path.join(sourcesDir, name), "utf-8"));
+    if (typeof meta.source === "string" && meta.source === source) return name;
+  }
+  return null;
+}
+
+/**
+ * Canonical comparison key for a source document: stable frontmatter + body,
+ * excluding volatile fields (`ingestedAt`). So a re-ingest with identical
+ * content but a fresh timestamp is `unchanged`, while a changed title /
+ * sourceType / truncation is `updated`.
+ */
+function stableContent(document: string): string {
+  const { meta, body } = parseFrontmatter(document);
+  const stable: Record<string, unknown> = {};
+  for (const key of Object.keys(meta).sort()) {
+    if (key === "ingestedAt") continue;
+    stable[key] = meta[key];
+  }
+  return `${JSON.stringify(stable)}\n${body}`;
+}
+
+/**
  * Write a markdown document into `sources/` under a slug derived from
  * the title, applying the empty-slug guard and basename-collision
  * disambiguation.
  *
- * The body (content after frontmatter) is compared against any existing
- * file so that volatile frontmatter fields like `ingestedAt` don't cause
- * a phantom write. When the body is unchanged the write is skipped and
- * `writeStatus` is `"unchanged"`, preserving the file's mtime.
+ * The source identity (not the title-derived slug) is the key: if the same
+ * source was previously saved under a different title, the existing file is
+ * updated in place rather than forking a new file. Stable frontmatter fields
+ * (title, sourceType, truncated, originalChars) are included in the
+ * comparison so changed metadata is detected, but volatile fields (`ingestedAt`)
+ * are excluded so a re-ingest with fresh timestamp is still `"unchanged"`.
  *
- * The body comparison is exact, so callers must use a consistent
- * trailing-newline convention — a body differing only by a trailing `\n`
- * counts as `"updated"`. `buildDocument` already appends `\n` consistently.
- *
- * @param title - Human-readable title used to derive the filename.
+ * @param title - Human-readable title used to derive the filename for new sources.
  * @param document - Full markdown content (frontmatter + body) to write.
- * @param source - Source identity (URL, file path, etc.) used both for
- *                 collision disambiguation and idempotency on re-ingest.
+ * @param source - Source identity (URL, file path, etc.) used as the canonical
+ *                 key for finding existing files and collision disambiguation.
  * @returns An object with the resolved destination `path` and a
  *          `writeStatus` of `"created"`, `"updated"`, or `"unchanged"`.
  */
@@ -107,26 +142,19 @@ export async function saveSource(
   const sourcesDir = path.join(root, SOURCES_DIR);
   await mkdir(sourcesDir, { recursive: true });
 
-  const filename = await resolveCollisionFreeFilename(sourcesDir, slug, source);
+  // The source identity (not the title-derived slug) is the key: reuse the
+  // existing file for this source even if the title changed; only allocate a
+  // new (slug-based) filename when this is a genuinely new source.
+  const existingByIdentity = await findFileBySourceIdentity(sourcesDir, source);
+  const filename = existingByIdentity ?? (await resolveCollisionFreeFilename(sourcesDir, slug, source));
   const destPath = path.join(sourcesDir, filename);
 
-  // Decide created/updated/unchanged by comparing the BODY (not full bytes):
-  // buildDocument stamps a fresh `ingestedAt` every call, so a byte compare
-  // would never be "unchanged". On a body match, skip the write entirely so
-  // mtime / freshness surfaces don't see a phantom change.
-  const newBody = parseFrontmatter(document).body;
-  let existingBody: string | null = null;
-  try {
-    existingBody = parseFrontmatter(await readFile(destPath, "utf-8")).body;
-  } catch (err) {
-    if ((err as { code?: string }).code !== "ENOENT") throw err;
-  }
-
-  if (existingBody === null) {
+  if (existingByIdentity === null) {
     await writeFile(destPath, document, "utf-8");
     return { path: destPath, writeStatus: "created" };
   }
-  if (existingBody === newBody) {
+  const existing = await readFile(destPath, "utf-8");
+  if (stableContent(existing) === stableContent(document)) {
     return { path: destPath, writeStatus: "unchanged" };
   }
   await writeFile(destPath, document, "utf-8");

--- a/src/utils/source-writer.ts
+++ b/src/utils/source-writer.ts
@@ -14,12 +14,13 @@
  *    `source` field is consulted before suffixing.
  */
 
-import { mkdir, readdir, readFile, writeFile } from "fs/promises";
+import { mkdir, readdir, readFile, writeFile, lstat } from "fs/promises";
 import path from "path";
 import { createHash } from "crypto";
 import { parseFrontmatter, slugify } from "./markdown.js";
 import { safeRealpath, isInsideDir } from "./path-confine.js";
 import { SOURCES_DIR } from "./constants.js";
+import { PathSafetyError } from "../viewer/path-safety.js";
 import type { WriteStatus } from "./types.js";
 
 /** Length of the hex hash suffix appended to disambiguate basename collisions. */
@@ -148,8 +149,14 @@ export async function saveSource(
         `Rename the source file to one with at least one letter or digit.`,
     );
   }
-  const sourcesDir = path.join(root, SOURCES_DIR);
+  const canonicalRoot = await safeRealpath(root);
+  if (canonicalRoot === null) throw new PathSafetyError(`root does not exist: ${root}`);
+  const sourcesDir = path.join(canonicalRoot, SOURCES_DIR);
   await mkdir(sourcesDir, { recursive: true });
+  // sources/ must be a real directory — refuse to write into a symlinked-away sources/.
+  if (!(await lstat(sourcesDir)).isDirectory()) {
+    throw new PathSafetyError(`sources/ must be a real directory, not a symlink`);
+  }
 
   // The source identity (not the title-derived slug) is the key: reuse the
   // existing file for this source even if the title changed; only allocate a
@@ -159,8 +166,22 @@ export async function saveSource(
   const destPath = path.join(sourcesDir, filename);
 
   if (existingByIdentity === null) {
-    await writeFile(destPath, document, "utf-8");
+    // New source: exclusive create — never write through a pre-existing entry
+    // (e.g. a planted symlink at the slug/hash destination).
+    try {
+      await writeFile(destPath, document, { encoding: "utf-8", flag: "wx" });
+    } catch (err) {
+      if ((err as { code?: string }).code === "EEXIST") {
+        throw new PathSafetyError(`refusing to write: ${filename} already exists in sources/`);
+      }
+      throw err;
+    }
     return { path: destPath, writeStatus: "created" };
+  }
+  // Update: the identity scan returned an in-tree match — require a regular file
+  // (reject an intra-sources symlink target; never writeFile through a symlink).
+  if (!(await lstat(destPath)).isFile()) {
+    throw new PathSafetyError(`refusing to write: ${filename} is not a regular file`);
   }
   const existing = await readFile(destPath, "utf-8");
   if (stableContent(existing) === stableContent(document)) {

--- a/src/utils/source-writer.ts
+++ b/src/utils/source-writer.ts
@@ -67,7 +67,9 @@ async function resolveCollisionFreeFilename(
  * Find the existing source file whose frontmatter `source` matches `source`,
  * regardless of its title-derived filename — the source identity is the key,
  * so re-ingesting under a renamed title updates the same file instead of
- * forking. O(number of sources): reads each file's frontmatter.
+ * forking. O(number of sources) per ingest — reads each existing source, so
+ * bulk ingest is O(n^2); a `source`->filename manifest index is the planned
+ * v1.x remedy for large source sets.
  *
  * Realpath-confined: entries whose resolved path escapes `sourcesDir` (e.g. a
  * planted symlink) are silently skipped, preventing both arbitrary-file-reads

--- a/src/utils/source-writer.ts
+++ b/src/utils/source-writer.ts
@@ -18,7 +18,7 @@ import { mkdir, readdir, readFile, writeFile, lstat } from "fs/promises";
 import path from "path";
 import { createHash } from "crypto";
 import { parseFrontmatter, slugify } from "./markdown.js";
-import { safeRealpath, isInsideDir } from "./path-confine.js";
+import { safeRealpath, confinedRegularFile } from "./path-confine.js";
 import { SOURCES_DIR } from "./constants.js";
 import { PathSafetyError } from "../viewer/path-safety.js";
 import type { WriteStatus } from "./types.js";
@@ -87,13 +87,11 @@ async function findFileBySourceIdentity(sourcesDir: string, source: string): Pro
     if ((err as { code?: string }).code === "ENOENT") return null;
     throw err;
   }
-  const canonicalDir = await safeRealpath(sourcesDir);
-  if (canonicalDir === null) return null;
   for (const name of names) {
-    // Realpath-confine: skip entries whose target escapes sources/ (e.g. a planted
-    // symlink), so we never read — or, via saveSource's writeFile, write — through them.
-    const real = await safeRealpath(path.join(sourcesDir, name));
-    if (real === null || !isInsideDir(real, canonicalDir)) continue;
+    // Regular files only: symlinks (whether escaping or in-tree aliases) are never
+    // sources, keeping the scan consistent with list/get/delete.
+    const real = await confinedRegularFile(sourcesDir, name);
+    if (real === null) continue;
     const { meta } = parseFrontmatter(await readFile(real, "utf-8"));
     if (typeof meta.source === "string" && meta.source === source) return name;
   }

--- a/src/utils/source-writer.ts
+++ b/src/utils/source-writer.ts
@@ -19,6 +19,7 @@ import path from "path";
 import { createHash } from "crypto";
 import { parseFrontmatter, slugify } from "./markdown.js";
 import { SOURCES_DIR } from "./constants.js";
+import type { WriteStatus } from "./types.js";
 
 /** Length of the hex hash suffix appended to disambiguate basename collisions. */
 const COLLISION_HASH_LEN = 8;
@@ -68,19 +69,26 @@ async function resolveCollisionFreeFilename(
 /**
  * Write a markdown document into `sources/` under a slug derived from
  * the title, applying the empty-slug guard and basename-collision
- * disambiguation. Returns the resolved destination path.
+ * disambiguation.
+ *
+ * The body (content after frontmatter) is compared against any existing
+ * file so that volatile frontmatter fields like `ingestedAt` don't cause
+ * a phantom write. When the body is unchanged the write is skipped and
+ * `writeStatus` is `"unchanged"`, preserving the file's mtime.
  *
  * @param title - Human-readable title used to derive the filename.
  * @param document - Full markdown content (frontmatter + body) to write.
  * @param source - Source identity (URL, file path, etc.) used both for
  *                 collision disambiguation and idempotency on re-ingest.
+ * @returns An object with the resolved destination `path` and a
+ *          `writeStatus` of `"created"`, `"updated"`, or `"unchanged"`.
  */
 export async function saveSource(
   root: string,
   title: string,
   document: string,
   source: string,
-): Promise<string> {
+): Promise<{ path: string; writeStatus: WriteStatus }> {
   const slug = slugify(title);
   // Defense in depth — even with the Unicode-aware slugifier (#35), a
   // title made entirely of punctuation/emoji/symbols still slugifies to
@@ -94,8 +102,29 @@ export async function saveSource(
   }
   const sourcesDir = path.join(root, SOURCES_DIR);
   await mkdir(sourcesDir, { recursive: true });
+
   const filename = await resolveCollisionFreeFilename(sourcesDir, slug, source);
   const destPath = path.join(sourcesDir, filename);
+
+  // Decide created/updated/unchanged by comparing the BODY (not full bytes):
+  // buildDocument stamps a fresh `ingestedAt` every call, so a byte compare
+  // would never be "unchanged". On a body match, skip the write entirely so
+  // mtime / freshness surfaces don't see a phantom change.
+  const newBody = parseFrontmatter(document).body;
+  let existingBody: string | null = null;
+  try {
+    existingBody = parseFrontmatter(await readFile(destPath, "utf-8")).body;
+  } catch (err) {
+    if ((err as { code?: string }).code !== "ENOENT") throw err;
+  }
+
+  if (existingBody === null) {
+    await writeFile(destPath, document, "utf-8");
+    return { path: destPath, writeStatus: "created" };
+  }
+  if (existingBody === newBody) {
+    return { path: destPath, writeStatus: "unchanged" };
+  }
   await writeFile(destPath, document, "utf-8");
-  return destPath;
+  return { path: destPath, writeStatus: "updated" };
 }

--- a/src/utils/source-writer.ts
+++ b/src/utils/source-writer.ts
@@ -54,13 +54,16 @@ async function resolveCollisionFreeFilename(
   const candidate = `${slug}.md`;
   const candidatePath = path.join(sourcesDir, candidate);
   try {
-    await readFile(candidatePath, "utf-8");
+    // No-follow existence probe: lstat never reads or follows a planted symlink
+    // at sources/<slug>.md (readFile here would EISDIR on a symlinked dir or leak
+    // an outside file). The actual write is still guarded by wx/lstat downstream.
+    await lstat(candidatePath);
   } catch (err) {
-    const e = err as { code?: string };
-    if (e.code === "ENOENT") return candidate;
+    if ((err as { code?: string }).code === "ENOENT") return candidate;
     throw err;
   }
-  // File exists and is owned by a different source — append a stable hash suffix.
+  // An entry already occupies sources/<slug>.md (a different source, or a planted
+  // symlink) — append a stable hash suffix instead of touching it.
   return `${slug}-${shortHashOfSource(source)}.md`;
 }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -222,6 +222,8 @@ export interface IngestResult {
   source: string;
   /** Detected source type; undefined for legacy results produced before this field was added. */
   sourceType?: SourceType;
+  /** Whether the source file was created, updated (content changed), or unchanged (no-op). */
+  writeStatus: WriteStatus;
 }
 
 /**

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -211,6 +211,9 @@ export interface QueryResult {
 /** Source type tag persisted in frontmatter to describe the ingest origin. */
 export type SourceType = "web" | "file" | "image" | "pdf" | "transcript";
 
+/** Outcome of a source write: a new file, a content change, or a no-op. */
+export type WriteStatus = "created" | "updated" | "unchanged";
+
 /** Structured result returned by the ingest pipeline. */
 export interface IngestResult {
   filename: string;

--- a/src/wiki/collect.ts
+++ b/src/wiki/collect.ts
@@ -26,11 +26,12 @@
  *     pages in the UI.
  */
 
-import { readdir, readFile, realpath } from "fs/promises";
+import { readdir, readFile } from "fs/promises";
 import path from "path";
 import { parseFrontmatterStatus, slugify } from "../utils/markdown.js";
 import { CONCEPTS_DIR, QUERIES_DIR } from "../utils/constants.js";
 import type { PageDirectory } from "../export/types.js";
+import { safeRealpath, isInsideDir } from "../utils/path-confine.js";
 
 /** Regex that matches `[[wikilink]]` or `[[wikilink|alias]]` patterns. */
 const WIKILINK_RE = /\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g;
@@ -108,26 +109,6 @@ export function extractWikilinkTargets(body: string): { slug: string; display: s
     }
   }
   return targets;
-}
-
-/**
- * `realpath` wrapper that returns null instead of throwing on missing
- * files. Used everywhere we resolve a possibly-absent or possibly-broken
- * symlink and want to fall through to "skip this entry."
- */
-async function safeRealpath(p: string): Promise<string | null> {
-  try {
-    return await realpath(p);
-  } catch {
-    return null;
-  }
-}
-
-/** True when `child` equals `dir` or sits beneath it. */
-function isInsideDir(child: string, dir: string): boolean {
-  if (child === dir) return true;
-  const prefix = dir.endsWith(path.sep) ? dir : dir + path.sep;
-  return child.startsWith(prefix);
 }
 
 /**

--- a/test/commands/ingest-status.test.ts
+++ b/test/commands/ingest-status.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { mkdtemp, readFile, stat } from "node:fs/promises";
+import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { ingestTextSource } from "../../src/commands/ingest.js";
+import { ingestSource, ingestTextSource } from "../../src/commands/ingest.js";
 import { LOG_FILE } from "../../src/utils/constants.js";
 
 describe("ingestTextSource writeStatus + journaling", () => {
@@ -24,5 +24,17 @@ describe("ingestTextSource writeStatus + journaling", () => {
     expect(r3.writeStatus).toBe("unchanged");
     expect(await readFile(path.join(root, LOG_FILE), "utf-8")).toBe(logBefore); // no new journal line
     expect((await stat(path.join(root, "sources", r3.filename))).mtimeMs).toBe(fileBefore.mtimeMs);
+  });
+
+  it("ingestSource: re-ingesting an unchanged file is a no-op (writeStatus + no journal)", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "ingest-src-status-"));
+    const src = path.join(root, "note.md");
+    await writeFile(src, "Enough body content to satisfy the minimum source length requirement.", "utf-8");
+    const a = await ingestSource(root, src);
+    expect(a.writeStatus).toBe("created");
+    const logAfterFirst = await readFile(path.join(root, LOG_FILE), "utf-8");
+    const b = await ingestSource(root, src);
+    expect(b.writeStatus).toBe("unchanged");
+    expect(await readFile(path.join(root, LOG_FILE), "utf-8")).toBe(logAfterFirst); // no new entry
   });
 });

--- a/test/commands/ingest-status.test.ts
+++ b/test/commands/ingest-status.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, readFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { ingestTextSource } from "../../src/commands/ingest.js";
+import { LOG_FILE } from "../../src/utils/constants.js";
+
+describe("ingestTextSource writeStatus + journaling", () => {
+  it("created/updated/unchanged; unchanged writes no journal entry and no rewrite", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "ingest-status-"));
+    const body = "Enough body content to satisfy the minimum source length requirement.";
+
+    const r1 = await ingestTextSource(root, { title: "N", text: body, source: "manual:fixed" });
+    expect(r1.writeStatus).toBe("created");
+
+    const r2 = await ingestTextSource(root, { title: "N", text: body + " more", source: "manual:fixed" });
+    expect(r2.writeStatus).toBe("updated");
+
+    const logBefore = await readFile(path.join(root, LOG_FILE), "utf-8");
+    const fileBefore = await stat(path.join(root, "sources", r2.filename));
+    await new Promise((res) => setTimeout(res, 5));
+
+    const r3 = await ingestTextSource(root, { title: "N", text: body + " more", source: "manual:fixed" });
+    expect(r3.writeStatus).toBe("unchanged");
+    expect(await readFile(path.join(root, LOG_FILE), "utf-8")).toBe(logBefore); // no new journal line
+    expect((await stat(path.join(root, "sources", r3.filename))).mtimeMs).toBe(fileBefore.mtimeMs);
+  });
+});

--- a/test/sdk/source-api.test.ts
+++ b/test/sdk/source-api.test.ts
@@ -15,6 +15,8 @@ describe("Wiki source API", () => {
 
     const { sources } = await wiki.listSources();
     expect(sources.map((s) => s.id)).toContain(r.filename);
+    const listed = sources.find((s) => s.id === r.filename);
+    expect(listed?.body).toBeUndefined(); // bodies are opt-in via includeBody
 
     const got = await wiki.getSource(r.filename);
     expect(got?.body).toContain("source body");

--- a/test/sdk/source-api.test.ts
+++ b/test/sdk/source-api.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createWiki } from "../../src/sdk/wiki.js";
+
+describe("Wiki source API", () => {
+  it("ingest → list/get → delete round-trip, with writeStatus, silently", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "sdk-src-"));
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const wiki = createWiki({ root });
+
+    const r = await wiki.ingestText({ title: "Note", text: "Some sufficiently long source body content here." });
+    expect(r.writeStatus).toBe("created");
+
+    const { sources } = await wiki.listSources();
+    expect(sources.map((s) => s.id)).toContain(r.filename);
+
+    const got = await wiki.getSource(r.filename);
+    expect(got?.body).toContain("source body");
+
+    expect(await wiki.deleteSource(r.filename)).toBe(true);
+    expect(await wiki.getSource(r.filename)).toBeNull();
+
+    expect(logSpy).not.toHaveBeenCalled(); // quiet
+    logSpy.mockRestore();
+  });
+});

--- a/test/sources/delete.test.ts
+++ b/test/sources/delete.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { deleteSource } from "../../src/sources/store.js";
+import { PathSafetyError } from "../../src/viewer/path-safety.js";
+
+describe("deleteSource", () => {
+  it("true when removed, false when absent, throws on unsafe id", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "src-del-"));
+    await mkdir(path.join(root, "sources"), { recursive: true });
+    await writeFile(path.join(root, "sources/a.md"), "---\ntitle: A\n---\nbody", "utf-8");
+
+    expect(await deleteSource(root, "a.md")).toBe(true);
+    expect(existsSync(path.join(root, "sources/a.md"))).toBe(false);
+    expect(await deleteSource(root, "a.md")).toBe(false); // already gone
+    await expect(deleteSource(root, "../etc/passwd.md")).rejects.toBeInstanceOf(PathSafetyError);
+  });
+});

--- a/test/sources/store-intree-alias.test.ts
+++ b/test/sources/store-intree-alias.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, writeFile, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { listSources, getSource, deleteSource } from "../../src/sources/store.js";
+
+async function seedAlias() {
+  const root = await mkdtemp(path.join(tmpdir(), "src-alias-"));
+  await mkdir(path.join(root, "sources"), { recursive: true });
+  await writeFile(path.join(root, "sources/real.md"), "---\ntitle: Real\nsource: ident\n---\nbody-real", "utf-8");
+  // alias.md -> real.md, sorts BEFORE real.md
+  await symlink(path.join(root, "sources/real.md"), path.join(root, "sources/alias.md"));
+  return root;
+}
+
+describe("in-tree symlink aliases are not sources", () => {
+  it("listSources returns only the regular file", async () => {
+    const root = await seedAlias();
+    const { sources } = await listSources(root);
+    expect(sources.map((s) => s.id)).toEqual(["real.md"]); // alias.md excluded
+  });
+  it("getSource(alias) is null; getSource(real) works", async () => {
+    const root = await seedAlias();
+    expect(await getSource(root, "alias.md")).toBeNull();
+    expect((await getSource(root, "real.md"))?.body).toContain("body-real");
+  });
+  it("deleteSource(alias) is false; deleteSource(real) is true", async () => {
+    const root = await seedAlias();
+    expect(await deleteSource(root, "alias.md")).toBe(false);
+    expect(await deleteSource(root, "real.md")).toBe(true);
+  });
+});

--- a/test/sources/store-sources-symlink.test.ts
+++ b/test/sources/store-sources-symlink.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Bug 1: sources/ itself being a symlink to an outside directory.
+ *
+ * Before the fix, safeRealpath(join(root, "sources")) would follow the sources/
+ * symlink and return the outside dir as the "trusted base". Every subsequent
+ * per-entry confinement check would pass because all entries resolved inside
+ * that outside dir. This exposed the outside directory for reads (listSources,
+ * getSource) and writes (saveSource).
+ *
+ * The fix: resolveSourcesDir() requires sources/ to be a REAL directory via
+ * lstat() before trusting it. A symlink returns null → treated as absent.
+ */
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, writeFile, symlink, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { listSources, getSource } from "../../src/sources/store.js";
+import { saveSource } from "../../src/utils/source-writer.js";
+
+describe("sources/ itself being a symlink is rejected (no escape)", () => {
+  async function setup() {
+    const base = await mkdtemp(path.join(tmpdir(), "src-symdir-"));
+    const root = path.join(base, "proj");
+    await mkdir(root, { recursive: true });
+    const outside = path.join(base, "outside");
+    await mkdir(outside, { recursive: true });
+    await writeFile(path.join(outside, "secret.md"), "---\ntitle: S\nsource: s\n---\nSECRET", "utf-8");
+    // <root>/sources is a SYMLINK to the outside dir
+    await symlink(outside, path.join(root, "sources"));
+    return { root, outside };
+  }
+
+  it("listSources/getSource do not expose the outside dir", async () => {
+    const { root } = await setup();
+    expect((await listSources(root, { includeBody: true })).sources).toEqual([]);
+    expect(await getSource(root, "secret.md")).toBeNull();
+  });
+
+  it("saveSource does not write into the symlinked-away sources/", async () => {
+    const { root, outside } = await setup();
+    await expect(saveSource(root, "Note", "---\ntitle: Note\nsource: x\n---\n\nbody\n", "x")).rejects.toThrow();
+    const outsideFiles = (await readdir(outside)).sort();
+    expect(outsideFiles).toEqual(["secret.md"]); // nothing new written outside
+  });
+});

--- a/test/sources/store-symlink.test.ts
+++ b/test/sources/store-symlink.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, writeFile, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { listSources, getSource } from "../../src/sources/store.js";
+
+describe("source store rejects symlink escape", () => {
+  it("does not read or list a symlink pointing outside sources/", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "src-symlink-"));
+    await mkdir(path.join(root, "sources"), { recursive: true });
+    // a real source, and a SECRET file outside sources/
+    await writeFile(path.join(root, "sources/real.md"), "---\ntitle: Real\nsource: s\n---\nreal-body", "utf-8");
+    await writeFile(path.join(root, "secret.txt"), "TOP SECRET CONTENTS", "utf-8");
+    // plant a symlink inside sources/ that escapes to the secret
+    await symlink(path.join(root, "secret.txt"), path.join(root, "sources/leak.md"));
+
+    const { sources } = await listSources(root, { includeBody: true });
+    expect(sources.map((s) => s.id)).toEqual(["real.md"]); // leak.md excluded
+    expect(JSON.stringify(sources)).not.toContain("SECRET");
+
+    expect(await getSource(root, "leak.md")).toBeNull(); // not read through the symlink
+    expect((await getSource(root, "real.md"))?.body).toContain("real-body"); // real file still works
+  });
+});

--- a/test/sources/store-symlink.test.ts
+++ b/test/sources/store-symlink.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtemp, mkdir, writeFile, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { listSources, getSource } from "../../src/sources/store.js";
+import { listSources, getSource, deleteSource } from "../../src/sources/store.js";
 
 describe("source store rejects symlink escape", () => {
   it("does not read or list a symlink pointing outside sources/", async () => {
@@ -20,5 +20,18 @@ describe("source store rejects symlink escape", () => {
 
     expect(await getSource(root, "leak.md")).toBeNull(); // not read through the symlink
     expect((await getSource(root, "real.md"))?.body).toContain("real-body"); // real file still works
+  });
+
+  it("deleteSource agrees with getSource on an escaping symlink (both treat it as absent)", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "src-del-sym-"));
+    await mkdir(path.join(root, "sources"), { recursive: true });
+    await writeFile(path.join(root, "secret.txt"), "SECRET", "utf-8");
+    await symlink(path.join(root, "secret.txt"), path.join(root, "sources/leak.md"));
+    await writeFile(path.join(root, "sources/real.md"), "---\ntitle: R\nsource: s\n---\nbody", "utf-8");
+
+    expect(await getSource(root, "leak.md")).toBeNull();       // get: not a source
+    expect(await deleteSource(root, "leak.md")).toBe(false);   // delete: also not a source (coherent)
+    expect(await deleteSource(root, "real.md")).toBe(true);    // real file deletes
+    expect(await deleteSource(root, "missing.md")).toBe(false); // absent → false
   });
 });

--- a/test/sources/store.test.ts
+++ b/test/sources/store.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { listSources, getSource } from "../../src/sources/store.js";
+import { PathSafetyError } from "../../src/viewer/path-safety.js";
+
+async function seed(root: string) {
+  await mkdir(path.join(root, "sources"), { recursive: true });
+  await writeFile(path.join(root, "sources/b.md"), "---\ntitle: B\nsource: s2\nsourceType: file\n---\nbody-b", "utf-8");
+  await writeFile(path.join(root, "sources/a.md"), "---\ntitle: A\nsource: s1\nsourceType: web\ningestedAt: 2026-01-01T00:00:00.000Z\n---\nbody-a", "utf-8");
+}
+
+describe("source store reads", () => {
+  it("lists sorted by id, bodies opt-in, with frontmatter metadata", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "src-list-"));
+    await seed(root);
+    const { sources } = await listSources(root);
+    expect(sources.map((s) => s.id)).toEqual(["a.md", "b.md"]);
+    expect(sources[0]).toMatchObject({ id: "a.md", title: "A", source: "s1", sourceType: "web" });
+    expect(sources[0].body).toBeUndefined();
+    const withBody = await listSources(root, { includeBody: true });
+    expect(withBody.sources.find((s) => s.id === "a.md")?.body).toContain("body-a");
+  });
+
+  it("paginates", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "src-page-"));
+    await seed(root);
+    const p1 = await listSources(root, { limit: 1 });
+    expect(p1.sources.map((s) => s.id)).toEqual(["a.md"]);
+    expect(p1.cursor).toBeDefined();
+    const p2 = await listSources(root, { limit: 1, cursor: p1.cursor });
+    expect(p2.sources.map((s) => s.id)).toEqual(["b.md"]);
+    expect(p2.cursor).toBeUndefined();
+  });
+
+  it("getSource hit/miss; rejects unsafe ids", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "src-get-"));
+    await seed(root);
+    expect((await getSource(root, "a.md"))?.body).toContain("body-a");
+    expect(await getSource(root, "missing.md")).toBeNull();
+    await expect(getSource(root, "../secret.md")).rejects.toBeInstanceOf(PathSafetyError);
+    await expect(getSource(root, "a.txt")).rejects.toBeInstanceOf(PathSafetyError);
+  });
+});

--- a/test/utils/source-identity.test.ts
+++ b/test/utils/source-identity.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, readdir, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { saveSource } from "../../src/utils/source-writer.js";
+
+// Build a document with an explicit source identity and a given title/body.
+const doc = (title: string, body: string, source = "https://x.test/a") =>
+  `---\ntitle: ${title}\nsource: ${source}\ningestedAt: ${new Date().toISOString()}\n---\n\n${body}\n`;
+
+describe("saveSource keys on source identity, compares stable content", () => {
+  it("same source, changed title → updates the SAME file (no fork)", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "src-id-"));
+    const r1 = await saveSource(root, "Original Title", doc("Original Title", "body-A", "https://x.test/a"), "https://x.test/a");
+    expect(r1.writeStatus).toBe("created");
+
+    const r2 = await saveSource(root, "Renamed Title", doc("Renamed Title", "body-A", "https://x.test/a"), "https://x.test/a");
+    expect(r2.writeStatus).toBe("updated"); // same source, body same but title changed → metadata update
+    expect(r2.path).toBe(r1.path);          // SAME file reused
+
+    const files = (await readdir(path.join(root, "sources"))).filter((f) => f.endsWith(".md"));
+    expect(files.length).toBe(1);           // did NOT fork into a second file
+    expect(await readFile(r2.path, "utf-8")).toContain("title: Renamed Title"); // metadata updated
+  });
+
+  it("identical stable content, fresh ingestedAt → unchanged (no-op)", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "src-id2-"));
+    const a = await saveSource(root, "T", doc("T", "same body", "https://x.test/b"), "https://x.test/b");
+    expect(a.writeStatus).toBe("created");
+    const b = await saveSource(root, "T", doc("T", "same body", "https://x.test/b"), "https://x.test/b"); // only ingestedAt differs
+    expect(b.writeStatus).toBe("unchanged");
+  });
+
+  it("changed body → updated", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "src-id3-"));
+    await saveSource(root, "T", doc("T", "v1", "https://x.test/c"), "https://x.test/c");
+    const r = await saveSource(root, "T", doc("T", "v2", "https://x.test/c"), "https://x.test/c");
+    expect(r.writeStatus).toBe("updated");
+  });
+});

--- a/test/utils/source-writer-collision-nofollow.test.ts
+++ b/test/utils/source-writer-collision-nofollow.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, readdir, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { saveSource } from "../../src/utils/source-writer.js";
+
+/**
+ * Collision resolution must use a no-follow existence check: a planted
+ * `sources/<slug>.md` symlink must never be read/followed (which would EISDIR on
+ * a symlinked directory, or leak an outside file). Ingest picks the hash suffix.
+ */
+describe("resolveCollisionFreeFilename does not follow a symlinked candidate", () => {
+  it("picks the hash suffix instead of reading through sources/<slug>.md", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "sw-nofollow-"));
+    await mkdir(path.join(root, "sources"), { recursive: true });
+    const outsideDir = path.join(root, "outsideDir");
+    await mkdir(outsideDir, { recursive: true });
+    // sources/safe.md -> an outside DIRECTORY; readFile here would throw EISDIR.
+    await symlink(outsideDir, path.join(root, "sources/safe.md"));
+
+    const doc = "---\ntitle: Safe\nsource: newsource\ningestedAt: 2026-01-01T00:00:00.000Z\n---\n\nbody";
+    const r = await saveSource(root, "Safe", doc, "newsource"); // must NOT throw EISDIR
+
+    expect(r.writeStatus).toBe("created");
+    expect(path.basename(r.path)).not.toBe("safe.md"); // chose the suffix, didn't touch the symlink
+    expect(path.basename(r.path)).toMatch(/^safe-[0-9a-f]{8}\.md$/);
+    expect(await readdir(outsideDir)).toEqual([]); // nothing written through the symlink target
+  });
+});

--- a/test/utils/source-writer-collision-symlink.test.ts
+++ b/test/utils/source-writer-collision-symlink.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Bug 2: collision-suffix write path writes through a planted symlink.
+ *
+ * Before the fix, saveSource used plain writeFile(destPath, ...) for new sources.
+ * If a symlink existed at the expected hash-suffixed destination (e.g.
+ * sources/safe-<hash>.md → /outside.md), writeFile would follow it and overwrite
+ * the outside file. The identity scan skips symlinks escaping sources/, so
+ * existingByIdentity is null, and saveSource proceeds to the "created" path —
+ * straight into writeFile on the symlink target.
+ *
+ * The fix: use writeFile with flag "wx" (exclusive create) for new-source writes
+ * so that any pre-existing entry — including a symlink — causes EEXIST and a
+ * PathSafetyError rather than silent overwrite.
+ */
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, writeFile, readFile, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { saveSource } from "../../src/utils/source-writer.js";
+import { createHash } from "node:crypto";
+
+describe("saveSource never writes through a planted collision-suffix symlink", () => {
+  it("refuses to overwrite an outside file via sources/<slug>-<hash>.md symlink", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "sw-collide-"));
+    await mkdir(path.join(root, "sources"), { recursive: true });
+    // a DIFFERENT source already owns sources/safe.md (forces the hash-suffix path)
+    await writeFile(path.join(root, "sources/safe.md"), "---\ntitle: Safe\nsource: other\n---\nother", "utf-8");
+    // outside file we must NOT clobber
+    const outside = path.join(root, "outside.md");
+    await writeFile(outside, "ORIGINAL OUTSIDE", "utf-8");
+    // plant the symlink at exactly the hash-suffixed name for source "poison"
+    const hash = createHash("sha256").update("poison").digest("hex").slice(0, 8);
+    await symlink(outside, path.join(root, `sources/safe-${hash}.md`));
+
+    // ingest "poison" under slug "Safe" → would resolve to safe-<hash>.md (the symlink)
+    const doc = "---\ntitle: Safe\nsource: poison\ningestedAt: 2026-01-01T00:00:00.000Z\n---\n\nnew body";
+    await expect(saveSource(root, "Safe", doc, "poison")).rejects.toThrow(); // refuses to write through it
+    expect(await readFile(outside, "utf-8")).toBe("ORIGINAL OUTSIDE"); // untouched
+  });
+});

--- a/test/utils/source-writer-intree-alias.test.ts
+++ b/test/utils/source-writer-intree-alias.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, writeFile, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { saveSource } from "../../src/utils/source-writer.js";
+
+describe("saveSource re-ingest is not blocked by an in-tree symlink alias", () => {
+  it("updates the real file even when an alias sorts first", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "sw-alias-"));
+    await mkdir(path.join(root, "sources"), { recursive: true });
+    await writeFile(path.join(root, "sources/real.md"),
+      "---\ntitle: Real\nsource: ident\ningestedAt: 2026-01-01T00:00:00.000Z\n---\n\nold body", "utf-8");
+    await symlink(path.join(root, "sources/real.md"), path.join(root, "sources/alias.md")); // sorts first
+
+    const doc = "---\ntitle: Real\nsource: ident\ningestedAt: 2026-02-02T00:00:00.000Z\n---\n\nnew body";
+    const r = await saveSource(root, "Real", doc, "ident"); // must NOT throw
+
+    expect(r.writeStatus).toBe("updated");
+    expect(path.basename(r.path)).toBe("real.md"); // updated the regular file, not the alias
+  });
+});

--- a/test/utils/source-writer-status.test.ts
+++ b/test/utils/source-writer-status.test.ts
@@ -12,9 +12,12 @@ describe("saveSource writeStatus", () => {
     const r1 = await saveSource(root, "Note", doc("alpha"), "manual:fixed");
     expect(r1.writeStatus).toBe("created");
 
+    const r1mtime = (await stat(r1.path)).mtimeMs;
+    await new Promise((res) => setTimeout(res, 5));
     const r2 = await saveSource(root, "Note", doc("beta"), "manual:fixed"); // same source, new body
     expect(r2.writeStatus).toBe("updated");
     expect(r2.path).toBe(r1.path);
+    expect((await stat(r2.path)).mtimeMs).toBeGreaterThan(r1mtime); // actually rewritten
 
     const before = await stat(r2.path);
     await new Promise((res) => setTimeout(res, 5));

--- a/test/utils/source-writer-status.test.ts
+++ b/test/utils/source-writer-status.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, readFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { saveSource } from "../../src/utils/source-writer.js";
+
+const doc = (body: string) => `---\ntitle: Note\nsource: manual:fixed\ningestedAt: ${new Date().toISOString()}\n---\n\n${body}\n`;
+
+describe("saveSource writeStatus", () => {
+  it("created → updated → unchanged, and unchanged is a true no-op", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "ss-status-"));
+    const r1 = await saveSource(root, "Note", doc("alpha"), "manual:fixed");
+    expect(r1.writeStatus).toBe("created");
+
+    const r2 = await saveSource(root, "Note", doc("beta"), "manual:fixed"); // same source, new body
+    expect(r2.writeStatus).toBe("updated");
+    expect(r2.path).toBe(r1.path);
+
+    const before = await stat(r2.path);
+    await new Promise((res) => setTimeout(res, 5));
+    const r3 = await saveSource(root, "Note", doc("beta"), "manual:fixed"); // identical body, new ingestedAt
+    expect(r3.writeStatus).toBe("unchanged");
+    const after = await stat(r3.path);
+    expect(after.mtimeMs).toBe(before.mtimeMs); // not rewritten
+    expect((await readFile(r3.path, "utf-8"))).toContain("beta");
+  });
+});

--- a/test/utils/source-writer-symlink.test.ts
+++ b/test/utils/source-writer-symlink.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, writeFile, readFile, symlink, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { saveSource } from "../../src/utils/source-writer.js";
+
+describe("saveSource ignores symlinked source entries (no read/write-through)", () => {
+  it("does not match or write through a symlink escaping sources/", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "sw-symlink-"));
+    await mkdir(path.join(root, "sources"), { recursive: true });
+    // an OUTSIDE file whose frontmatter source matches what we'll ingest
+    const outside = path.join(root, "outside.md");
+    const outsideContent = "---\ntitle: Outside\nsource: poison\n---\nORIGINAL OUTSIDE CONTENT";
+    await writeFile(outside, outsideContent, "utf-8");
+    // plant a symlink inside sources/ pointing at the outside file
+    await symlink(outside, path.join(root, "sources/evil.md"));
+
+    // ingest a NEW source with identity "poison" — must NOT match evil.md (the symlink),
+    // must NOT write through it, and must create a fresh real source file.
+    const doc = "---\ntitle: Safe\nsource: poison\ningestedAt: 2026-01-01T00:00:00.000Z\n---\n\nsafe body";
+    const r = await saveSource(root, "Safe", doc, "poison");
+
+    expect(r.writeStatus).toBe("created"); // not "updated" via the symlink
+    expect(path.basename(r.path)).not.toBe("evil.md"); // wrote a real file, not the symlink
+    // the outside file is UNTOUCHED (no write-through):
+    expect(await readFile(outside, "utf-8")).toBe(outsideContent);
+    // a real (non-symlink) source file now exists
+    const names = (await readdir(path.join(root, "sources"))).filter((f) => f.endsWith(".md"));
+    expect(names).toContain(path.basename(r.path));
+  });
+});


### PR DESCRIPTION
Adds a source-management API to the in-process SDK so consumers can treat a project's `sources/` directory as a coherent CRUD surface, alongside the existing page/compile/export methods.

Ingest results now carry a `writeStatus` (`created` / `updated` / `unchanged`), decided by comparing the source body rather than raw bytes — so re-ingesting identical content is a true no-op: no file rewrite, no mtime change, and no activity-journal entry, even though each ingest stamps a fresh `ingestedAt`. `createWiki` gains `listSources` (paginated, body opt-in), `getSource`, and `deleteSource`, all with path-safe `.md` ids (the id is the `IngestResult.filename`). Deleting a source removes the file; the compiled page is reconciled on the next `compile`.