### PR TITLE
chore: untrack committed node_modules symlink

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-../../node_modules


### PR DESCRIPTION
`node_modules` was committed to the repository as a symlink (git mode `120000`). The `.gitignore` rule `node_modules/` has a trailing slash, so it matches a *directory* — it never matched the tracked symlink (a file), which is how the symlink got committed and stayed tracked. Fresh clones and worktrees inherited that symlink, which broke local toolchain resolution (`tsc`/`fallow` couldn't resolve from a real install).

This untracks the symlink. The existing `node_modules/` rule already ignores a real `node_modules` install directory, so no `.gitignore` change is needed and `git status` is clean after a normal `npm ci`.