### PR TITLE
feat(refresh): llmwiki refresh --stale — targeted recompile of stale pages

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,7 @@ import reviewApproveCommand from "./commands/review-approve.js";
 import reviewRejectCommand from "./commands/review-reject.js";
 import { registerRulesCommand } from "./commands/rules-register.js";
 import nextCommand from "./commands/next.js";
+import refreshCommand from "./commands/refresh.js";
 import quickstartCommand, { type QuickstartOptions } from "./commands/quickstart.js";
 import contextCommand, { type ContextCommandOptions } from "./commands/context.js";
 import { startMCPServer } from "./mcp/server.js";
@@ -103,6 +104,21 @@ program
       applyLanguageOption(options.lang);
       requireProvider();
       await compileCommand({ review: options.review });
+    } catch (err) {
+      console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
+      process.exit(1);
+    }
+  });
+
+program
+  .command("refresh")
+  .description("Recompile only stale/changed pages without touching unrelated new sources")
+  .option("--stale", "Resolve stale/orphaned pages and recompile them")
+  .option("--dry-run", "Print the refresh plan without calling the LLM or writing files")
+  .action(async (options: { stale?: boolean; dryRun?: boolean }) => {
+    try {
+      const code = await refreshCommand(options, requireProvider);
+      process.exit(code);
     } catch (err) {
       console.error(`\x1b[31mError:\x1b[0m ${err instanceof Error ? err.message : err}`);
       process.exit(1);

--- a/src/commands/refresh.ts
+++ b/src/commands/refresh.ts
@@ -1,0 +1,139 @@
+/**
+ * Commander action for `llmwiki refresh --stale [--dry-run]`. Resolves the set of
+ * stale/orphaned pages, then either prints the plan (dry-run, no LLM/writes) or
+ * delegates a scoped recompile to the compile pipeline via CompileOptions.
+ * Repairs stale compiled knowledge; deliberately skips unrelated new sources.
+ */
+
+import { compileAndReport } from "../compiler/index.js";
+import {
+  resolveStaleRefresh,
+  type RefreshPlan,
+  type RefreshStateStatus,
+} from "../compiler/refresh-plan.js";
+import * as output from "../utils/output.js";
+
+interface RefreshCommandOptions {
+  stale?: boolean;
+  dryRun?: boolean;
+}
+
+/** Pairs of [items, label, icon] for plan detail lines — data-driven to keep cyclomatic low. */
+type PlanDetailRow = [items: string[], label: string, icon: string];
+
+/**
+ * Run the refresh command. Resolves the stale-refresh plan and either prints
+ * it (--dry-run) or delegates a scoped recompile to the compile pipeline.
+ * @param options - CLI options forwarded by Commander.
+ * @param ensureProvider - Optional provider guard, invoked only on the live
+ *   recompile path (never for dry-run or any early-exit path) so dry-run works
+ *   with no API key configured.
+ * @returns Exit code: 0 for success, 1 for usage/corrupt-state errors.
+ */
+export default async function refreshCommand(
+  options: RefreshCommandOptions = {},
+  ensureProvider?: () => void,
+): Promise<number> {
+  if (!options.stale) {
+    output.status("!", output.warn("Usage: llmwiki refresh --stale [--dry-run]"));
+    return 1;
+  }
+  const root = process.cwd();
+  const { stateStatus, plan } = await resolveStaleRefresh(root);
+  const stateExit = checkStateStatus(stateStatus);
+  if (stateExit !== null) return stateExit;
+  // The "ok" branch always carries a plan; this guard narrows the type
+  // (and is defensive) so the live path below needs no non-null assertions.
+  if (!plan) return 1;
+  return runRefresh(root, plan, options, ensureProvider);
+}
+
+/**
+ * Execute the scoped recompile after all pre-work guards have passed. Returns
+ * early when nothing is stale. The provider guard fires only here on the live
+ * path — never for dry-run — so `refresh --stale --dry-run` succeeds with no
+ * API key configured.
+ */
+async function runRefresh(
+  root: string,
+  plan: RefreshPlan,
+  options: RefreshCommandOptions,
+  ensureProvider?: () => void,
+): Promise<number> {
+  if (!hasWork(plan)) {
+    output.status("✓", output.success("Wiki is up to date — nothing to refresh."));
+    return 0;
+  }
+  printPlan(plan);
+  if (options.dryRun) {
+    output.status("i", output.dim("Dry run — no files changed, no LLM calls made."));
+    return 0;
+  }
+  ensureProvider?.();
+  await compileAndReport(root, { changeFilter: plan.changeFilter, skipSeedPages: true });
+  reportNewSkipped(plan.newSkipped);
+  return 0;
+}
+
+/**
+ * Return 1 for corrupt state, 0 for missing state, null to proceed.
+ * Kept separate so refreshCommand's cyclomatic stays below threshold.
+ */
+function checkStateStatus(stateStatus: RefreshStateStatus): number | null {
+  if (stateStatus === "corrupt") {
+    output.status("✗", output.error(".llmwiki/state.json is unreadable — run `llmwiki compile` to rebuild it."));
+    return 1;
+  }
+  if (stateStatus === "missing") {
+    output.status("i", output.dim("No compiled wiki yet — run `llmwiki compile`."));
+    return 0;
+  }
+  return null;
+}
+
+/** Emit the "new sources skipped" hint when the plan identified any. */
+function reportNewSkipped(newSkipped: string[]): void {
+  if (newSkipped.length === 0) return;
+  output.status("i", output.dim(
+    `${newSkipped.length} new source(s) skipped — run \`llmwiki compile\` to include new content.`,
+  ));
+}
+
+/** Print the plan summary line and all non-empty category detail lines. */
+function printPlan(plan: RefreshPlan): void {
+  const modelSources = plan.changedOwners.length + plan.knownAffected.length;
+  output.status("~", output.info(
+    `Recompiling ${plan.recompiledPages.length} page(s) from ${modelSources} source(s) ` +
+    `(${plan.changedOwners.length} changed + ${plan.knownAffected.length} known affected; more may be found during the run); ` +
+    `${plan.sharedKeptPages.length} kept (shared, content not rebuilt); ` +
+    `cleaning up ${plan.computedOrphanedPages.length} orphaned page(s).`,
+  ));
+  for (const [items, label, icon] of planDetailRows(plan)) {
+    if (items.length > 0) output.status(icon, output.dim(`${label}: ${items.join(", ")}`));
+  }
+}
+
+/**
+ * True when the plan has any actionable work: pages to recompile, orphaned
+ * pages to clean up, OR shared (partial-deletion) pages whose state needs
+ * repairing (the deleted owner removed from state, content kept).
+ */
+function hasWork(plan: RefreshPlan): boolean {
+  return (
+    plan.recompiledPages.length > 0 ||
+    plan.sharedKeptPages.length > 0 ||
+    plan.computedOrphanedPages.length > 0
+  );
+}
+
+/** Data-driven detail rows for the plan: [items, label, icon]. Keeps printPlan cyclomatic low. */
+function planDetailRows(plan: RefreshPlan): PlanDetailRow[] {
+  return [
+    [plan.recompiledPages, "recompiled", "~"],
+    [plan.sharedKeptPages, "kept (shared) — content not regenerated", "i"],
+    [plan.computedOrphanedPages, "cleaned up (orphaned)", "⚠"],
+    [plan.alreadyOrphanedPages, "already orphaned — no action", "i"],
+    [plan.knownAffected, "known affected sources (more may be found during the run)", "~"],
+    [plan.newSkipped, "new sources skipped", "i"],
+  ];
+}

--- a/src/commands/refresh.ts
+++ b/src/commands/refresh.ts
@@ -69,10 +69,22 @@ async function runRefresh(
     output.status("i", output.dim("Dry run — no files changed, no LLM calls made."));
     return 0;
   }
-  ensureProvider?.();
+  maybeEnsureProvider(plan, ensureProvider);
   await compileAndReport(root, { changeFilter: plan.changeFilter, skipSeedPages: true });
   reportNewSkipped(plan.newSkipped);
   return 0;
+}
+
+/**
+ * Invoke the provider guard only when the plan will trigger an LLM extraction.
+ * Concept extraction runs solely for changed owners and their known-affected
+ * co-contributors; with no changed owners, knownAffected is empty too
+ * (findAffectedSources expands only from changed/new sources), so cleanup-only
+ * plans (orphan/shared state repair) skip the guard and need no key.
+ */
+function maybeEnsureProvider(plan: RefreshPlan, ensureProvider?: () => void): void {
+  const needsLLM = plan.changedOwners.length > 0 || plan.knownAffected.length > 0;
+  if (needsLLM) ensureProvider?.();
 }
 
 /**

--- a/src/commands/refresh.ts
+++ b/src/commands/refresh.ts
@@ -6,12 +6,14 @@
  */
 
 import { compileAndReport } from "../compiler/index.js";
+import { countCandidates } from "../compiler/candidates.js";
 import {
   resolveStaleRefresh,
   type RefreshPlan,
   type RefreshStateStatus,
 } from "../compiler/refresh-plan.js";
 import * as output from "../utils/output.js";
+import type { CompileResult } from "../utils/types.js";
 
 interface RefreshCommandOptions {
   stale?: boolean;
@@ -69,8 +71,40 @@ async function runRefresh(
     output.status("i", output.dim("Dry run — no files changed, no LLM calls made."));
     return 0;
   }
+  await warnOnReviewBypass(root);
   maybeEnsureProvider(plan, ensureProvider);
-  await compileAndReport(root, { changeFilter: plan.changeFilter, skipSeedPages: true });
+  const result = await compileAndReport(root, { changeFilter: plan.changeFilter, skipSeedPages: true });
+  return reportCompileOutcome(result, plan);
+}
+
+/**
+ * Warn that refresh writes directly to wiki/ (bypassing the review workflow)
+ * when pending candidates exist, so a review-workflow user isn't surprised by
+ * un-reviewed direct writes. Advisory only — never blocks the recompile.
+ */
+async function warnOnReviewBypass(root: string): Promise<void> {
+  const pending = await countCandidates(root);
+  if (pending > 0) {
+    output.status("!", output.warn(
+      `refresh --stale writes directly to wiki/ and does not create review candidates (${pending} pending candidate(s) exist).`,
+    ));
+  }
+}
+
+/**
+ * Surface the compile result: print any pipeline errors and exit 1 on failure
+ * (lock contention, extraction/validation errors), or a one-line success
+ * summary and exit 0. Without this, refresh swallowed errors and always exited 0.
+ */
+function reportCompileOutcome(result: CompileResult, plan: RefreshPlan): number {
+  if (result.errors.length > 0) {
+    for (const e of result.errors) output.status("✗", output.error(e));
+    reportNewSkipped(plan.newSkipped);
+    return 1;
+  }
+  output.status("✓", output.success(
+    `Refreshed ${plan.recompiledPages.length} page(s); cleaned up ${plan.computedOrphanedPages.length} orphaned page(s).`,
+  ));
   reportNewSkipped(plan.newSkipped);
   return 0;
 }

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -291,6 +291,34 @@ function summarizeCompile(
   return baseResult;
 }
 
+/**
+ * Apply `options.changeFilter` to the full detected change set.
+ * When no filter is provided, returns the original list unchanged.
+ * Separating this keeps `runCompilePipeline` below the cyclomatic threshold.
+ */
+function applyChangeFilter(
+  detected: SourceChange[],
+  filter: CompileOptions["changeFilter"],
+): SourceChange[] {
+  return filter ? detected.filter(filter) : detected;
+}
+
+/**
+ * Generate seed pages unless `skipSeedPages` is set or we are in review mode.
+ * Centralises both guard conditions so each call site in the pipeline is a
+ * single unconditional statement instead of an inline if-block.
+ */
+async function maybeSeedPages(
+  root: string,
+  schema: SchemaConfig,
+  generation: PageGenerationResult,
+  options: CompileOptions,
+): Promise<void> {
+  if (!options.review && !options.skipSeedPages) {
+    await generateSeedPages(root, schema, generation);
+  }
+}
+
 /** Inner pipeline, runs under lock protection. Returns structured CompileResult. */
 async function runCompilePipeline(
   root: string,
@@ -299,7 +327,8 @@ async function runCompilePipeline(
   const schema = await loadSchema(root);
   reportSchemaStatus(schema);
   const state = await readState(root);
-  const changes = await detectChanges(root, state);
+  const detected = await detectChanges(root, state);
+  const changes = applyChangeFilter(detected, options.changeFilter);
   augmentWithAffectedSources(changes, findAffectedSources(state, changes));
 
   const buckets = bucketChanges(changes);
@@ -315,7 +344,7 @@ async function runCompilePipeline(
         candidates: [],
         seedSlugs: [],
       };
-      await generateSeedPages(root, schema, emptyGeneration);
+      await maybeSeedPages(root, schema, emptyGeneration, options);
       // Rebuild index/MOC so the newly-written seed pages become discoverable,
       // and propagate any seed-page validation errors into the returned result.
       await finalizeWiki(root, emptyGeneration.pages, emptyGeneration.seedSlugs);
@@ -365,7 +394,7 @@ async function runCompilePipeline(
     await persistFrozenSlugs(root, frozenSlugs, extractions);
     // Seed pages write directly into wiki/, so skip them in review mode
     // to honour the "no wiki/ mutation" contract of that mode.
-    await generateSeedPages(root, schema, generation);
+    await maybeSeedPages(root, schema, generation, options);
     await finalizeWiki(root, generation.pages, generation.seedSlugs);
     await logCompile(root, buckets, generation, existingIds);
   }

--- a/src/compiler/refresh-plan.ts
+++ b/src/compiler/refresh-plan.ts
@@ -1,0 +1,206 @@
+/**
+ * Resolver for `llmwiki refresh --stale`. Computes a RefreshPlan from a single
+ * read-only freshness snapshot — page-level ownership drives the action sets, so
+ * status is repaired without re-implementing any compile logic. Read-only and
+ * LLM-free (it reads + hashes sources, but never writes); never calls
+ * detectChanges (avoids the double-hash regression) and never uses readState
+ * (which writes .bak on corrupt state).
+ */
+
+import { readdir } from "fs/promises";
+import path from "path";
+import { readStateClassified } from "../utils/state.js";
+import { buildFreshnessSnapshot } from "../freshness/index.js";
+import { findAffectedSources } from "./deps.js";
+import { scanWikiPages } from "./indexgen.js";
+import { CONCEPTS_DIR, SOURCES_DIR } from "../utils/constants.js";
+import type { SourceChange, WikiState } from "../utils/types.js";
+import type { FreshnessSnapshot } from "../freshness/types.js";
+
+export interface RefreshPlan {
+  /** Stale pages with a changed live owner — recompiled. Disjoint from the other outcome lists. */
+  recompiledPages: string[];
+  /** Partial-deletion pages (a deleted owner but every live owner is unchanged) — status repaired, content kept. Disjoint. */
+  sharedKeptPages: string[];
+  /** Pages whose owners are ALL deleted — recomputed as orphaned. Disjoint. */
+  computedOrphanedPages: string[];
+  /** Frontmatter-orphaned pages with no tracked owner — already orphaned, no action. Disjoint. */
+  alreadyOrphanedPages: string[];
+  /** Live owner files whose hash drifted — the changed sources to recompile. */
+  changedOwners: string[];
+  /** Owner files no longer on disk — the deleted sources to process. */
+  deletedOwners: string[];
+  /**
+   * Unchanged co-contributors pulled in because they share a concept with a
+   * selected owner (from current state, NOT the owners themselves). The real
+   * compile run may surface more affected sources post-extraction.
+   */
+  knownAffected: string[];
+  /** Sources on disk but not in state (new) — skipped by refresh; distinct from the outcome lists. */
+  newSkipped: string[];
+  /** Keep a detected change only if its file is a selected owner (changed or deleted). */
+  changeFilter: (change: SourceChange) => boolean;
+}
+
+export interface RefreshResolution {
+  stateStatus: "ok" | "missing" | "corrupt";
+  /** null unless stateStatus === "ok" */
+  plan: RefreshPlan | null;
+}
+
+interface Owner {
+  file: string;
+  exists: boolean;
+  changed: boolean;
+}
+
+/** Owners of a slug derived directly from the snapshot's per-source concept lists. */
+function ownersOf(slug: string, snapshot: FreshnessSnapshot): Owner[] {
+  return Object.entries(snapshot.sources)
+    .filter(([, s]) => s.concepts.includes(slug))
+    .map(([file, s]) => ({
+      file,
+      exists: s.exists,
+      changed: s.exists && s.currentHash !== s.recordedHash,
+    }));
+}
+
+interface PageClassification {
+  recompiledPages: string[];
+  sharedKeptPages: string[];
+  computedOrphanedPages: string[];
+  alreadyOrphanedPages: string[];
+  changedOwners: Set<string>;
+  deletedOwners: Set<string>;
+}
+
+/** Sort each page into exactly one outcome list and collect its actionable owners. */
+function classifyPages(
+  pages: { slug: string; meta: Record<string, unknown> }[],
+  snapshot: FreshnessSnapshot,
+): PageClassification {
+  const c: PageClassification = {
+    recompiledPages: [],
+    sharedKeptPages: [],
+    computedOrphanedPages: [],
+    alreadyOrphanedPages: [],
+    changedOwners: new Set(),
+    deletedOwners: new Set(),
+  };
+  for (const { slug, meta } of pages) {
+    classifyOnePage(slug, meta, snapshot, c);
+  }
+  return c;
+}
+
+/** Classify a single page into the classification object (mutates c). */
+function classifyOnePage(
+  slug: string,
+  meta: Record<string, unknown>,
+  snapshot: FreshnessSnapshot,
+  c: PageClassification,
+): void {
+  const owners = ownersOf(slug, snapshot);
+  if (owners.length === 0) {
+    if (meta.orphaned === true) c.alreadyOrphanedPages.push(slug);
+    // else: page not tracked in state (e.g. hand-written) — not refresh's concern.
+    return;
+  }
+  const deleted = owners.filter((o) => !o.exists);
+  const live = owners.filter((o) => o.exists);
+  const changedLive = live.filter((o) => o.changed);
+
+  if (live.length === 0) {
+    c.computedOrphanedPages.push(slug);
+    deleted.forEach((o) => c.deletedOwners.add(o.file));
+  } else if (changedLive.length > 0) {
+    c.recompiledPages.push(slug);
+    changedLive.forEach((o) => c.changedOwners.add(o.file));
+    deleted.forEach((o) => c.deletedOwners.add(o.file));
+  } else if (deleted.length > 0) {
+    c.sharedKeptPages.push(slug);
+    deleted.forEach((o) => c.deletedOwners.add(o.file));
+  }
+  // else: all live and fresh — no action needed
+}
+
+/** Deterministic output: every plan array is sorted so dry-run/CLI output is stable. */
+const sorted = (xs: Iterable<string>): string[] => [...xs].sort();
+
+/**
+ * Resolve the stale-refresh plan from a read-only freshness snapshot.
+ * Returns stateStatus and a RefreshPlan (null when state is missing or corrupt).
+ * @param root - Absolute path to the llmwiki project root.
+ */
+export async function resolveStaleRefresh(root: string): Promise<RefreshResolution> {
+  const classified = await readStateClassified(root);
+  if (classified.status !== "ok") {
+    return { stateStatus: classified.status, plan: null };
+  }
+
+  const snapshot = await buildFreshnessSnapshot(root, classified);
+  const state = classified.state;
+  const pages = await scanWikiPages(path.join(root, CONCEPTS_DIR));
+  const c = classifyPages(pages, snapshot);
+
+  return {
+    stateStatus: "ok",
+    plan: {
+      recompiledPages: sorted(c.recompiledPages),
+      sharedKeptPages: sorted(c.sharedKeptPages),
+      computedOrphanedPages: sorted(c.computedOrphanedPages),
+      alreadyOrphanedPages: sorted(c.alreadyOrphanedPages),
+      changedOwners: sorted(c.changedOwners),
+      deletedOwners: sorted(c.deletedOwners),
+      knownAffected: sorted(knownAffectedFor(state, c.changedOwners, c.deletedOwners)),
+      newSkipped: sorted(await listNewSkipped(root, state)),
+      changeFilter: makeChangeFilter(c.changedOwners, c.deletedOwners),
+    },
+  };
+}
+
+/**
+ * Affected co-contributors for the same seed the real compile run will use
+ * (changed owners as "changed", deleted owners as "deleted").
+ * Mirrors the seed construction in the actual refresh command so knownAffected
+ * stays in sync with what the compiler would process.
+ */
+function knownAffectedFor(
+  state: WikiState,
+  changed: Set<string>,
+  deleted: Set<string>,
+): string[] {
+  const seed: SourceChange[] = [
+    ...[...changed].map((file) => ({ file, status: "changed" as const })),
+    ...[...deleted].map((file) => ({ file, status: "deleted" as const })),
+  ];
+  return findAffectedSources(state, seed);
+}
+
+/**
+ * Source files present on disk that are not tracked in state (new sources).
+ * These are skipped by refresh — the full compile run handles new sources.
+ * No hashing performed; presence on disk is sufficient.
+ */
+async function listNewSkipped(root: string, state: WikiState): Promise<string[]> {
+  let files: string[];
+  try {
+    files = (await readdir(path.join(root, SOURCES_DIR))).filter((f) => f.endsWith(".md"));
+  } catch {
+    return [];
+  }
+  return files.filter((f) => !(f in state.sources));
+}
+
+/**
+ * Build a filter that keeps only SourceChanges whose file is a selected owner
+ * (changed or deleted). Used to narrow the full detected-changes list to just
+ * the stale owners so the refresh command skips unchanged and new sources.
+ */
+function makeChangeFilter(
+  changed: Set<string>,
+  deleted: Set<string>,
+): (c: SourceChange) => boolean {
+  const ownerSet = new Set<string>([...changed, ...deleted]);
+  return (c) => ownerSet.has(c.file);
+}

--- a/src/compiler/refresh-plan.ts
+++ b/src/compiler/refresh-plan.ts
@@ -42,8 +42,11 @@ export interface RefreshPlan {
   changeFilter: (change: SourceChange) => boolean;
 }
 
+/** Classified outcome of reading .llmwiki/state.json for a refresh run. */
+export type RefreshStateStatus = "ok" | "missing" | "corrupt";
+
 export interface RefreshResolution {
-  stateStatus: "ok" | "missing" | "corrupt";
+  stateStatus: RefreshStateStatus;
   /** null unless stateStatus === "ok" */
   plan: RefreshPlan | null;
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -126,6 +126,21 @@ export interface CompileOptions {
    * of mutating wiki/. Reviewers approve/reject via `llmwiki review`.
    */
   review?: boolean;
+  /**
+   * Narrows a compile run to a subset of detected source changes. Applied to the
+   * FULL change set from `detectChanges` (new | changed | deleted) immediately
+   * after detection and BEFORE affected-source expansion. A change is processed
+   * only if the predicate returns true; the deleted entries it keeps still go
+   * through deletion/orphan bookkeeping. Omitted ⇒ all detected changes are
+   * processed (normal compile). Used by `refresh --stale` to scope a run.
+   */
+  changeFilter?: (change: SourceChange) => boolean;
+  /**
+   * Skip schema seed-page generation (but still run index/MOC/link/embedding
+   * finalization). Used by `refresh --stale` so a stale-repair run does not
+   * write seed pages unrelated to the repair.
+   */
+  skipSeedPages?: boolean;
 }
 
 /**

--- a/test/refresh-cli.test.ts
+++ b/test/refresh-cli.test.ts
@@ -13,7 +13,7 @@
 
 import { describe, it, expect } from "vitest";
 import { existsSync } from "fs";
-import { readFile } from "fs/promises";
+import { mkdir, readFile, writeFile } from "fs/promises";
 import path from "path";
 import { runCLI, expectCLIExit } from "./fixtures/run-cli.js";
 import { makeTempRoot } from "./fixtures/temp-root.js";
@@ -97,13 +97,37 @@ describe("llmwiki refresh --stale --dry-run", () => {
   });
 });
 
+/**
+ * Set up a cleanup-only stale project: a page whose sole owning source is in
+ * state but deleted from disk → computedOrphaned, no recompile, no LLM.
+ */
+async function setupCleanupOnlyStale(label: string): Promise<string> {
+  const root = await makeTempRoot(label);
+  await writeConceptPage(root, "topic");
+  await writeSourceState(root, { "a.md": { hash: sha256Hex("gone"), concepts: ["topic"] } });
+  return root;
+}
+
+/** Hold the compile lock by writing a live PID, so the subprocess can't acquire it. */
+async function holdLock(root: string, pid: number): Promise<void> {
+  await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+  await writeFile(path.join(root, ".llmwiki/lock"), String(pid), "utf-8");
+}
+
+/** Write a minimal valid pending review candidate so countCandidates() sees one. */
+async function writePendingCandidate(root: string): Promise<void> {
+  const dir = path.join(root, ".llmwiki/candidates");
+  await mkdir(dir, { recursive: true });
+  const candidate = {
+    id: "cand1", title: "Topic", slug: "topic", body: "Body.",
+    sources: ["a.md"], generatedAt: "2026-01-01T00:00:00.000Z",
+  };
+  await writeFile(path.join(dir, "cand1.json"), JSON.stringify(candidate), "utf-8");
+}
+
 describe("llmwiki refresh --stale (live, cleanup-only)", () => {
   it("cleans up a deleted-owner page with no provider key and makes no LLM calls", async () => {
-    const root = await makeTempRoot("refresh-cleanup");
-    await writeConceptPage(root, "topic");
-    // a.md is recorded in state but absent on disk → its exclusively-owned page
-    // is orphaned cleanup only, never a recompile, so the LLM is never invoked.
-    await writeSourceState(root, { "a.md": { hash: sha256Hex("gone"), concepts: ["topic"] } });
+    const root = await setupCleanupOnlyStale("refresh-cleanup");
 
     const result = await runCLI(["refresh", "--stale"], root, NO_KEY_ENV);
 
@@ -115,5 +139,27 @@ describe("llmwiki refresh --stale (live, cleanup-only)", () => {
     expect(state.sources["a.md"]).toBeUndefined();
     const page = await readFile(path.join(root, "wiki/concepts/topic.md"), "utf-8");
     expect(page).toMatch(/^orphaned:\s*true/m);
+  });
+
+  it("exits non-zero and surfaces the error when the compile lock is held", async () => {
+    const root = await setupCleanupOnlyStale("refresh-locked");
+    // The test process is alive for the whole run, so its PID reads as a live
+    // lock holder in the subprocess → acquireLock returns false → compile error.
+    await holdLock(root, process.pid);
+
+    const result = await runCLI(["refresh", "--stale"], root, NO_KEY_ENV);
+
+    expectCLIExit(result, 1);
+    expect(result.stdout + result.stderr).toMatch(/could not acquire .*lock/i);
+  });
+
+  it("warns that refresh bypasses review when pending candidates exist", async () => {
+    const root = await setupCleanupOnlyStale("refresh-bypass");
+    await writePendingCandidate(root);
+
+    const result = await runCLI(["refresh", "--stale"], root, NO_KEY_ENV);
+
+    expectCLIExit(result, 0);
+    expect(result.stdout + result.stderr).toMatch(/writes directly to wiki\/.*does not create review candidates/i);
   });
 });

--- a/test/refresh-cli.test.ts
+++ b/test/refresh-cli.test.ts
@@ -96,3 +96,24 @@ describe("llmwiki refresh --stale --dry-run", () => {
     expect(result.stdout + result.stderr).toMatch(/usage: llmwiki refresh --stale/i);
   });
 });
+
+describe("llmwiki refresh --stale (live, cleanup-only)", () => {
+  it("cleans up a deleted-owner page with no provider key and makes no LLM calls", async () => {
+    const root = await makeTempRoot("refresh-cleanup");
+    await writeConceptPage(root, "topic");
+    // a.md is recorded in state but absent on disk → its exclusively-owned page
+    // is orphaned cleanup only, never a recompile, so the LLM is never invoked.
+    await writeSourceState(root, { "a.md": { hash: sha256Hex("gone"), concepts: ["topic"] } });
+
+    const result = await runCLI(["refresh", "--stale"], root, NO_KEY_ENV);
+
+    expectCLIExit(result, 0);
+    const combined = result.stdout + result.stderr;
+    expect(combined).not.toMatch(/anthropic|credentials|API[_ ]?KEY/i);
+    expect(combined).toMatch(/cleaned up \(orphaned\):.*topic/);
+    const state = JSON.parse(await readFile(path.join(root, ".llmwiki/state.json"), "utf-8"));
+    expect(state.sources["a.md"]).toBeUndefined();
+    const page = await readFile(path.join(root, "wiki/concepts/topic.md"), "utf-8");
+    expect(page).toMatch(/^orphaned:\s*true/m);
+  });
+});

--- a/test/refresh-cli.test.ts
+++ b/test/refresh-cli.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Subprocess tests for `llmwiki refresh --stale [--dry-run]`.
+ *
+ * Covers dry-run/no-work/error paths that must work with NO provider key and
+ * make NO LLM calls. Each test asserts exit code, output strings, and — for
+ * the dry-run case — a zero-writes contract (state.json + page content
+ * unchanged, no .bak file created).
+ *
+ * Tests run against `dist/cli.js` with the Anthropic key/token stripped from the
+ * environment, proving these dry-run / early-exit paths never invoke the
+ * provider guard.
+ */
+
+import { describe, it, expect } from "vitest";
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
+import path from "path";
+import { runCLI, expectCLIExit } from "./fixtures/run-cli.js";
+import { makeTempRoot } from "./fixtures/temp-root.js";
+import {
+  writeSourceFile,
+  writeSourceState,
+  sha256Hex,
+  writeCorruptTestStateJson,
+} from "./fixtures/state-json.js";
+import { writePage } from "./fixtures/write-page.js";
+
+/** Env with Anthropic credentials stripped — proves these paths never hit the provider guard. */
+const NO_KEY_ENV = { ANTHROPIC_API_KEY: undefined, ANTHROPIC_AUTH_TOKEN: undefined };
+
+/** Write a concept page with the minimal frontmatter the compiler expects. */
+async function writeConceptPage(root: string, slug: string): Promise<void> {
+  await writePage(
+    path.join(root, "wiki/concepts"),
+    slug,
+    { title: "Topic", sources: ["a.md"], summary: "s", createdAt: "t" },
+    "Body.",
+  );
+}
+
+describe("llmwiki refresh --stale --dry-run", () => {
+  it("previews the plan, makes no LLM calls, and writes nothing", async () => {
+    const root = await makeTempRoot("refresh-dry");
+    await writeConceptPage(root, "topic");
+    await writeSourceFile(root, "a.md", "NEW body");
+    await writeSourceFile(root, "new.md", "brand new");
+    await writeSourceState(root, { "a.md": { hash: sha256Hex("OLD body"), concepts: ["topic"] } });
+
+    const statePath = path.join(root, ".llmwiki/state.json");
+    const pagePath = path.join(root, "wiki/concepts/topic.md");
+    const stateBefore = await readFile(statePath, "utf-8");
+    const pageBefore = await readFile(pagePath, "utf-8");
+
+    const result = await runCLI(["refresh", "--stale", "--dry-run"], root, NO_KEY_ENV);
+
+    expectCLIExit(result, 0);
+    const combined = result.stdout + result.stderr;
+    expect(combined).toMatch(/recompiled:\s+topic\b/);
+    expect(combined).toMatch(/new sources skipped:.*new\.md/);
+    expect(combined).toMatch(/no files changed, no LLM calls made/i);
+    expect(await readFile(statePath, "utf-8")).toBe(stateBefore);
+    expect(await readFile(pagePath, "utf-8")).toBe(pageBefore);
+    expect(existsSync(path.join(root, ".llmwiki/state.json.bak"))).toBe(false);
+  });
+
+  it("nothing-stale exits 0 with the up-to-date message", async () => {
+    const root = await makeTempRoot("refresh-clean");
+    await writeConceptPage(root, "topic");
+    await writeSourceFile(root, "a.md", "SAME");
+    await writeSourceState(root, { "a.md": { hash: sha256Hex("SAME"), concepts: ["topic"] } });
+
+    const result = await runCLI(["refresh", "--stale", "--dry-run"], root, NO_KEY_ENV);
+
+    expectCLIExit(result, 0);
+    expect(result.stdout + result.stderr).toMatch(/up to date — nothing to refresh/i);
+  });
+
+  it("corrupt state.json exits 1 with the unreadable message and writes no .bak", async () => {
+    const root = await makeTempRoot("refresh-corrupt");
+    await writeConceptPage(root, "topic");
+    await writeCorruptTestStateJson(root);
+
+    const result = await runCLI(["refresh", "--stale", "--dry-run"], root, NO_KEY_ENV);
+
+    expectCLIExit(result, 1);
+    expect(result.stdout + result.stderr).toMatch(/state\.json is unreadable/i);
+    expect(existsSync(path.join(root, ".llmwiki/state.json.bak"))).toBe(false);
+  });
+
+  it("missing --stale prints usage and exits 1", async () => {
+    const root = await makeTempRoot("refresh-nostale");
+
+    const result = await runCLI(["refresh"], root, NO_KEY_ENV);
+
+    expectCLIExit(result, 1);
+    expect(result.stdout + result.stderr).toMatch(/usage: llmwiki refresh --stale/i);
+  });
+});

--- a/test/refresh-integration.test.ts
+++ b/test/refresh-integration.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Real-run integration tests for `llmwiki refresh --stale`.
+ *
+ * Exercises the full in-process recompile path via `resolveStaleRefresh` +
+ * `compileAndReport` with a stubbed AnthropicProvider (same convention as
+ * compile-delta.test.ts). Proves three guarantees of the v1 implementation:
+ *
+ *  1. A stale page (changed source hash) IS recompiled.
+ *  2. A new source (not in state) is skipped — refresh does not compile new sources.
+ *  3. A partial-deletion "shared" page has its state REPAIRED (deleted owner
+ *     removed from state.sources) but its content byte-for-byte UNCHANGED — the
+ *     unchanged live owner is NOT recompiled (v1 limitation: no force-rebuild).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { writeFile, mkdir, readFile, rm } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import os from "os";
+import { compileAndReport } from "../src/compiler/index.js";
+import { resolveStaleRefresh } from "../src/compiler/refresh-plan.js";
+import { AnthropicProvider } from "../src/providers/anthropic.js";
+import { readStateClassified } from "../src/utils/state.js";
+import { CONCEPTS_DIR } from "../src/utils/constants.js";
+import { writeSourceState, writeSourceFile, sha256Hex } from "./fixtures/state-json.js";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal extraction JSON for one concept. */
+function extractionFor(title: string): string {
+  return JSON.stringify({
+    concepts: [{ concept: title, summary: `Summary of ${title}.`, is_new: true }],
+  });
+}
+
+const STUB_BODY = "Stub body content. ^[a.md]";
+
+/** Build a fresh temp project root with sources/ wiki/concepts/ .llmwiki/ dirs. */
+async function makeTmpRoot(suffix: string): Promise<string> {
+  const root = path.join(os.tmpdir(), `llmwiki-refresh-integ-${suffix}-${Date.now()}`);
+  await mkdir(path.join(root, "sources"), { recursive: true });
+  await mkdir(path.join(root, "wiki", "concepts"), { recursive: true });
+  await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+  return root;
+}
+
+/** Silence compile output and run resolveStaleRefresh + compileAndReport. */
+async function runRefresh(root: string) {
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  const { plan } = await resolveStaleRefresh(root);
+  expect(plan).not.toBeNull();
+  return compileAndReport(root, { changeFilter: plan!.changeFilter, skipSeedPages: true });
+}
+
+/** Write a minimal valid wiki page for a concept slug. */
+async function writeConceptPage(root: string, slug: string, title: string, sources: string[], body: string): Promise<void> {
+  const frontmatter = [
+    "---",
+    `title: ${title}`,
+    `summary: ${title} summary.`,
+    `sources: [${sources.join(", ")}]`,
+    "createdAt: 2024-01-01T00:00:00.000Z",
+    "updatedAt: 2024-01-01T00:00:00.000Z",
+    "---",
+    "",
+    body,
+  ].join("\n");
+  await writeFile(path.join(root, CONCEPTS_DIR, `${slug}.md`), frontmatter, "utf-8");
+}
+
+/** Stub extraction and page-body calls on AnthropicProvider. Returns the extraction spy. */
+function stubProviderCalls(extractionTitle: string) {
+  const spy = vi.spyOn(AnthropicProvider.prototype, "toolCall")
+    .mockResolvedValue(extractionFor(extractionTitle));
+  vi.spyOn(AnthropicProvider.prototype, "complete").mockResolvedValue(STUB_BODY);
+  return spy;
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: recompile a stale page, leave a new source uncompiled
+// ---------------------------------------------------------------------------
+
+describe("refresh --stale (real run, stubbed provider)", () => {
+  it("recompiles a stale page and leaves a new source uncompiled", async () => {
+    process.env.LLMWIKI_PROVIDER = "anthropic";
+    process.env.ANTHROPIC_API_KEY = "test-key";
+    const root = await makeTmpRoot("stale");
+
+    try {
+      const aContent = "# Topic A\n\nAbout A.";
+      await writeSourceFile(root, "a.md", aContent);
+      await writeSourceState(root, {
+        "a.md": { hash: "stale-hash-not-matching-disk", concepts: ["topic-a"] },
+      });
+      // Wiki page must exist on disk for resolveStaleRefresh to classify it as stale.
+      await writeConceptPage(root, "topic-a", "Topic A", ["a.md"], "Old body.");
+      // new.md on disk but NOT in state — refresh must skip it.
+      await writeSourceFile(root, "new.md", "# New Topic\n\nBrand new.");
+
+      const extractSpy = stubProviderCalls("Topic A");
+      const result = await runRefresh(root);
+
+      expect(result.pages).toContain("topic-a");
+      const { state } = await readStateClassified(root);
+      expect(state.sources["a.md"]?.hash).toBe(sha256Hex(aContent));
+      expect("new.md" in state.sources).toBe(false);
+      expect(result.pages).not.toContain("new-topic");
+      // Only a.md was extracted; new.md was filtered out by changeFilter.
+      expect(extractSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.restoreAllMocks();
+      delete process.env.LLMWIKI_PROVIDER;
+      delete process.env.ANTHROPIC_API_KEY;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 2: partial-deletion shared page — status repaired, content kept
+  // -------------------------------------------------------------------------
+
+  it("status-repairs a partial-deletion shared page but does NOT regenerate its content (v1)", async () => {
+    process.env.LLMWIKI_PROVIDER = "anthropic";
+    process.env.ANTHROPIC_API_KEY = "test-key";
+    const root = await makeTmpRoot("shared-kept");
+
+    try {
+      const aContent = "# Topic X\n\nAbout X from A.";
+      await writeSourceFile(root, "a.md", aContent);
+      // b.md intentionally absent from disk — it's the deleted owner.
+      await writeSourceState(root, {
+        "a.md": { hash: sha256Hex(aContent), concepts: ["topic-x"] },
+        "b.md": { hash: "some-old-hash", concepts: ["topic-x"] },
+      });
+      await writeConceptPage(root, "topic-x", "Topic X", ["a.md", "b.md"], "Existing body of X.");
+      const ORIGINAL_CONTENT = await readFile(path.join(root, CONCEPTS_DIR, "topic-x.md"), "utf-8");
+
+      // Spy: extraction must NOT fire (a.md is unchanged; no changed owners).
+      const extractSpy = stubProviderCalls("Topic X");
+      vi.spyOn(console, "log").mockImplementation(() => {});
+
+      const { plan } = await resolveStaleRefresh(root);
+      expect(plan).not.toBeNull();
+      // Sanity: page is shared-kept, not recompiled.
+      expect(plan!.sharedKeptPages).toContain("topic-x");
+      expect(plan!.changedOwners).not.toContain("a.md");
+      expect(plan!.deletedOwners).toContain("b.md");
+
+      await compileAndReport(root, { changeFilter: plan!.changeFilter, skipSeedPages: true });
+
+      // Deletion bookkeeping: b.md removed from state.
+      const { state } = await readStateClassified(root);
+      expect("b.md" in state.sources).toBe(false);
+      // Content kept: topic-x.md byte-for-byte UNCHANGED.
+      const afterContent = await readFile(path.join(root, CONCEPTS_DIR, "topic-x.md"), "utf-8");
+      expect(afterContent).toBe(ORIGINAL_CONTENT);
+      // a.md NOT extracted — unchanged live owner skipped in v1.
+      expect(extractSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.restoreAllMocks();
+      delete process.env.LLMWIKI_PROVIDER;
+      delete process.env.ANTHROPIC_API_KEY;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/refresh-integration.test.ts
+++ b/test/refresh-integration.test.ts
@@ -13,15 +13,15 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { writeFile, mkdir, readFile, rm } from "fs/promises";
+import { writeFile, readFile, rm } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
-import os from "os";
 import { compileAndReport } from "../src/compiler/index.js";
 import { resolveStaleRefresh } from "../src/compiler/refresh-plan.js";
 import { AnthropicProvider } from "../src/providers/anthropic.js";
 import { readStateClassified } from "../src/utils/state.js";
 import { CONCEPTS_DIR } from "../src/utils/constants.js";
+import { makeCompileProjectRoot } from "./fixtures/compile-project.js";
 import { writeSourceState, writeSourceFile, sha256Hex } from "./fixtures/state-json.js";
 
 // ---------------------------------------------------------------------------
@@ -37,13 +37,14 @@ function extractionFor(title: string): string {
 
 const STUB_BODY = "Stub body content. ^[a.md]";
 
-/** Build a fresh temp project root with sources/ wiki/concepts/ .llmwiki/ dirs. */
+/**
+ * Build a fresh temp project root with sources/ wiki/concepts/ .llmwiki/ dirs.
+ * The shared fixture also seeds an unrelated `sample.md` into sources/ with no
+ * state entry — like new.md it has no owner page and is correctly filtered out
+ * of the refresh run, so each test's effective sources are its own files + sample.md.
+ */
 async function makeTmpRoot(suffix: string): Promise<string> {
-  const root = path.join(os.tmpdir(), `llmwiki-refresh-integ-${suffix}-${Date.now()}`);
-  await mkdir(path.join(root, "sources"), { recursive: true });
-  await mkdir(path.join(root, "wiki", "concepts"), { recursive: true });
-  await mkdir(path.join(root, ".llmwiki"), { recursive: true });
-  return root;
+  return makeCompileProjectRoot({ dirSuffix: `refresh-integ-${suffix}` });
 }
 
 /** Silence compile output and run resolveStaleRefresh + compileAndReport. */
@@ -107,6 +108,8 @@ describe("refresh --stale (real run, stubbed provider)", () => {
       expect(state.sources["a.md"]?.hash).toBe(sha256Hex(aContent));
       expect("new.md" in state.sources).toBe(false);
       expect(result.pages).not.toContain("new-topic");
+      // No page file for new.md landed on disk either (slug "new-topic" from "# New Topic").
+      expect(existsSync(path.join(root, CONCEPTS_DIR, "new-topic.md"))).toBe(false);
       // Only a.md was extracted; new.md was filtered out by changeFilter.
       expect(extractSpy).toHaveBeenCalledTimes(1);
     } finally {
@@ -135,7 +138,7 @@ describe("refresh --stale (real run, stubbed provider)", () => {
         "b.md": { hash: "some-old-hash", concepts: ["topic-x"] },
       });
       await writeConceptPage(root, "topic-x", "Topic X", ["a.md", "b.md"], "Existing body of X.");
-      const ORIGINAL_CONTENT = await readFile(path.join(root, CONCEPTS_DIR, "topic-x.md"), "utf-8");
+      const originalContent = await readFile(path.join(root, CONCEPTS_DIR, "topic-x.md"), "utf-8");
 
       // Spy: extraction must NOT fire (a.md is unchanged; no changed owners).
       const extractSpy = stubProviderCalls("Topic X");
@@ -155,7 +158,7 @@ describe("refresh --stale (real run, stubbed provider)", () => {
       expect("b.md" in state.sources).toBe(false);
       // Content kept: topic-x.md byte-for-byte UNCHANGED.
       const afterContent = await readFile(path.join(root, CONCEPTS_DIR, "topic-x.md"), "utf-8");
-      expect(afterContent).toBe(ORIGINAL_CONTENT);
+      expect(afterContent).toBe(originalContent);
       // a.md NOT extracted — unchanged live owner skipped in v1.
       expect(extractSpy).not.toHaveBeenCalled();
     } finally {

--- a/test/refresh-pipeline.test.ts
+++ b/test/refresh-pipeline.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for the `changeFilter` and `skipSeedPages` CompileOptions introduced
+ * for `refresh --stale`.
+ *
+ * (A) `changeFilter` — verifies the option scopes the compile run to a subset
+ *     of detected source changes AND that affected-source expansion still pulls
+ *     in co-contributors of shared concepts from the filtered set.
+ *
+ * (B) `skipSeedPages` — verifies that schema-declared seed pages are NOT
+ *     written to disk when the flag is set, while a control run without the
+ *     flag DOES write them.
+ *
+ * Strategy mirrors compile-provenance.test.ts: stub AnthropicProvider so
+ * extraction / page-generation calls are deterministic and no real API is hit.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { writeFile, mkdir } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import { compileAndReport } from "../src/compiler/index.js";
+import type { CompileOptions } from "../src/utils/types.js";
+import { AnthropicProvider } from "../src/providers/anthropic.js";
+import { useCompileProject } from "./fixtures/compile-project.js";
+import { writeSourceState, sha256Hex } from "./fixtures/state-json.js";
+import { CONCEPTS_DIR } from "../src/utils/constants.js";
+
+// ---------------------------------------------------------------------------
+// Shared stub helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal extraction JSON for a single concept with the given title. */
+function extractionFor(title: string): string {
+  return JSON.stringify({
+    concepts: [{ concept: title, summary: `Summary of ${title}.`, is_new: true }],
+  });
+}
+
+const STUB_BODY = "Body content. ^[a.md]";
+
+/**
+ * Stub AnthropicProvider so toolCall returns an extraction keyed on which
+ * source the system prompt mentions, and complete() returns a fixed body.
+ * Routes by sniffing the system-prompt string for each source's title.
+ */
+function stubProviderFor(titlesBySource: Record<string, string>): void {
+  vi.spyOn(AnthropicProvider.prototype, "toolCall").mockImplementation(
+    async (system: string) => {
+      for (const [, title] of Object.entries(titlesBySource)) {
+        if (system.includes(title)) return extractionFor(title);
+      }
+      // Default: return the first entry's extraction.
+      const firstTitle = Object.values(titlesBySource)[0] ?? "Default";
+      return extractionFor(firstTitle);
+    },
+  );
+  vi.spyOn(AnthropicProvider.prototype, "complete").mockResolvedValue(STUB_BODY);
+}
+
+// ---------------------------------------------------------------------------
+// (A) changeFilter
+// ---------------------------------------------------------------------------
+
+/**
+ * Silence console output and run compileAndReport scoped to a single file.
+ * Both changeFilter tests share this setup: filter to "a.md", suppress output,
+ * return the CompileResult for assertion.
+ */
+async function runFilteredToA(root: string) {
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  return compileAndReport(root, { changeFilter: (c) => c.file === "a.md" });
+}
+
+describe("changeFilter scopes the run", () => {
+  const ctx = useCompileProject({
+    dirSuffix: "filter-drop",
+    sourceFile: "a.md",
+    sourceContent: "# Topic A\n\nAbout A.",
+  });
+
+  it("drops an unrelated changed source", async () => {
+    // Add a second independent source so detectChanges sees two "new" entries.
+    await writeFile(
+      path.join(ctx.dir, "sources", "c.md"),
+      "# Topic C\n\nAbout C.",
+      "utf-8",
+    );
+    stubProviderFor({ "a.md": "Topic A", "c.md": "Topic C" });
+
+    const result = await runFilteredToA(ctx.dir);
+
+    expect(result.pages).toContain("topic-a");
+    expect(result.pages).not.toContain("topic-c");
+  });
+
+  it("still pulls a co-contributor in via affected expansion after filtering", async () => {
+    // a.md is "changed": its on-disk content hashes differently from what
+    // state records. b.md is "unchanged": its recorded hash matches on-disk.
+    // Both share concept "x" in state, so findAffectedSources will pull b.md
+    // in when only a.md passes the changeFilter.
+    const aContent = "# Topic A\n\nAbout A.";
+    const bContent = "# Topic B\n\nAbout B.";
+
+    // Overwrite a.md (fixture already created it) with known content.
+    await writeFile(path.join(ctx.dir, "sources", "a.md"), aContent, "utf-8");
+    await writeFile(path.join(ctx.dir, "sources", "b.md"), bContent, "utf-8");
+
+    // Write a concept page for the shared concept so the wiki dir is not empty.
+    await mkdir(path.join(ctx.dir, CONCEPTS_DIR), { recursive: true });
+    await writeFile(
+      path.join(ctx.dir, CONCEPTS_DIR, "topic-x.md"),
+      "---\ntitle: Topic X\nsummary: x.\nsources: []\ncreatedAt: t\nupdatedAt: t\n---\n\nX content.",
+      "utf-8",
+    );
+
+    // Seed state: a.md hash is intentionally wrong ("stale") → "changed".
+    // b.md hash matches on-disk content exactly → "unchanged".
+    // Both share concept slug "topic-x".
+    await writeSourceState(ctx.dir, {
+      "a.md": { hash: "stale-hash-differs-from-disk", concepts: ["topic-x"] },
+      "b.md": { hash: sha256Hex(bContent), concepts: ["topic-x"] },
+    });
+
+    // Stub extraction: every source produces "Topic X". toolCall is the
+    // EXTRACTION call (once per source); its system prompt embeds the source
+    // content, so we can detect which source it ran for. complete() is the
+    // page-BODY call (once per page) and would pass even without b.md, so the
+    // co-contributor assertion must hinge on toolCall instead.
+    const extractSpy = vi.spyOn(AnthropicProvider.prototype, "toolCall")
+      .mockImplementation(async (_system: string) => extractionFor("Topic X"));
+    vi.spyOn(AnthropicProvider.prototype, "complete").mockResolvedValue(STUB_BODY);
+
+    const result = await runFilteredToA(ctx.dir);
+
+    // The shared concept page must be produced.
+    expect(result.pages).toContain("topic-x");
+    // Affected-source expansion must pull b.md in: extraction runs once per
+    // source, so exactly two extraction calls (a.md + the b.md co-contributor)
+    // prove b.md was processed. This goes red if augmentWithAffectedSources is
+    // disabled (only a.md would be extracted).
+    expect(extractSpy).toHaveBeenCalledTimes(2);
+    const extractedBContent = extractSpy.mock.calls.some(
+      ([system]) => typeof system === "string" && system.includes("About B."),
+    );
+    expect(extractedBContent).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (B) skipSeedPages
+// ---------------------------------------------------------------------------
+
+describe("skipSeedPages suppresses seed-page writes", () => {
+  const SEED_TITLE = "Overview Page";
+  const SEED_SLUG = "overview-page";
+
+  const ctx = useCompileProject({
+    dirSuffix: "skip-seed",
+    sourceFile: "a.md",
+    sourceContent: "# Topic A\n\nAbout A.",
+  });
+
+  /** Write a schema.json with one overview seed page under .llmwiki/. */
+  async function writeSeedSchema(root: string): Promise<void> {
+    await mkdir(path.join(root, ".llmwiki"), { recursive: true });
+    const schema = {
+      version: 1,
+      defaultKind: "concept",
+      kinds: {},
+      seedPages: [
+        { title: SEED_TITLE, kind: "overview", summary: "A top-level overview." },
+      ],
+    };
+    await writeFile(
+      path.join(root, ".llmwiki", "schema.json"),
+      JSON.stringify(schema),
+      "utf-8",
+    );
+  }
+
+  /** Set up the seed-schema project, stub the LLM, and run compileAndReport. */
+  async function runSeedCompile(root: string, options: CompileOptions = {}): Promise<string> {
+    await writeSeedSchema(root);
+    stubProviderFor({ "a.md": "Topic A" });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    await compileAndReport(root, options);
+    return path.join(root, CONCEPTS_DIR, `${SEED_SLUG}.md`);
+  }
+
+  it("does not write the seed page when skipSeedPages is true", async () => {
+    const seedPath = await runSeedCompile(ctx.dir, { skipSeedPages: true });
+    expect(existsSync(seedPath)).toBe(false);
+  });
+
+  it("does write the seed page in a control run without skipSeedPages", async () => {
+    const seedPath = await runSeedCompile(ctx.dir);
+    expect(existsSync(seedPath)).toBe(true);
+  });
+});

--- a/test/refresh-plan.test.ts
+++ b/test/refresh-plan.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for resolveStaleRefresh — the read-only resolver that computes a
+ * RefreshPlan from a single freshness snapshot. Covers all four page outcomes
+ * (recompiled, shared-kept, computed-orphaned, already-orphaned) plus the
+ * newSkipped/changeFilter/knownAffected helpers and corrupt-state short-circuit.
+ */
+
+import { describe, it, expect } from "vitest";
+import { existsSync } from "fs";
+import path from "path";
+import { resolveStaleRefresh } from "../src/compiler/refresh-plan.js";
+import { makeLintTempRoot } from "./fixtures/lint-temp-root.js";
+import {
+  writeSourceState,
+  writeSourceFile,
+  sha256Hex,
+  writeCorruptTestStateJson,
+} from "./fixtures/state-json.js";
+import { writePage } from "./fixtures/write-page.js";
+
+describe("resolveStaleRefresh", () => {
+  it("classifies a changed-owner stale page as recompiled", async () => {
+    const { root, writeConceptPage } = await makeLintTempRoot("refresh-plan-changed");
+    await writeConceptPage(
+      "topic",
+      `---\ntitle: Topic\nsources: [a.md]\nsummary: s\ncreatedAt: t\n---\nbody`,
+    );
+    await writeSourceState(root, {
+      "a.md": { hash: sha256Hex("OLD body"), concepts: ["topic"] },
+    });
+    await writeSourceFile(root, "a.md", "NEW body");
+
+    const { stateStatus, plan } = await resolveStaleRefresh(root);
+    expect(stateStatus).toBe("ok");
+    expect(plan!.recompiledPages).toContain("topic");
+    expect(plan!.changedOwners).toContain("a.md");
+    expect(plan!.sharedKeptPages).toEqual([]);
+  });
+
+  it("classifies an all-owners-deleted page as computed-orphaned", async () => {
+    const { root, writeConceptPage } = await makeLintTempRoot("refresh-plan-orphan");
+    await writeConceptPage(
+      "topic",
+      `---\ntitle: Topic\nsources: [a.md]\nsummary: s\ncreatedAt: t\n---\nbody`,
+    );
+    await writeSourceState(root, {
+      "a.md": { hash: sha256Hex("body"), concepts: ["topic"] },
+    });
+    // a.md NOT written to disk → deleted
+
+    const { plan } = await resolveStaleRefresh(root);
+    expect(plan!.computedOrphanedPages).toContain("topic");
+    expect(plan!.deletedOwners).toContain("a.md");
+    expect(plan!.recompiledPages).toEqual([]);
+  });
+
+  it("classifies a partial-deletion page (live unchanged + deleted owner) as shared-kept, not recompiled", async () => {
+    const { root, writeConceptPage } = await makeLintTempRoot("refresh-plan-shared");
+    await writeConceptPage(
+      "x",
+      `---\ntitle: X\nsources: [a.md, b.md]\nsummary: s\ncreatedAt: t\n---\nbody`,
+    );
+    const aBody = "A body";
+    await writeSourceState(root, {
+      "a.md": { hash: sha256Hex(aBody), concepts: ["x"] },
+      "b.md": { hash: sha256Hex("B body"), concepts: ["x"] },
+    });
+    await writeSourceFile(root, "a.md", aBody); // unchanged live owner
+    // b.md NOT written → deleted
+
+    const { plan } = await resolveStaleRefresh(root);
+    expect(plan!.sharedKeptPages).toContain("x");
+    expect(plan!.recompiledPages).not.toContain("x");
+    expect(plan!.changedOwners).not.toContain("a.md");
+    expect(plan!.deletedOwners).toContain("b.md");
+  });
+
+  it("reports a frontmatter-orphaned page with no owners as already-orphaned (no action)", async () => {
+    const { root } = await makeLintTempRoot("refresh-plan-already-orphaned");
+    await writePage(
+      path.join(root, "wiki", "concepts"),
+      "old",
+      { title: "Old", sources: [], summary: "s", createdAt: "t", orphaned: true },
+      "body",
+    );
+    await writeSourceState(root, {}); // no owners
+
+    const { plan } = await resolveStaleRefresh(root);
+    expect(plan!.alreadyOrphanedPages).toContain("old");
+    expect(plan!.changedOwners).toEqual([]);
+    expect(plan!.deletedOwners).toEqual([]);
+  });
+
+  it("lists new sources separately and excludes them from the changeFilter", async () => {
+    const { root, writeConceptPage } = await makeLintTempRoot("refresh-plan-new");
+    await writeConceptPage(
+      "topic",
+      `---\ntitle: Topic\nsources: [a.md]\nsummary: s\ncreatedAt: t\n---\nbody`,
+    );
+    await writeSourceState(root, {
+      "a.md": { hash: sha256Hex("OLD body"), concepts: ["topic"] },
+    });
+    await writeSourceFile(root, "a.md", "NEW body");
+    await writeSourceFile(root, "new.md", "brand new");
+
+    const { plan } = await resolveStaleRefresh(root);
+    expect(plan!.newSkipped).toContain("new.md");
+    expect(plan!.changeFilter({ file: "new.md", status: "new" })).toBe(false);
+    expect(plan!.changeFilter({ file: "a.md", status: "changed" })).toBe(true);
+  });
+
+  it("knownAffected pulls in an unchanged co-contributor but not a deleted owner", async () => {
+    const { root, writeConceptPage } = await makeLintTempRoot("refresh-plan-known-affected");
+    await writeConceptPage(
+      "x",
+      `---\ntitle: X\nsources: [a.md, b.md, c.md]\nsummary: s\ncreatedAt: t\n---\nbody`,
+    );
+    const cBody = "C body";
+    await writeSourceState(root, {
+      "a.md": { hash: sha256Hex("OLD A"), concepts: ["x"] },
+      "b.md": { hash: sha256Hex("B body"), concepts: ["x"] },
+      "c.md": { hash: sha256Hex(cBody), concepts: ["x"] },
+    });
+    await writeSourceFile(root, "a.md", "NEW A"); // changed owner
+    await writeSourceFile(root, "c.md", cBody); // unchanged co-contributor
+    // b.md NOT on disk → deleted
+
+    const { plan } = await resolveStaleRefresh(root);
+    expect(plan!.knownAffected).toContain("c.md"); // real co-contributor pulled in
+    expect(plan!.knownAffected).not.toContain("b.md"); // deleted owner excluded
+  });
+
+  it("excludes a page with no state owners and no orphaned flag from all four outcome lists", async () => {
+    const { root, writeConceptPage } = await makeLintTempRoot("refresh-plan-untracked");
+    await writeConceptPage(
+      "handwritten",
+      `---\ntitle: Handwritten\nsources: []\nsummary: s\ncreatedAt: t\n---\nbody`,
+    );
+    await writeSourceState(root, {}); // no owners; page has no orphaned frontmatter
+
+    const { plan } = await resolveStaleRefresh(root);
+    expect(plan!.recompiledPages).not.toContain("handwritten");
+    expect(plan!.sharedKeptPages).not.toContain("handwritten");
+    expect(plan!.computedOrphanedPages).not.toContain("handwritten");
+    expect(plan!.alreadyOrphanedPages).not.toContain("handwritten");
+  });
+
+  it("returns stateStatus corrupt with a null plan and writes no .bak on corrupt state", async () => {
+    const { root } = await makeLintTempRoot("refresh-plan-corrupt");
+    await writeCorruptTestStateJson(root);
+
+    const { stateStatus, plan } = await resolveStaleRefresh(root);
+    expect(stateStatus).toBe("corrupt");
+    expect(plan).toBeNull();
+    expect(existsSync(path.join(root, ".llmwiki/state.json.bak"))).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds `llmwiki refresh --stale [--dry-run]`, the remedy companion to the source-freshness surfaces (#88): it repairs the pages those surfaces flag as stale/orphaned, instead of requiring a full recompile.

## What it does

- Recompiles the **changed owners** of stale pages, and cleans up the **deleted owners** of stale/orphaned pages.
- **Skips unrelated new sources** (and says so) — that's what makes it distinct from `compile`.
- `--dry-run` previews the plan and changes nothing: no LLM calls, no writes.

## How it works

- A read-only resolver derives the plan from one freshness snapshot (no second state read, no `.bak` on corrupt state) and maps stale/orphaned pages back to their owning sources.
- It delegates a scoped recompile to the existing compile pipeline via two new, additive `CompileOptions`: `changeFilter` (narrows the run to the selected owners while still expanding shared-concept co-contributors) and `skipSeedPages` (so the run doesn't write unrelated seed pages).

## v1 limitation (deliberate)

A page stale because one of several owners was deleted has its **status** repaired (the deleted owner is removed from state) but its **content is kept** — not regenerated. Force-rebuilding shared pages collides with the frozen-slug mechanism and is deferred as its own change; an integration test locks in the current behavior.